### PR TITLE
fix reset notifier on rails initialize

### DIFF
--- a/lib/rollbar/rails.rb
+++ b/lib/rollbar/rails.rb
@@ -15,6 +15,7 @@ module Rollbar
         config.root = defined?(::Rails.root) && ::Rails.root || defined?(RAILS_ROOT) && RAILS_ROOT
         config.framework = defined?(::Rails.version) && "Rails: #{::Rails.version}" || defined?(::Rails::VERSION::STRING) && "Rails: #{::Rails::VERSION::STRING}"
       end
+      Rollbar.reset_notifier!
     end
   end
 end

--- a/spec/dummyapp/config/application.rb
+++ b/spec/dummyapp/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 require "rails/all"
 
 Bundler.require
-require "rollbar"
 
 module Dummy
   class Application < Rails::Application

--- a/spec/dummyapp/config/environments/development.rb
+++ b/spec/dummyapp/config/environments/development.rb
@@ -34,4 +34,5 @@ Dummy::Application.configure do
 
   # Expands the lines which load the assets
   #config.assets.debug = true
+  config.eager_load = false
 end

--- a/spec/dummyapp/config/environments/production.rb
+++ b/spec/dummyapp/config/environments/production.rb
@@ -64,4 +64,5 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+  config.eager_load = true
 end

--- a/spec/dummyapp/config/environments/test.rb
+++ b/spec/dummyapp/config/environments/test.rb
@@ -34,4 +34,5 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+  config.eager_load = false
 end

--- a/spec/dummyapp/config/initializers/_new_thread.rb
+++ b/spec/dummyapp/config/initializers/_new_thread.rb
@@ -1,0 +1,1 @@
+Thread.new { }

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -12,6 +12,10 @@ rescue LoadError
 end
 
 describe Rollbar do
+  it 'should have a notifier enabled when Thread.new has been called', :reset_notifier => true do
+    Rollbar.notifier.configuration.enabled.should be_truthy
+  end
+
   let(:notifier) { Rollbar.notifier }
   context 'Notifier' do
     context 'log' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,13 @@ RSpec.configure do |config|
   config.before(:each) do
     DatabaseCleaner.start
     DatabaseCleaner.clean
-    Rollbar.reset_notifier!
+    Rollbar.reset_notifier! unless ENV['RESET']
+  end
+
+  if ENV['RESET']
+    config.filter_run(:reset_notifier => true)
+  else
+    config.filter_run_excluding(:reset_notifier => true)
   end
 
   config.after(:each) do


### PR DESCRIPTION
Hi,

If an initializer calls `Thread.new` before Rollbar is initialized then the notifier doesn't clone the correct configuration.  I've added a spec which can be called using
`RESET=1 rake spec`
because in the spec helper is calling `Rollbar.reset_notifier!` already.
