### PR TITLE
Allow scrubbing headers just as params are scrubbed

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -23,6 +23,7 @@ module Rollbar
     attr_accessor :person_email_method
     attr_accessor :root
     attr_accessor :scrub_fields
+    attr_accessor :scrub_headers
     attr_accessor :use_async
     attr_accessor :use_eventmachine
     attr_accessor :web_base
@@ -55,6 +56,7 @@ module Rollbar
       @project_gems = []
       @scrub_fields = [:passwd, :password, :password_confirmation, :secret,
                        :confirm_password, :password_confirmation, :secret_token]
+      @scrub_headers = [ 'Cookie', 'Authorization' ]
       @use_async = false
       @use_eventmachine = false
       @web_base = DEFAULT_WEB_BASE

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -50,9 +50,8 @@ module Rollbar
     def rollbar_headers(env)
       env.keys.grep(/^HTTP_/).map do |header|
         name = header.gsub(/^HTTP_/, '').split('_').map(&:capitalize).join('-')
-        # exclude cookies - we already include a parsed version as request_data[:cookies]
-        if name == 'Cookie'
-          {}
+        if sensitive_headers_list.include?(name)
+          { name => rollbar_scrubbed(header) }
         else
           { name => env[header] }
         end
@@ -119,7 +118,7 @@ module Rollbar
       else
         params.to_hash.inject({}) do |result, (key, value)|
           if sensitive_params.include?(key.to_sym)
-            result[key] = '*' * (value.length rescue 8)
+            result[key] = rollbar_scrubbed(value)
           elsif value.is_a?(Hash)
             result[key] = rollbar_filtered_params(sensitive_params, value)
           elsif ATTACHMENT_CLASSES.include?(value.class.name)
@@ -139,5 +138,14 @@ module Rollbar
     def sensitive_params_list(env)
       Rollbar.configuration.scrub_fields |= Array(env['action_dispatch.parameter_filter'])
     end
+
+    def sensitive_headers_list
+      Rollbar.configuration.scrub_headers |= []
+    end
+
+    def rollbar_scrubbed(value)
+      '*' * (value.length rescue 8)
+    end
+
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -153,6 +153,44 @@ describe HomeController do
       end
     end
 
+    context 'rollbar_scrub_headers' do
+
+      it 'should filter cookies and authentication by default' do
+        headers = {
+          'HTTP_AUTHORIZATION' => 'some-user',
+          'HTTP_COOKIE' => 'some-cookie',
+          'HTTP_USER_AGENT' => 'spec'
+        }
+
+        filtered = controller.send( :rollbar_headers, headers )
+        filtered.should == {
+          "Authorization" => "******************",
+          "Cookie" => "***********",
+          "User-Agent" => "spec"
+        }
+      end
+
+      it 'should filter custom headers' do
+        Rollbar.configure do |config|
+          config.scrub_headers = ['Auth', 'Token']
+        end
+
+        headers = {
+          'HTTP_AUTH' => 'auth-value',
+          'HTTP_TOKEN' => 'token-value',
+          'HTTP_CONTENT_TYPE' => 'text/html'
+        }
+
+        filtered = controller.send( :rollbar_headers, headers )
+        filtered.should == {
+          "Auth" => "*********",
+          "Token" => "**********",
+          "Content-Type" => "text/html"
+        }
+      end
+
+    end
+
     context "rollbar_request_url" do
       it "should build simple http urls" do
         req = controller.request

--- a/spec/dummyapp/app/models/user.rb
+++ b/spec/dummyapp/app/models/user.rb
@@ -1,3 +1,7 @@
 class User < ActiveRecord::Base
-  attr_accessible :username, :email, :password, :password_confirmation, :remember_me
+
+  if Rails::VERSION::MAJOR < 4
+    attr_accessible :username, :email, :password, :password_confirmation, :remember_me
+  end
+
 end


### PR DESCRIPTION
Scrubbing headers is as important as doing it for params since there could be sensitive information there as well.

Includes spec and a fix to make the tests go green on Rails 4 as well.
