### PR TITLE
Making report_exception_to_rollbar protected

### DIFF
--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -2,6 +2,8 @@ module Rollbar
   module ExceptionReporter
     include RequestDataExtractor
 
+    protected
+
     def report_exception_to_rollbar(env, exception)
       Rollbar.log_error "Reporting exception: #{exception.message}"
       request_data = extract_request_data_from_rack(env)


### PR DESCRIPTION
So it won't be visible as an action method inside Rails controllers. Right now if you do `controller.action_methods` this method will be listed there.
