### PR TITLE
Replace ActiveSupport::JSON with a simple MultiJSON

### DIFF
--- a/lib/ratchetio.rb
+++ b/lib/ratchetio.rb
@@ -274,7 +274,7 @@ module Ratchetio
         :access_token => configuration.access_token,
         :data => data
       }
-      ActiveSupport::JSON.encode(payload)
+      MultiJson.dump(payload)
     end
 
     def base_data(level = 'error')

--- a/ratchetio.gemspec
+++ b/ratchetio.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Ratchetio::VERSION
 
-  gem.add_runtime_dependency 'activesupport', '~> 3.2.9'
+  gem.add_runtime_dependency 'multi_json', '~> 1.5.0'
 
   gem.add_development_dependency 'rails', '~> 3.2.9'
   gem.add_development_dependency 'devise', '>= 2.1.2'

--- a/spec/ratchetio_spec.rb
+++ b/spec/ratchetio_spec.rb
@@ -93,7 +93,7 @@ describe Ratchetio do
     it 'should report exception objects with no backtrace' do
       payload = nil
       Ratchetio.stub(:schedule_payload) do |*args|
-        payload = JSON.parse( args[0] )
+        payload = MultiJson.load(args[0])
       end
       Ratchetio.report_exception(StandardError.new("oops"))
       payload["data"]["body"]["trace"]["frames"].should == []
@@ -361,15 +361,13 @@ describe Ratchetio do
   context 'build_payload' do
     it 'should build valid json' do
       json = Ratchetio.send(:build_payload, {:foo => {:bar => "baz"}})
-      hash = ActiveSupport::JSON.decode(json)
+      hash = MultiJson.load(json)
       hash["data"]["foo"]["bar"].should == "baz"
     end
   end
 
   context 'base_data' do
-    before(:each) do
-      configure
-    end
+    before(:each) { configure }
 
     it 'should have the correct notifier name' do
       Ratchetio.send(:base_data)[:notifier][:name].should == 'ratchetio-gem'


### PR DESCRIPTION
Let's replace ActiveSupport gem with MultiJSON, because the only thing that we need is some JSON encoder / decouder, so I think it's reasonable to use such a minimal thing as MultiJSON.
