### PR TITLE
Require 'rack' in request data extractor.

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -1,4 +1,5 @@
 require 'multi_json'
+require 'rack'
 
 module Rollbar
   module RequestDataExtractor
@@ -14,7 +15,7 @@ module Rollbar
     end
 
     def extract_request_data_from_rack(env)
-      rack_req = Rack::Request.new(env)
+      rack_req = ::Rack::Request.new(env)
 
       sensitive_params = sensitive_params_list(env)
       request_params = rollbar_filtered_params(sensitive_params, rollbar_request_params(env))


### PR DESCRIPTION
It could be crashing in some environments and it's desirable to require all the constants we are using in a module.
