### PR TITLE
Ignore logging in development environment by default

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -12,8 +12,8 @@ Rollbar.configure do |config|
   <% else %>
   config.access_token = <%= access_token_expr %>
 
-  # Here we'll disable in 'test':
-  if Rails.env.test?
+  # Here we'll disable in 'test' and 'development':
+  if Rails.env.test? || Rails.env.development?
     config.enabled = false
   end
   <% end %>


### PR DESCRIPTION
Logging errors from development to an external service is weird. Not sure about what the usecase is, in our case it just causes noise. Any thoughts on changing the default?
