### PR TITLE
Use https for test rake task if force_ssl is true

### DIFF
--- a/lib/rollbar/rake_tasks.rb
+++ b/lib/rollbar/rake_tasks.rb
@@ -53,7 +53,8 @@ namespace :rollbar do
     end
 
     puts "Processing..."
-    env = Rack::MockRequest.env_for("/verify")
+    protocol = Rails.application.config.force_ssl ? 'https' : 'http'
+    env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify")
     status, headers, response = Rails.application.call(env)
     
     unless status == 500


### PR DESCRIPTION
I ran into some trouble trying to run `rake rollbar:test` in my production environment. If `config.force_ssl` is set to true, the rake task fails without any indication what went wrong. I've [run into this issue before](https://github.com/airbrake/airbrake/pull/152), so I've applied the same fix here.
