### PR TITLE
Change log level from error to info in ExceptionReporter module.

### DIFF
--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -3,11 +3,11 @@ module Rollbar
     include RequestDataExtractor
 
     def report_exception_to_rollbar(env, exception)
-      Rollbar.log_error "Reporting exception: #{exception.message}"
+      Rollbar.log_info "Reporting exception: #{exception.message}"
       request_data = extract_request_data_from_rack(env)
       person_data = extract_person_data_from_controller(env)
       exception_data = Rollbar.report_exception(exception, request_data, person_data)
-      
+
       if exception_data.is_a?(Hash)
         env['rollbar.exception_uuid'] = exception_data[:uuid]
         Rollbar.log_debug "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"


### PR DESCRIPTION
Actually the log message about being reporting an error in `ExceptionReporter` has `error` level. I think it could be better change it to `info`. This is not an error in the gem but in the application itself and it's not responsability of the gem log it as an `error` IMHO.

Can we consider merge this change?
