### PR TITLE
Replaced GirlFriday async handler by Celluloid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 gem 'sqlite3',                          :platform => [:ruby, :mswin, :mingw]
 gem 'jruby-openssl',                    :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-gem 'girl_friday'
+gem 'celluloid'
 gem 'appraisal'

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Rollbar.silenced {
 
 ## Asynchronous reporting
 
-By default, all messages are reported synchronously. You can enable asynchronous reporting with [girl_friday](https://github.com/mperham/girl_friday) or [Sidekiq](https://github.com/mperham/sidekiq).
+By default, all messages are reported synchronously. You can enable asynchronous reporting with [Celluloid](https://github.com/celluloid/celluloid) or [Sidekiq](https://github.com/mperham/sidekiq).
 
-### Using girl_friday
+### Using Celluloid
 
 Add the following in ```config/initializers/rollbar.rb```:
 
@@ -188,7 +188,7 @@ Add the following in ```config/initializers/rollbar.rb```:
 config.use_async = true
 ```
 
-Asynchronous reporting falls back to Threading if girl_friday is not installed.
+Asynchronous reporting falls back to Threading if Celluloid is not installed.
 
 ### Using Sidekiq
 

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
-gem "girl_friday"
+gem "celluloid"
 gem "appraisal"
 gem "rails", "3.0.20"
 

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
-gem "girl_friday"
+gem "celluloid"
 gem "appraisal"
 gem "rails", "3.1.12"
 

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
-gem "girl_friday"
+gem "celluloid"
 gem "appraisal"
 gem "rails", "3.2.12"
 

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
-gem "girl_friday"
+gem "celluloid"
 gem "appraisal"
 gem "rails", "4.0.0"
 gem "protected_attributes"

--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -29,7 +29,7 @@ Rollbar.configure do |config|
   # 'ignore' will cause the exception to not be reported at all.
   # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
   
-  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # Enable asynchronous reporting (uses Celluloid or Threading if Celluloid
   # is not installed)
   # config.use_async = true
   # Supply your own async handler:

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rails', '>= 3.0.0'
   gem.add_development_dependency 'rspec-rails', '~> 2.12.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.0.0'
-  gem.add_development_dependency 'girl_friday', '>= 0.11.1'
+  gem.add_development_dependency 'celluloid', '>= 0.14.1'
   gem.add_development_dependency 'genspec', '>= 0.2.7'
 end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -305,21 +305,20 @@ describe Rollbar do
 
     let(:logger_mock) { double("Rails.logger").as_null_object }
 
-    it 'should send the payload using the default asynchronous handler girl_friday' do
+    it 'should send the payload using the default asynchronous handler Celluloid' do
       logger_mock.should_receive(:info).with('[Rollbar] Scheduling payload')
       logger_mock.should_receive(:info).with('[Rollbar] Sending payload')
       logger_mock.should_receive(:info).with('[Rollbar] Success')
 
       Rollbar.configure do |config|
         config.use_async = true
-        GirlFriday::WorkQueue::immediate!
       end
 
+      Celluloid::Future.should_receive(:new).and_yield
       Rollbar.report_exception(@exception)
 
       Rollbar.configure do |config|
         config.use_async = false
-        GirlFriday::WorkQueue::queue!
       end
     end
 


### PR DESCRIPTION
This is an opinionated proposal to replace actor pattern library used in async handler GirlFriday by Celluloid.

Celluloid is a popular and under active development actor pattern library with many features like Futures, Supervisors, Timers and Finite State Machine.

This pull request change Rollbar's default async handler from a GirlFriday::WorkQueue to a Celluloid::Future to process block of code asynchronously. Both are conceptually pretty close, async handler is executed on another thread for concurrency.
Celluloid::Future.new uses threads from Celluloid internal thread pool ([link](https://github.com/celluloid/celluloid/wiki/Futures)).
