### PR TITLE
Add default @logger to Configuration

### DIFF
--- a/lib/ratchetio/configuration.rb
+++ b/lib/ratchetio/configuration.rb
@@ -19,6 +19,7 @@ module Ratchetio
     def initialize
       @endpoint = DEFAULT_ENDPOINT
       @framework = 'Plain'
+      @logger = Logger.new(STDERR)
       @exception_level_filters = {
         'ActiveRecord::RecordNotFound' => 'warning',
         'AbstractController::ActionNotFound' => 'warning',


### PR DESCRIPTION
Let's define top-level logger, so we can don't ourself with defining it in non-Rails environment.
