### PR TITLE
Catch all exceptions in our handlers, not just StandardError subclasses.

### DIFF
--- a/lib/rollbar/middleware/rack/builder.rb
+++ b/lib/rollbar/middleware/rack/builder.rb
@@ -6,7 +6,7 @@ module Rollbar
 
         def call_with_rollbar(env)
           call_without_rollbar(env)
-        rescue => exception
+        rescue Exception => exception
           report_exception_to_rollbar(env, exception)
           raise exception
         end

--- a/lib/rollbar/middleware/rack/test_session.rb
+++ b/lib/rollbar/middleware/rack/test_session.rb
@@ -6,7 +6,7 @@ module Rollbar
 
         def env_for_with_rollbar(path, env)
           env_for_without_rollbar(path, env)
-        rescue => exception
+        rescue Exception => exception
           report_exception_to_rollbar(env, exception)
           raise exception
         end

--- a/lib/rollbar/middleware/rails/show_exceptions.rb
+++ b/lib/rollbar/middleware/rails/show_exceptions.rb
@@ -6,7 +6,7 @@ module Rollbar
 
         def render_exception_with_rollbar(env, exception)
           key = 'action_dispatch.show_detailed_exceptions'
-          
+
           # don't report production exceptions here as it is done below
           # in call_with_rollbar() when show_detailed_exception is false
           if not env.has_key?(key) or env[key]
@@ -14,10 +14,10 @@ module Rollbar
           end
           render_exception_without_rollbar(env, exception)
         end
-        
+
         def call_with_rollbar(env)
           call_without_rollbar(env)
-        rescue => exception
+        rescue Exception => exception
           # won't reach here if show_detailed_exceptions is true
           report_exception_to_rollbar(env, exception)
           raise exception

--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -5,7 +5,7 @@ module Rollbar
     def call(worker, msg, queue)
       begin
         yield
-      rescue => e
+      rescue Exception => e
         msg.delete('backtrace')
         msg.delete('error_backtrace')
         msg.delete('error_message')


### PR DESCRIPTION
This matches the behaviour of ActionDispatch::ShowExceptions. Some
Ruby developers (like this one, until very recently) aren't aware that
you should subclass StandardError, not Exception, when creating custom
exception classes. Such exceptions would thus not be reported to Rollbar.
