### PR TITLE
`match` is no longer available in rails 4. use `get` instead which works.

### DIFF
--- a/lib/rollbar/rake_tasks.rb
+++ b/lib/rollbar/rake_tasks.rb
@@ -44,12 +44,12 @@ namespace :rollbar do
         nil
       end
     end
-    
+
     class RollbarTestController < ApplicationController; end
 
     Rails.application.routes_reloader.execute_if_updated
     Rails.application.routes.draw do
-      match 'verify' => 'application#verify', :as => 'verify'
+      get 'verify' => 'application#verify', :as => 'verify'
     end
 
     puts "Processing..."


### PR DESCRIPTION
`get` should work in both rails 3 and rails 4.
