### PR TITLE
Allow callables to set filter level for exceptions

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -174,7 +174,12 @@ module Rollbar
     end
 
     def filtered_level(exception)
-      configuration.exception_level_filters[exception.class.name]
+      filter = configuration.exception_level_filters[exception.class.name]
+      if filter.respond_to?(:call)
+        filter.call(exception)
+      else
+        filter
+      end
     end
 
     def message_data(message, level, extra_data)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -127,6 +127,25 @@ describe Rollbar do
       end
     end
 
+    it 'should allow callables to set exception filtered level' do
+      callable_mock = double
+      saved_filters = Rollbar.configuration.exception_level_filters
+      Rollbar.configure do |config|
+        config.exception_level_filters = { 'NameError' => callable_mock }
+      end
+
+      callable_mock.should_receive(:call).with(@exception).at_least(:once).and_return("info")
+      logger_mock.should_receive(:info)
+      logger_mock.should_not_receive(:warn)
+      logger_mock.should_not_receive(:error)
+
+      Rollbar.report_exception(@exception)
+
+      Rollbar.configure do |config|
+        config.exception_level_filters = saved_filters
+      end
+    end
+
     it 'should not report exceptions when silenced' do
       Rollbar.should_not_receive :schedule_payload
 


### PR DESCRIPTION
This means that applications can be easily configured to change the status (ignore, warning) of exceptions based on things that matter to them.

e.g. maybe there are some paths that you just don't care about ActionController::RoutingErrors for
e.g. maybe errors that happen to certain user classes can be marked as warning rather than error

See also: https://github.com/rollbar/rollbar-gem/issues/61
