### PR TITLE
Add Sinatra middleware.

### DIFF
--- a/lib/rollbar/middleware/sinatra.rb
+++ b/lib/rollbar/middleware/sinatra.rb
@@ -1,0 +1,27 @@
+require 'rollbar'
+require 'rollbar/exception_reporter'
+
+module Rollbar
+  module Middleware
+    class Sinatra
+      include ::Rollbar::ExceptionReporter
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        response = @app.call(env)
+        report_exception_to_rollbar(env, framework_error(env)) if framework_error(env)
+        response
+      rescue ::Exception => exception
+        report_exception_to_rollbar(env, exception)
+        raise
+      end
+
+      def framework_error(env)
+        env['sinatra.error']
+      end
+    end
+  end
+end

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'sucker_punch', '>= 1.0.0' if RUBY_VERSION != '1.8.7'
   gem.add_development_dependency 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
   gem.add_development_dependency 'genspec', '>= 0.2.7'
+  gem.add_development_dependency 'sinatra'
 end

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'rollbar/middleware/sinatra'
+require 'sinatra/base'
+require 'rack/test'
+
+class SinatraDummy < Sinatra::Base
+  class DummyError < StandardError; end
+
+  use Rollbar::Middleware::Sinatra
+
+  get '/foo' do
+    raise DummyError.new
+  end
+
+  get '/bar' do
+    'this will not crash'
+  end
+end
+
+describe Rollbar::Middleware::Sinatra do
+  include Rack::Test::Methods
+
+  def app
+    SinatraDummy
+  end
+
+  let(:expected_report_args) do
+    [exception, kind_of(Hash), kind_of(Hash)]
+  end
+
+  describe '#call' do
+    context 'for a crashing endpoint' do
+      # this is the default for test mode in Sinatra
+      context 'with raise_errors? == true' do
+        let(:exception) { kind_of(SinatraDummy::DummyError) }
+
+        before do
+          allow(app.settings).to receive(:raise_errors?).and_return(true)
+        end
+
+        it 'reports the error to Rollbar API and raises error' do
+          expect(Rollbar).to receive(:report_exception).with(*expected_report_args)
+
+          expect do
+            get '/foo'
+          end.to raise_error(SinatraDummy::DummyError)
+        end
+      end
+
+      context 'with raise_errors? == false' do
+        let(:exception) { kind_of(SinatraDummy::DummyError) }
+
+        before do
+          allow(app.settings).to receive(:raise_errors?).and_return(false)
+        end
+
+        it 'reports the error to Rollbar, but nothing is raised' do
+          expect(Rollbar).to receive(:report_exception).with(*expected_report_args)
+          get '/foo'
+        end
+      end
+    end
+
+    context 'for a NOT crashing endpoint' do
+      it 'doesnt report any error to Rollbar API' do
+        expect(Rollbar).not_to receive(:report_exception)
+        get '/bar'
+      end
+    end
+
+    context 'if the middleware itself fails' do
+      let(:exception) { Exception.new }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:framework_error).and_raise(exception)
+        allow(app.settings).to receive(:raise_errors?).and_return(false)
+      end
+
+      it 'reports the report error' do
+        expect(Rollbar).to receive(:report_exception).with(*expected_report_args)
+
+        expect do
+          get '/foo'
+        end.to raise_error(exception)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 
-ENV['RAILS_ENV'] = 'test'
+ENV['RAILS_ENV'] = ENV['RACK_ENV'] = 'test'
 require File.expand_path('../dummyapp/config/environment', __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'


### PR DESCRIPTION
Hi!

I had some problems with the gem using it in a Sinatra project. I had to write my own middleware and I think it could be interesting for you having it in the gem.

The problem comes from here in the Sinatra code:
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1112
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1122

The first line raise the error only in development environment by default, and the second one only raise the error in test mode, https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1839.

However Sinatra saves the exception in `env['sinatra.error']`, you can see it here:
https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1098

The result of all of this is that the exception doesn't arrive to your monkey patch to `Rack::Builder` so it doesn't work for Sinatra projects.

IMHO it's better don't monkey patch `Rack::Builder` and just add the middleware to the rack stack using `use Rollbar::Middleware::Rack`, for example. But ok, this change could break the projects of other people so I've only added a isolated Sinatra middleware.

I think it could be interesting to add a warn message and a condition to monkey patch or not `Rack::Builder` and in next versions just add a middlware so the users can add it to their apps.

I hope this code is useful for you, it helped me in my developments.
