### PR TITLE
Fix typo in generated initializer comments

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -2,7 +2,7 @@ require 'rollbar/rails'
 Rollbar.configure do |config|
   config.access_token = <%= access_token_expr %>
 
-  # Without configuration, Rollbar is enabled by in all environments. 
+  # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
   # Here we'll disable in 'test':
   if Rails.env.test?


### PR DESCRIPTION
Fixes a small grammatical issue in the generated initializer.
