### PR TITLE
Fix request params key duplicates.

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -81,9 +81,9 @@ module Rollbar
     def rollbar_request_params(env)
       route = ::Rails.application.routes.recognize_path(env['PATH_INFO']) rescue {}
       {
-        :controller => route[:controller],
-        :action => route[:action],
-        :format => route[:format],
+        "controller" => route[:controller],
+        "action" => route[:action],
+        "format" => route[:format],
       }.merge(env['action_dispatch.request.parameters'] || {})
     end
     


### PR DESCRIPTION
The problem is that `env['action_dispatch.request.parameters']` has strings as its keys. That leads to having params like `{:controller => nil, :action => nil, :format =>nil, "controller"=>"flights", "action"=>"index"}`. Then it's converted into json by multi_json, and the behavior of json adapters differ in this case. That how Oj behaves:

```
>> puts Oj.dump(:controller => nil, :action => nil, :format =>nil, "controller"=>"flights", "action"=>"index")
{"controller":null,"action":null,"format":null,"controller":"flights","action":"index"}
```

And that's valid json. Such json used to be parsed successfully by the Rollbar server, but three days ago it started to throw this:

```
[Rollbar] Sending payload
[Rollbar] Got unexpected status code from Rollbar api: 403
[Rollbar] Response: {
  "err": 1,
  "message": "access token not found: undefined"
}
```

Whilst having no duplicates leads to a successful payload sending. So I guess that JSON parser was changed on the Rollbar server three days ago.
