### PR TITLE
Don't require request_data_extractor by default in rollbar.rb.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -12,7 +12,6 @@ end
 require 'rollbar/version'
 require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
-require 'rollbar/request_data_extractor'
 require 'rollbar/exception_reporter'
 require 'rollbar/active_record_extension' if defined?(ActiveRecord)
 require 'rollbar/util'

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -1,12 +1,10 @@
 module Rollbar
   module ExceptionReporter
-    include RequestDataExtractor
-
     def report_exception_to_rollbar(env, exception)
       Rollbar.log_debug "[Rollbar] Reporting exception: #{exception.try(:message)}"
-      
+
       exception_data = Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception)
-      
+
       if exception_data.is_a?(Hash)
         env['rollbar.exception_uuid'] = exception_data[:uuid]
         Rollbar.log_debug "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -1,3 +1,6 @@
+require 'rollbar/request_data_extractor'
+require 'rollbar/exception_reporter'
+
 module Rollbar
   module Middleware
     module Rails

--- a/lib/rollbar/rails/controller_methods.rb
+++ b/lib/rollbar/rails/controller_methods.rb
@@ -1,3 +1,5 @@
+require 'rollbar/request_data_extractor'
+
 module Rollbar
   module Rails
     module ControllerMethods


### PR DESCRIPTION
It's already required in rack middleares (Rack, Sinatra or Rails)
