### PR TITLE
Add support for better_errors 1.0 calling semantics.

### DIFF
--- a/lib/rollbar/better_errors.rb
+++ b/lib/rollbar/better_errors.rb
@@ -3,12 +3,13 @@ require 'better_errors'
 module BetterErrors
   class Middleware
     alias_method :orig_show_error_page, :show_error_page
-    
+
     private
 
-    def show_error_page(env)
+    def show_error_page(*args)
       exception = @error_page.exception
-      
+
+      env = args.first
       exception_data = nil
       begin
         controller = env['action_controller.instance']
@@ -17,9 +18,9 @@ module BetterErrors
         exception_data = Rollbar.report_exception(exception, request_data, person_data)
       rescue => e
         # TODO use logger here?
-        puts "[Rollbar] Exception while reporting exception to Rollbar: #{e}" 
+        puts "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
       end
-      
+
       # if an exception was reported, save uuid in the env
       # so it can be displayed to the user on the error page
       if exception_data.is_a?(Hash)
@@ -30,9 +31,9 @@ module BetterErrors
       elsif exception_data == 'ignored'
         puts "[Rollbar] Exception not reported because it was ignored"
       end
-      
+
       # now continue as normal
-      orig_show_error_page(env)
+      orig_show_error_page(*args)
     end
   end
 end


### PR DESCRIPTION
better_errors 1.0.0-rc1 doesn't work with rollbar 0.10.12: presumably show_error_page takes multiple arguments now.

Here's my workaround.

cc @charliesome: maybe you guys can work together to come up with something more elegant?
