### PR TITLE
Integration test for utf8

### DIFF
--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -870,6 +870,19 @@ describe Rollbar do
 
       payload['data'][:level].should == 'debug'
     end
+
+    context 'with invalid utf8 encoding' do
+      let(:extra) do
+        { :extra => "bad value 1\255" }
+      end
+
+      it 'removes te invalid characteres' do
+        Rollbar.info('removing invalid chars', extra)
+
+        extra_value = Rollbar.last_report[:body][:message][:extra][:extra]
+        expect(extra_value).to be_eql('bad value 1')
+      end
+    end
   end
 
   # Backwards


### PR DESCRIPTION
We had the `enforce_valid_utf8` method tested just isolated. Now it's testead with the whole chain executing `Rollbar.chain`.
