### PR TITLE
Travis updates - Ruby 2.1.0, get Rubinius running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,19 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
   - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-18mode
-  - rbx-19mode
+  - rbx
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-18mode
     - rvm: jruby-19mode
     - rvm: jruby-head
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode
+    - rvm: rbx
   exclude:
     - rvm: 1.8.7
       gemfile: gemfiles/rails40.gemfile
@@ -51,17 +50,11 @@ matrix:
       gemfile: gemfiles/rails31.gemfile
     - rvm: jruby-head
       gemfile: gemfiles/rails40.gemfile
-    - rvm: rbx-18mode
+    - rvm: rbx
       gemfile: gemfiles/rails30.gemfile
-    - rvm: rbx-18mode
+    - rvm: rbx
       gemfile: gemfiles/rails31.gemfile
-    - rvm: rbx-18mode
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: rbx-19mode
-      gemfile: gemfiles/rails30.gemfile
-    - rvm: rbx-19mode
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: rbx-19mode
+    - rvm: rbx
       gemfile: gemfiles/rails40.gemfile
 gemfile:
   - gemfiles/rails30.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,9 @@ gem 'sqlite3',                          :platform => [:ruby, :mswin, :mingw]
 gem 'jruby-openssl',                    :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
+
+gem 'rubysl', '~> 2.0',                 :platform => :rbx
+gem 'racc',                             :platform => :rbx
+gem 'minitest',                         :platform => :rbx
+gem 'rubysl-test-unit',                 :platform => :rbx
+gem 'rubinius-developer_tools',         :platform => :rbx

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -6,6 +6,13 @@ gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
 gem "appraisal"
+
+gem 'rubysl', '~> 2.0',                 :platform => :rbx
+gem 'racc',                             :platform => :rbx
+gem 'minitest',                         :platform => :rbx
+gem 'rubysl-test-unit',                 :platform => :rbx
+gem 'rubinius-developer_tools',         :platform => :rbx
+
 gem "rails", "3.0.20"
 
 gemspec :path=>"../"

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -6,6 +6,13 @@ gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
 gem "appraisal"
+
+gem 'rubysl', '~> 2.0',                 :platform => :rbx
+gem 'racc',                             :platform => :rbx
+gem 'minitest',                         :platform => :rbx
+gem 'rubysl-test-unit',                 :platform => :rbx
+gem 'rubinius-developer_tools',         :platform => :rbx
+
 gem "rails", "3.1.12"
 
 gemspec :path=>"../"

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -6,6 +6,13 @@ gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
 gem "appraisal"
+
+gem 'rubysl', '~> 2.0',                 :platform => :rbx
+gem 'racc',                             :platform => :rbx
+gem 'minitest',                         :platform => :rbx
+gem 'rubysl-test-unit',                 :platform => :rbx
+gem 'rubinius-developer_tools',         :platform => :rbx
+
 gem "rails", "3.2.12"
 
 gemspec :path=>"../"

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -7,6 +7,13 @@ gem "jruby-openssl", :platform=>:jruby
 gem "activerecord-jdbcsqlite3-adapter", :platform=>:jruby
 gem "appraisal"
 gem "rails", "4.0.0"
+
+gem 'rubysl', '~> 2.0',                 :platform => :rbx
+gem 'racc',                             :platform => :rbx
+gem 'minitest',                         :platform => :rbx
+gem 'rubysl-test-unit',                 :platform => :rbx
+gem 'rubinius-developer_tools',         :platform => :rbx
+
 gem "protected_attributes"
 
 gemspec :path=>"../"


### PR DESCRIPTION
1. Added Ruby 2.1.0 to .travis.yml.
2. Added Rubinius gems to gemfiles, so Rubinius build runs.
3. Replace 'rbx-18mode' and 'rbx-19mode' with the updated 'rbx' label

Rubinius runs, but it has a couple of spec failures.  Ruby 2.1.0 specs run green.  
