### PR TITLE
Change resque-rollbar source

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ If you're using [Goalie](https://github.com/obvio171/goalie) for custom error pa
 
 ## Using with Resque
 
-Check out [resque-rollbar](https://github.com/CrowdFlower/resque-rollbar) for using Rollbar as a failure backend for Resque.
+Check out [resque-rollbar](https://github.com/dimko/resque-rollbar) for using Rollbar as a failure backend for Resque.
 
 
 ## Using with Zeus


### PR DESCRIPTION
https://github.com/dimko/resque-rollbar is the source for the rubygems version of resque-rollbar.  It is now functionally equivalent to CrowdFlower/resque-rollbar after https://github.com/dimko/resque-rollbar/pull/7.  Given that, CrowdFlower is going to deprecate their version and point it to @dimko's.
