### PR TITLE
Allow hashes, arrays or other values as POST body

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -21,12 +21,12 @@ module Rollbar
       request_params = rollbar_filtered_params(sensitive_params, rollbar_request_params(env))
       get_params = rollbar_filtered_params(sensitive_params, rollbar_get_params(rack_req))
       post_params = rollbar_filtered_params(sensitive_params, rollbar_post_params(rack_req))
-      raw_post_params = rollbar_filtered_params(sensitive_params, mergeable_raw_post_params(rack_req))
+      raw_body_params = rollbar_filtered_params(sensitive_params, mergeable_raw_body_params(rack_req))
       cookies = rollbar_filtered_params(sensitive_params, rollbar_request_cookies(rack_req))
       session = rollbar_filtered_params(sensitive_params, env['rack.session.options'])
       route_params = rollbar_filtered_params(sensitive_params, rollbar_route_params(env))
 
-      params = request_params.merge(get_params).merge(post_params).merge(raw_post_params)
+      params = request_params.merge(get_params).merge(post_params).merge(raw_body_params)
 
       data = {
         :params => params,
@@ -48,15 +48,15 @@ module Rollbar
 
     private
 
-    def mergeable_raw_post_params(rack_req)
-      raw_post_params = rollbar_raw_post_params(rack_req)
+    def mergeable_raw_body_params(rack_req)
+      raw_body_params = rollbar_raw_body_params(rack_req)
 
-      if raw_post_params.is_a?(Hash)
-        raw_post_params
-      elsif raw_post_params.is_a?(Array) && raw_post_params.size == 1
-        raw_post_params[0]
+      if raw_body_params.is_a?(Hash)
+        raw_body_params
+      elsif raw_body_params.is_a?(Array)
+        { 'body.multi' => raw_body_params }
       else
-        {}
+        { 'body.value' => raw_body_params }
       end
     end
 
@@ -112,7 +112,7 @@ module Rollbar
       {}
     end
 
-    def rollbar_raw_post_params(rack_req)
+    def rollbar_raw_body_params(rack_req)
       correct_method = rack_req.post? || rack_req.put? || rack_req.patch?
 
       return {} unless correct_method
@@ -154,32 +154,28 @@ module Rollbar
     def rollbar_filtered_params(sensitive_params, params)
       sensitive_params_regexp = Regexp.new(sensitive_params.map{ |val| Regexp.escape(val.to_s).to_s }.join('|'), true)
 
-      if params.nil?
-        {}
-      elsif params.is_a?(Array)
-        params.map { |value| rollbar_filtered_params(sensitive_params, value) }
-      else
-        params.to_hash.inject({}) do |result, (key, value)|
-          if sensitive_params_regexp =~ key.to_s
-            result[key] = rollbar_scrubbed(value)
-          elsif value.is_a?(Hash)
-            result[key] = rollbar_filtered_params(sensitive_params, value)
-          elsif value.is_a?(Array)
-            result[key] = value.map do |v|
-              v.is_a?(Hash) ? rollbar_filtered_params(sensitive_params, v) : v
-            end
-          elsif ATTACHMENT_CLASSES.include?(value.class.name)
-            result[key] = {
-              :content_type => value.content_type,
-              :original_filename => value.original_filename,
-              :size => value.tempfile.size
-            } rescue 'Uploaded file'
-          else
-            result[key] = value
-          end
+      return {} unless params
 
-          result
+      params.to_hash.inject({}) do |result, (key, value)|
+        if sensitive_params_regexp =~ key.to_s
+          result[key] = rollbar_scrubbed(value)
+        elsif value.is_a?(Hash)
+          result[key] = rollbar_filtered_params(sensitive_params, value)
+        elsif value.is_a?(Array)
+          result[key] = value.map do |v|
+            v.is_a?(Hash) ? rollbar_filtered_params(sensitive_params, v) : v
+          end
+        elsif ATTACHMENT_CLASSES.include?(value.class.name)
+          result[key] = {
+            :content_type => value.content_type,
+            :original_filename => value.original_filename,
+            :size => value.tempfile.size
+          } rescue 'Uploaded file'
+        else
+          result[key] = value
         end
+
+        result
       end
     end
 

--- a/spec/rollbar/middleware/rack/builder_spec.rb
+++ b/spec/rollbar/middleware/rack/builder_spec.rb
@@ -56,56 +56,33 @@ describe Rollbar::Middleware::Rack::Builder do
 
       expect(Rollbar.last_report[:request][:params]).to be_eql(params)
     end
+  end
 
-    context 'with crashing payload' do
-      let(:body) { 'this is not a valid json' }
-
-      it 'returns {} and doesnt raise' do
-        expect do
-          request.post('/dont_crash', :input => body, 'CONTENT_TYPE' => 'application/json')
-        end.to raise_error(exception)
-
-        expect(Rollbar.last_report[:request][:params]).to be_eql({})
-      end
+  context 'with array POST parameters' do
+    let(:params) do
+      [{ :key => 'value'}, 'string', 10]
     end
 
-    context 'with an single element array params in POST' do
-      before do
-        Rollbar.configure do |config|
-          config.scrub_fields = [:secret]
-        end
-      end
+    it 'sends a body.multi key in params' do
+      expect do
+        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+      end.to raise_error(exception)
 
-      let(:params) do
-        [{ :secret => 'hidden', :willsee => 'visible'}]
-      end
-
-      it 'scrub custom fields in array params' do
-        expect do
-          request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
-        end.to raise_error(exception)
-
-        filtered = Rollbar.last_report[:request][:params]
-
-        expect(filtered['secret']).to be_eql('******')
-        expect(filtered['willsee']).to be_eql('visible')
-      end
+      reported_params = Rollbar.last_report[:request][:params]
+      expect(reported_params['body.multi']).to be_eql([{'key' => 'value'}, 'string', 10])
     end
+  end
 
-    context 'with an two element array params in POST' do
-      let(:params) do
-        [{ :secret => 'hidden', :willsee => 'visible'},
-         { :foo => 'bar', :key => 'value'}]
-      end
+  context 'with not array or hash POST parameters' do
+    let(:params) { 1000 }
 
-      it 'doesnt merge the post params in the reported params' do
-        expect do
-          request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
-        end.to raise_error(exception)
+    it 'sends a body.multi key in params' do
+      expect do
+        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+      end.to raise_error(exception)
 
-        reported_params = Rollbar.last_report[:request][:params]
-        expect(reported_params).to be_eql({})
-      end
+      reported_params = Rollbar.last_report[:request][:params]
+      expect(reported_params['body.value']).to be_eql(1000)
     end
   end
 end


### PR DESCRIPTION
Allow hashes, arrays or other values as raw POST body.
- If the parsed body is a Hash we just return the hash.
- If the parsed body is an Array we return { 'body.multi' => array }
- If the parsed body is other value we retur { 'body.value' => value }
