### PR TITLE
Fix |= in #sensitive_params_list

### DIFF
--- a/lib/ratchetio/request_data_extractor.rb
+++ b/lib/ratchetio/request_data_extractor.rb
@@ -109,7 +109,7 @@ module Ratchetio
     end
 
     def sensitive_params_list(env)
-      Ratchetio.configuration.scrub_fields |= Array(env['action_dispatch.parameter_filter'])
+      Ratchetio.configuration.scrub_fields ||= Array(env['action_dispatch.parameter_filter'])
     end
   end
 end


### PR DESCRIPTION
`|=` isn't a conditional assigment, so in case `Ratchetio.configuration.scrub_fields` will be equal `nil` that `#ratchetio_filtered_params` then expects.
