### PR TITLE
Trace exception local variables and args per frame

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -319,6 +319,7 @@ module Rollbar
         all_variable_names.each do |var_name|
           begin
             if var_value = binding.eval(var_name.to_s)
+              var_name = var_name.to_sym # ensure symbol for older versions of Ruby
               if arg_names.include? var_name
                 local_variables[:args][var_name] = var_value
               else

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -18,6 +18,7 @@ module Rollbar
     attr_accessor :filepath
     attr_accessor :framework
     attr_accessor :ignored_person_ids
+    attr_accessor :locals
     attr_accessor :logger
     attr_accessor :person_method
     attr_accessor :person_id_method
@@ -55,6 +56,7 @@ module Rollbar
       }
       @framework = 'Plain'
       @ignored_person_ids = []
+      @locals = { :enabled => false, :max_trace_frames => 100 }
       @person_method = 'current_user'
       @person_id_method = 'id'
       @person_username_method = 'username'

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -666,21 +666,43 @@ describe Rollbar do
         test_func("test_param_value")
       rescue => e
         @exception = e
+        @data = Rollbar.send(:exception_data, @exception)
       end
     end
 
-    it 'should include local variables and args for each stack frame when enabled' do
-      data = Rollbar.send(:exception_data, @exception)
-      top_frame = data[:body][:trace][:frames].last
-      top_frame[:locals].keys.count.should eq 1
-      top_frame[:locals][:local_func_var].should eq "local_func_var_value"
-      top_frame[:args][:test_param].should eq "test_param_value"
-      top_frame[:args].keys.count.should eq 1
+    context 'when using Ruby 1.9.3 and above' do
+      next unless Method.method_defined? :parameters
+      it 'should include local variables and args for each stack frame when enabled' do
+        top_frame = @data[:body][:trace][:frames].last
+        top_frame[:locals].keys.count.should eq 1
+        top_frame[:locals][:local_func_var].should eq "local_func_var_value"
+        top_frame[:args][:test_param].should eq "test_param_value"
+        top_frame[:args].keys.count.should eq 1
 
-      next_frame = data[:body][:trace][:frames][-2]
-      next_frame[:locals].keys.count.should eq 1
-      next_frame[:locals][:local_var].should eq "local_var_value"
+        next_frame = @data[:body][:trace][:frames][-2]
+        next_frame[:locals].keys.count.should eq 1
+        next_frame[:locals][:local_var].should eq "local_var_value"
+      end
     end
+
+    # In Ruby 1.8.7, we don't have the Method#parameters method
+    # Thus, all local variables, including method arguments will be
+    # available in the frame's :local key. The :args key will not be available
+    context 'when using Ruby 1.8.7 and below' do
+      next if Method.method_defined? :parameters
+      it 'should include local variables for each stack frame when enabled' do
+        top_frame = @data[:body][:trace][:frames].last
+        top_frame[:args].should be_nil
+        top_frame[:locals].keys.count.should eq 2
+        top_frame[:locals][:local_func_var].should eq "local_func_var_value"
+        top_frame[:locals][:test_param].should eq "test_param_value"
+
+        next_frame = @data[:body][:trace][:frames][-2]
+        next_frame[:locals].keys.count.should eq 1
+        next_frame[:locals][:local_var].should eq "local_var_value"
+      end
+    end
+
   end
 
   context 'logger' do


### PR DESCRIPTION
New configuration options and defaults
config.locals.enabled = off
config.locals.max_trace_frames = 100

Turned off by default because this may not be performant just yet!
1. Stores each Ruby process' local vars and method arguments
2. When gathering exception data, "replay" over each frame to get the variables for that frame's context
3. Dump the cache and repeat
