### PR TITLE
Add extensive Travis CI config for Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 1.9.2
+  - ree
+  - ruby-head
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+  - rbx-18mode
+  - rbx-19mode


### PR DESCRIPTION
Sure, you can remove some options, if you are not intend ratchet-gem to work on this platform.
