### PR TITLE
Fix nil error in string addtion

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -85,7 +85,7 @@ module Rollbar
       data = exception_data(exception, level ? level : filtered_level(exception))
       if request_data
         if request_data[:route]
-          data[:context] = request_data[:route][:controller] + '#' + request_data[:route][:action]
+          data[:context] = "#{request_data[:route][:controller]}" + '#' + "#{request_data[:route][:action]}"
         end
         
         request_data[:env].reject!{|k, v| v.is_a?(IO) } if request_data[:env]


### PR DESCRIPTION
I'm seeing a number of errors in my Rollbar console that look like this:

NoMethodError: undefined method `+' for nil:NilClass
... 23 non-project frames
1 File ".../vendor/bundle/ruby/2.0.0/gems/rollbar-0.12.5/lib/rollbar.rb" line 83 in report_exception
2 File ".../vendor/bundle/ruby/2.0.0/gems/rollbar-0.12.5/lib/rollbar/exception_reporter.rb" line 9 in report_exception_to_rollbar
3  File ".../vendor/bundle/ruby/2.0.0/gems/rollbar-0.12.5/lib/rollbar/middleware/rails/show_exceptions.rb" line 22 in rescue in call_with_rollbar
...

These are occurring because one or both of request_data[:route][:controller] or request_data[:route][:action] are nil.  The rollbar-gem is throwing an error in this case, that is hiding the actual error and causing a false report.

This PR makes the calculation of the data[:context] resilient against nil values by using Ruby string interpolation.
