### PR TITLE
[Expiremental] Allow `scrub_fields` to be empty

### DIFF
--- a/lib/ratchetio/request_data_extractor.rb
+++ b/lib/ratchetio/request_data_extractor.rb
@@ -91,11 +91,11 @@ module Ratchetio
 
     def ratchetio_filtered_params(sensitive_params, params)
       params.inject({}) do |result, (key, value)|
-        if key.to_sym.in?(sensitive_params)
+        if sensitive_params && sensitive_params.include?(key.to_sym)
           result[key] = '*' * (value.length rescue 8)
         elsif value.is_a?(Hash)
           result[key] = ratchetio_filtered_params(sensitive_params, value)
-        elsif value.class.name.in?(ATTACHMENT_CLASSES)
+        elsif ATTACHMENT_CLASSES.include?(value.class.name)
           result[key] = {
             :content_type => value.content_type,
             :original_filename => value.original_filename,

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -106,9 +106,7 @@ describe HomeController do
       end
 
       it "should scrub custom scrub_fields" do
-        Ratchetio.configure do |config|
-          config.scrub_fields = [:notpass, :secret]
-        end
+        Ratchetio.configuration.stub(:scrub_fields).and_return [:notpass, :secret]
 
         params = {
           :passwd => "visible",
@@ -123,6 +121,20 @@ describe HomeController do
         filtered[:password].should == "visible"
         filtered[:secret].should == "******"
         filtered[:notpass].should == "******"
+      end
+
+      it "should not scrub when scrub_fields is empty" do
+        Ratchetio.configuration.stub(:scrub_fields).and_return(nil)
+
+        params = {
+          :passwd => "visible",
+          :password => "visible"
+        }
+
+        filtered = controller.send(:ratchetio_filtered_params, Ratchetio.configuration.scrub_fields, params)
+
+        filtered[:passwd].should == "visible"
+        filtered[:password].should == "visible"
       end
     end
 


### PR DESCRIPTION
This is PoC feature. This allows `scruby_fields` to be empty, so we wouldn't scrub any parameters.

This feature depends on ratchetio/ratchetio-gem#19
