### PR TITLE
Allow exceptions with no backtrace

### DIFF
--- a/lib/ratchetio.rb
+++ b/lib/ratchetio.rb
@@ -135,13 +135,17 @@ module Ratchetio
       data[:level] = force_level if force_level
 
       # parse backtrace
-      frames = exception.backtrace.map { |frame|
-        # parse the line
-        match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
-        { :filename => match[1], :lineno => match[2].to_i, :method => match[3] }
-      }
-      # reverse so that the order is as ratchet expects
-      frames.reverse!
+      if exception.backtrace.respond_to?( :map )
+        frames = exception.backtrace.map { |frame|
+          # parse the line
+          match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
+          { :filename => match[1], :lineno => match[2].to_i, :method => match[3] }
+        }
+        # reverse so that the order is as ratchet expects
+        frames.reverse!
+      else
+        frames = []
+      end
 
       data[:body] = {
         :trace => {

--- a/spec/ratchetio_spec.rb
+++ b/spec/ratchetio_spec.rb
@@ -73,6 +73,17 @@ describe Ratchetio do
         config.exception_level_filters = saved_filters
       end
     end
+
+    it 'should report exception objects with no backtrace' do
+      payload = nil
+      Ratchetio.stub(:schedule_payload) do |*args|
+        payload = JSON.parse( args[0] )
+      end
+      Ratchetio.report_exception(StandardError.new("oops"))
+      payload["data"]["body"]["trace"]["frames"].should == []
+      payload["data"]["body"]["trace"]["exception"]["class"].should == "StandardError"
+      payload["data"]["body"]["trace"]["exception"]["message"].should == "oops"
+    end
   end
   
   context 'report_message' do


### PR DESCRIPTION
This fixes an error where the following will silently fail:

  error = StandardError.new("Oops.")
  Ratchetio.report_exception(error)
