### PR TITLE
Fix filtered levels.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -128,6 +128,9 @@ module Rollbar
 
       return 'ignored' if ignored?(exception)
 
+      exception_level = filtered_level(exception)
+      level = exception_level if exception_level
+
       begin
         report(level, message, exception, extra)
       rescue Exception => e
@@ -191,6 +194,8 @@ module Rollbar
     end
 
     def filtered_level(exception)
+      return unless exception
+
       filter = configuration.exception_level_filters[exception.class.name]
       if filter.respond_to?(:call)
         filter.call(exception)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -725,6 +725,15 @@ describe Rollbar do
       Rollbar.error(exception)
     end
 
+    it 'sends the correct filtered level' do
+      Rollbar.configure do |config|
+        config.exception_level_filters = { 'NameError' => 'warning' }
+      end
+
+      Rollbar.error(exception)
+      expect(Rollbar.last_report[:level]).to be_eql('warning')
+    end
+
     it "should work with an IO object as rack.errors" do
       logger_mock.should_receive(:info).with('[Rollbar] Success')
 


### PR DESCRIPTION
After new interface changes we lost this feature :-/. This PRs re-enables it.

BTW, ignore exceptions should be still working before this PR.
