### PR TITLE
Capistrano 3.x support

### DIFF
--- a/lib/rollbar/capistrano3.rb
+++ b/lib/rollbar/capistrano3.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../tasks/rollbar.cap", __FILE__)

--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -1,0 +1,38 @@
+require 'net/http'
+require 'rubygems'
+require 'json'
+
+namespace :rollbar do
+
+  desc 'Send the deployment notification to Rollbar.'
+  task :deploy do
+    uri    = URI.parse 'https://api.rollbar.com/api/1/deploy/'
+    params = {
+      :local_username => fetch(:rollbar_user),
+      :access_token   => fetch(:rollbar_token),
+      :environment    => fetch(:rollbar_env),
+      :revision       => fetch(:current_revision) }
+
+    request      = Net::HTTP::Post.new(uri.request_uri)
+    request.body = JSON.dump(params)
+
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      http.request(request)
+    end
+
+    # this is not the right way to output to capistrano's log..
+    puts 'Rollbar notification complete.'
+  end
+end
+
+namespace :deploy do
+  after 'deploy:finished', 'rollbar:deploy'
+end
+
+namespace :load do
+  task :defaults do
+    set :rollbar_user,  Proc.new { ENV['USER'] || ENV['USERNAME'] }
+    set :rollbar_env,   Proc.new { fetch :rails_env, 'production' }
+    set :rollbar_token, Proc.new { abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'" }
+  end
+end


### PR DESCRIPTION
This is an initial pass at Capistrano 3 support. To use:

Add to your `Capfile`:

``` ruby
require 'rollbar/capistrano3'
```

And then, to your `deploy.rb`:

``` ruby
set :rollbar_token, 'YOUR-TOKEN-GOES-HERE'
set :rollbar_env, Proc.new { fetch :stage }
```
