### PR TITLE
add the ability to disable tracking delayed_job fields

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -28,6 +28,7 @@ module Rollbar
     attr_accessor :web_base
     attr_accessor :write_to_file
     attr_accessor :report_dj_data
+    attr_accessor :dj_threshold
 
     attr_reader :project_gem_paths
 
@@ -61,6 +62,7 @@ module Rollbar
       @web_base = DEFAULT_WEB_BASE
       @write_to_file = false
       @report_dj_data = true
+      @dj_threshold = 0
     end
 
     def use_sidekiq(options = {})

--- a/lib/rollbar/delayed_job.rb
+++ b/lib/rollbar/delayed_job.rb
@@ -8,8 +8,10 @@ module Delayed
           begin
             block.call(job, *args)
           rescue Exception => e
-            data = ::Rollbar.configuration.report_dj_data ? job : nil
-            ::Rollbar.report_exception(e, data)
+            if job.attempts >= ::Rollbar.configuration.dj_threshold
+              data = ::Rollbar.configuration.report_dj_data ? job : nil
+              ::Rollbar.report_exception(e, data)
+            end
             raise e
           end
         end

--- a/lib/rollbar/version.rb
+++ b/lib/rollbar/version.rb
@@ -1,3 +1,3 @@
 module Rollbar
-  VERSION = "0.12.12"
+  VERSION = "0.12.12.1"
 end


### PR DESCRIPTION
Adds flag to rollbar `config.report_dj_data`, which is true by default that can prevent sending of DJ information to Rollbar as some DJ handlers may contain sensitive information.

Open to alternative (more generic) implementations and feedback.

relates to #95
