### PR TITLE
Add ability to report form validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ $ rake rollbar:test
 
 This will raise an exception within a test request; if it works, you'll see a stacktrace in the console, and the exception will appear in the Rollbar dashboard.
 
+## Reporting form validation errors
+
+To get form validation errors automatically reported to Rollbar just add the following ```after_validation``` callback to your models:
+
+```ruby
+after_validation :report_validation_errors_to_rollbar
+```
+
 ## Manually reporting exceptions and messages
 
 To report a caught exception to Rollbar, simply call ```Rollbar.report_exception```:
@@ -136,7 +144,7 @@ config.person_email_method = "email_address"  # default is "email"
 
 ## Including additional runtime data
 
-You can provide a lambda that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that takes no arguments and returns a hash. 
+You can provide a lambda that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that takes no arguments and returns a hash.
 
 Add the following in ```config/initializers/rollbar.rb```:
 
@@ -170,7 +178,7 @@ Rollbar.silenced {
 
 ## Asynchronous reporting
 
-By default, all messages are reported synchronously. You can enable asynchronous reporting with [girl_friday](https://github.com/mperham/girl_friday) or [Sidekiq](https://github.com/mperham/sidekiq). 
+By default, all messages are reported synchronously. You can enable asynchronous reporting with [girl_friday](https://github.com/mperham/girl_friday) or [Sidekiq](https://github.com/mperham/sidekiq).
 
 ### Using girl_friday
 
@@ -249,7 +257,7 @@ Available options:
   </dd>
   <dt>rollbar_env</dt>
   <dd>Deploy environment name
-  
+
 Default: ```rails_env```
 
   </dd>
@@ -286,7 +294,7 @@ Check out [resque-rollbar](https://github.com/CrowdFlower/resque-rollbar) for us
 
 ## Using with Zeus
 
-Some users have reported problems with Zeus when ```rake``` was not explicitly included in their Gemfile. If the zeus server fails to start after installing the rollbar gem, try explicitly adding ```gem 'rake'``` to your ```Gemfile```. See [this thread](https://github.com/rollbar/rollbar-gem/issues/30) for more information. 
+Some users have reported problems with Zeus when ```rake``` was not explicitly included in their Gemfile. If the zeus server fails to start after installing the rollbar gem, try explicitly adding ```gem 'rake'``` to your ```Gemfile```. See [this thread](https://github.com/rollbar/rollbar-gem/issues/30) for more information.
 
 
 ## Help / Support

--- a/lib/rollbar/active_record_extension.rb
+++ b/lib/rollbar/active_record_extension.rb
@@ -1,0 +1,14 @@
+module Rollbar
+  module ActiveRecordExtension
+    extend ActiveSupport::Concern
+
+    def report_validation_errors_to_rollbar
+      self.errors.full_messages.each do |error|
+        logger.info "[Rollbar] Reporting form validation error: #{error} for #{self.to_s}"
+        Rollbar.report_message("Form Validation Error: #{error} for #{self.to_s}")
+      end
+    end
+  end
+end
+
+ActiveRecord::Base.send(:include, Rollbar::ActiveRecordExtension)


### PR DESCRIPTION
I've added the ability for the gem to report form validation errors. Users can turn on this feature by simply adding a after_validation callback for :report_validation_errors_to_rollbar in their models. Basically I've just added this method to ActiveRecord::Base and have made sure it reports for the correct model name each time.

I have tested this a fair bit with a dummy app to ensure that the messages are hitting Rollbar but I've also written two specs to ensure that form validation errors are only reported if present. This means that users can add the after_validation callback and not worry about having issues when there are no validation errors.

My text editor picked up a bunch of whitespace errors so it looks like I've made commits all over the place. Don't worry about those and know that the green chunks of extra code are what I've added.

Have also updated the docs.
