### PR TITLE
Remove proc evaluation in payload values.

### DIFF
--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -44,9 +44,7 @@ module Rollbar
           block = proc { extract_person_data_from_controller(env) }
           return block unless defined?(ActiveRecord::Base)
 
-          proc do
-            ActiveRecord::Base.connection_pool.with_connection(&block)
-          end
+          proc { ActiveRecord::Base.connection_pool.with_connection(&block) }
         end
 
         def context(request_data)


### PR DESCRIPTION
requested by @brianr 

We needed it to evaluate the person data proc, that it's defined as part of the scope in the Rails middleware. Because it's defined before the person data is set by the controllers, we still need to use a proc for it. We evaluate the person data while we are building the payload but removing the evaluation of all defined proc in the configuration.

We'll think in the future about the correct feature for the users, but this approach was a little dangerous.
