### PR TITLE
Scope cap3 task by server role

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ And then, to your `deploy.rb`:
 ```ruby
 set :rollbar_token, 'POST_SERVER_ITEM_ACCESS_TOKEN'
 set :rollbar_env, Proc.new { fetch :stage }
+set :rollbar_role, Proc.new { :app }
 ```
 
 ### Capistrano 2

--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -6,22 +6,25 @@ namespace :rollbar do
 
   desc 'Send the deployment notification to Rollbar.'
   task :deploy do
-    uri    = URI.parse 'https://api.rollbar.com/api/1/deploy/'
-    params = {
-      :local_username => fetch(:rollbar_user),
-      :access_token   => fetch(:rollbar_token),
-      :environment    => fetch(:rollbar_env),
-      :revision       => fetch(:current_revision) }
+    on roles fetch(:rollbar_role) do
+      uri    = URI.parse 'https://api.rollbar.com/api/1/deploy/'
+      params = {
+        :local_username => fetch(:rollbar_user),
+        :access_token   => fetch(:rollbar_token),
+        :environment    => fetch(:rollbar_env),
+        :revision       => fetch(:current_revision) }
 
-    request      = Net::HTTP::Post.new(uri.request_uri)
-    request.body = JSON.dump(params)
+      debug "Building Rollbar POST to #{uri} with #{params.inspect}"
 
-    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
-      http.request(request)
+      request      = Net::HTTP::Post.new(uri.request_uri)
+      request.body = JSON.dump(params)
+
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+        http.request(request)
+      end
+
+      info 'Rollbar notification complete.'
     end
-
-    # this is not the right way to output to capistrano's log..
-    puts 'Rollbar notification complete.'
   end
 end
 
@@ -34,5 +37,6 @@ namespace :load do
     set :rollbar_user,  Proc.new { ENV['USER'] || ENV['USERNAME'] }
     set :rollbar_env,   Proc.new { fetch :rails_env, 'production' }
     set :rollbar_token, Proc.new { abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'" }
+    set :rollbar_role,  Proc.new { :app }
   end
 end


### PR DESCRIPTION
Make the cap3 task respect server roles, defaulting to just the :app
server.

Also replaces the hacky `puts` output with the proper `info` and
`debug` methods.
