### PR TITLE
Set the request id from action-dispatch so we can track them from the logs

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -37,7 +37,8 @@ module Rollbar
         :cookies => cookies,
         :session => session,
         :method => rollbar_request_method(env),
-        :route => route_params
+        :route => route_params,
+        :request_id => env["action_dispatch.request_id"],
       }
     end
 


### PR DESCRIPTION
The `RequestId` middleware in Rails sets a request-id field that we can use to rack the exception in log files, it would be nice if rollbar also sent it when sending error reports.
