### PR TITLE
do not require rails its evil + cleanup other weird requires

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -1,12 +1,7 @@
 require 'net/https'
-
-require 'securerandom' if defined?(SecureRandom)
 require 'socket'
 require 'thread'
 require 'uri'
-
-require 'girl_friday' if defined?(GirlFriday)
-require 'sucker_punch' if defined?(SuckerPunch)
 require 'multi_json'
 
 require 'rollbar/version'
@@ -15,7 +10,6 @@ require 'rollbar/request_data_extractor'
 require 'rollbar/exception_reporter'
 require 'rollbar/active_record_extension' if defined?(ActiveRecord)
 require 'rollbar/util'
-
 require 'rollbar/railtie' if defined?(Rails)
 
 module Rollbar
@@ -30,7 +24,7 @@ module Rollbar
     def preconfigure
       yield(configuration)
     end
-    
+
     # Configures the gem.
     #
     # Call on app startup to set the `access_token` (required) and other config params.
@@ -47,7 +41,7 @@ module Rollbar
         configuration.enabled = true
       end
       yield(configuration)
-      
+
       require_hooks
     end
 
@@ -252,7 +246,7 @@ module Rollbar
         require 'rollbar/delayed_job'
         Rollbar::Delayed::wrap_worker
       end
-      
+
       require 'rollbar/sidekiq' if defined?(Sidekiq)
       require 'rollbar/goalie' if defined?(Goalie)
       require 'rollbar/rack' if defined?(Rack)

--- a/lib/rollbar/railtie.rb
+++ b/lib/rollbar/railtie.rb
@@ -1,4 +1,4 @@
-require 'rails'
+require 'rails/railtie'
 require 'rollbar'
 
 module Rollbar
@@ -6,7 +6,7 @@ module Rollbar
     rake_tasks do
       require 'rollbar/rake_tasks'
     end
-    
+
     if defined? ActiveRecord
       initializer 'rollbar.middleware.rails' do |app|
         require 'rollbar/middleware/rails/rollbar_request_store'


### PR DESCRIPTION
`require 'securerandom' if defined?(SecureRandom)` etc does not make any sense to me ...

the usual railtie loads rails/railtie and not all of rails see https://github.com/rails/activemodel-globalid/blob/master/lib/active_model/railtie.rb and https://github.com/rails/activemodel-globalid/blob/master/lib/active_model/railtie.rb

@brianr @sbezboro 
