### PR TITLE
Fix params filtering

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -91,11 +91,11 @@ module Rollbar
 
     def rollbar_filtered_params(sensitive_params, params)
       params.inject({}) do |result, (key, value)|
-        if key.to_sym.in?(sensitive_params)
+        if sensitive_params.include?(key.to_sym)
           result[key] = '*' * (value.length rescue 8)
         elsif value.is_a?(Hash)
           result[key] = rollbar_filtered_params(sensitive_params, value)
-        elsif value.class.name.in?(ATTACHMENT_CLASSES)
+        elsif ATTACHMENT_CLASSES.include?(value.class.name)
           result[key] = {
             :content_type => value.content_type,
             :original_filename => value.original_filename,


### PR DESCRIPTION
Neither Symbol nor String in Ruby has `#in?` method.
So this filtering raises another exception instead
of sending it:

    Exception while reporting exception to Rollbar:
    undefined method `in?' for :session_id:Symbol

This patch fixes expressions to by Rubista not Pythonista :D
