### PR TITLE
Require forwardable module.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -3,6 +3,7 @@ require 'socket'
 require 'thread'
 require 'uri'
 require 'multi_json'
+require 'forwardable'
 
 begin
   require 'securerandom'


### PR DESCRIPTION
Otherwise it will throw an exception when requiring the rollbar module.
