### PR TITLE
Rails-like sensitive param scrubbing behavior

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -119,12 +119,12 @@ module Rollbar
     end
 
     def rollbar_filtered_params(sensitive_params, params)
-      sensitive_params_regexp = Regexp.new(sensitive_params.map(&:to_s).join('|'), true)
+      @sensitive_params_regexp ||= Regexp.new(sensitive_params.map(&:to_s).join('|'), true)
       if params.nil?
         {}
       else
         params.to_hash.inject({}) do |result, (key, value)|
-          if sensitive_params_regexp =~ key.to_s
+          if @sensitive_params_regexp =~ key.to_s
             result[key] = rollbar_scrubbed(value)
           elsif value.is_a?(Hash)
             result[key] = rollbar_filtered_params(sensitive_params, value)


### PR DESCRIPTION
- Adds the Rails behavior of converting the list of configured filter_parameters to a regexp that matches param names
- Adds handle for param values that are arrays, which may contain hashes
- Removes a DOS vulnerability caused by calling `to_sym` on all param keys. See http://brakemanscanner.org/docs/warning_types/denial_of_service/
