### PR TITLE
Adds support for specifying multiple project_gems with regex

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -104,14 +104,11 @@ module Rollbar
       @project_gem_paths = []
 
       gems.each { |name|
-        begin
-          spec = Gem::Specification.find_by_name(name.to_s)
-          gem_root = spec.gem_dir
-
-          @project_gem_paths.push gem_root
-        rescue Gem::LoadError
-          puts "[Rollbar] #{name} gem not found"
-        end
+        Gem::Specification.find_all_by_name(name).tap{ |results|
+          puts "[Rollbar] No gems found matching #{name.inspect}" if results.empty?
+        }.each{ |gem|
+          @project_gem_paths.push gem.gem_dir
+        }
       }
     end
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -145,14 +145,14 @@ describe Rollbar do
       }
       Rollbar.report_exception(@exception, {}, person_data)
     end
-    
+
     it 'should not ignore non-ignored persons' do
       Rollbar.configure do |config|
         config.ignored_person_ids += [1]
       end
-      
+
       Rollbar.last_report = nil
-      
+
       person_data = {
         :id => 1,
         :username => "test",
@@ -160,7 +160,7 @@ describe Rollbar do
       }
       Rollbar.report_exception(@exception, {}, person_data)
       Rollbar.last_report.should be_nil
-      
+
       person_data = {
         :id => 2,
         :username => "test2",
@@ -248,13 +248,13 @@ describe Rollbar do
       Rollbar.stub(:schedule_payload) do |*args|
         payload = MultiJson.load(args[0])
       end
-      
+
       Rollbar.report_exception(@exception)
-      
+
       payload["data"]["level"].should == 'error'
-      
+
       Rollbar.report_exception(@exception, nil, nil, 'debug')
-      
+
       payload["data"]["level"].should == 'debug'
     end
   end
@@ -324,7 +324,7 @@ describe Rollbar do
       end
     end
   end
-  
+
   context 'report_message_with_request' do
     before(:each) do
       configure
@@ -340,32 +340,32 @@ describe Rollbar do
       logger_mock.should_receive(:info).with('[Rollbar] Scheduling payload')
       logger_mock.should_receive(:info).with('[Rollbar] Success')
       Rollbar.report_message_with_request("Test message")
-      
+
       Rollbar.last_report[:request].should be_nil
       Rollbar.last_report[:person].should be_nil
     end
-    
+
     it 'should report messages with request, person data and extra data' do
       Rollbar.last_report = nil
-      
+
       logger_mock.should_receive(:info).with('[Rollbar] Scheduling payload')
       logger_mock.should_receive(:info).with('[Rollbar] Success')
-      
+
       request_data = {
         :params => {:foo => 'bar'}
       }
-      
+
       person_data = {
         :id => 123,
         :username => 'username'
       }
-      
+
       extra_data = {
         :extra_foo => 'extra_bar'
       }
-      
+
       Rollbar.report_message_with_request("Test message", 'info', request_data, person_data, extra_data)
-      
+
       Rollbar.last_report[:request].should == request_data
       Rollbar.last_report[:person].should == person_data
       Rollbar.last_report[:body][:message][:extra_foo].should == 'extra_bar'
@@ -658,35 +658,35 @@ describe Rollbar do
         config.logger = logger_mock
       end
     end
-    
+
     let(:logger_mock) { double("Rails.logger").as_null_object }
-    
+
     it 'should build valid json' do
       json = Rollbar.send(:build_payload, {:foo => {:bar => "baz"}})
       hash = MultiJson.load(json)
       hash["data"]["foo"]["bar"].should == "baz"
     end
-    
+
     it 'should truncate large strings if the payload is too big' do
       json = Rollbar.send(:build_payload, {:foo => {:bar => "baz"}, :large => 'a' * (128 * 1024), :small => 'b' * 1024})
       hash = MultiJson.load(json)
       hash["data"]["large"].should == '%s...' % ('a' * 1021)
       hash["data"]["small"].should == 'b' * 1024
     end
-    
+
     it 'should send a failsafe message if the payload cannot be reduced enough' do
       logger_mock.should_receive(:error).with(/Sending failsafe response due to Could not send payload due to it being too large after truncating attempts/)
       logger_mock.should_receive(:info).with('[Rollbar] Success')
-      
+
       orig_max = Rollbar::MAX_PAYLOAD_SIZE
-      
+
       Rollbar::MAX_PAYLOAD_SIZE = 1
       Rollbar.report_exception(@exception)
-      
+
       Rollbar::MAX_PAYLOAD_SIZE = orig_max
     end
   end
-  
+
   context 'truncate_payload' do
     it 'should truncate all nested strings in the payload' do
       payload = {
@@ -698,26 +698,26 @@ describe Rollbar do
           :array => ['12345678', '12', {:inner_inner => '123456789'}]
         }
       }
-      
+
       payload_copy = payload.clone
       Rollbar.send(:truncate_payload, payload_copy, 6)
-      
+
       payload_copy[:truncated].should == '123...'
       payload_copy[:not_truncated].should == '123456'
       payload_copy[:hash][:inner_truncated].should == '123...'
       payload_copy[:hash][:inner_not_truncated].should == '567'
       payload_copy[:hash][:array].should == ['123...', '12', {:inner_inner => '123...'}]
     end
-    
+
     it 'should truncate utf8 strings properly' do
       payload = {
         :truncated => 'Ŝǻмρļẻ śţяịņģ',
         :not_truncated => '123456',
       }
-      
+
       payload_copy = payload.clone
       Rollbar.send(:truncate_payload, payload_copy, 6)
-      
+
       payload_copy[:truncated].should == "Ŝǻм..."
       payload_copy[:not_truncated].should == '123456'
     end
@@ -812,6 +812,35 @@ describe Rollbar do
       data[:project_package_paths].each_with_index{|path, index|
         path.should == gem_paths[index]
       }
+    end
+
+    it "should handle regex gem patterns" do
+      gems = ["rack", /rspec/]
+      gem_paths = []
+
+      Rollbar.configure do |config|
+        config.project_gems = gems
+      end
+
+      gem_paths = gems.map{|gem| Gem::Specification.find_all_by_name(gem).map(&:gem_dir) }.flatten.compact.uniq
+      gem_paths.length.should > 1
+
+      data = Rollbar.send(:message_data, 'test', 'info', {})
+      data[:project_package_paths].kind_of?(Array).should == true
+      data[:project_package_paths].length.should == gem_paths.length
+      (data[:project_package_paths] - gem_paths).length.should == 0
+    end
+
+    it "should not break on non-existent gems" do
+      gems = ["this_gem_does_not_exist", "rack"]
+
+      Rollbar.configure do |config|
+        config.project_gems = gems
+      end
+
+      data = Rollbar.send(:message_data, 'test', 'info', {})
+      data[:project_package_paths].kind_of?(Array).should == true
+      data[:project_package_paths].length.should == 1
     end
   end
 


### PR DESCRIPTION
So we can do things like `config.project_gems = [/our_organization/]`.  Cheers!

Oh, let me know if the whitespace trimming is a problem, vim got a little carried away. (and obviously any of the other stuff too of course :)
