### PR TITLE
Add process ID to server data

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -370,6 +370,7 @@ module Rollbar
       }
       data[:root] = configuration.root.to_s if configuration.root
       data[:branch] = configuration.branch if configuration.branch
+      data[:pid] = Process.pid
 
       data
     end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -300,7 +300,7 @@ describe Rollbar do
         end
 
         it 'should have the correct server keys' do
-          payload['data'][:server].keys.should match_array([:host, :root])
+          payload['data'][:server].keys.should match_array([:host, :root, :pid])
         end
 
         it 'should have the correct level and message body' do


### PR DESCRIPTION
It's useful to report the PID of the process that raised the exception,
this commit adds it to server data so we can see it in Rollbar.

I will manually test it a little more, please don't merge until I report that it works properly.

I've only run the specs with this Ruby:
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]

Process.pid seems to work on one Windows computer we have here, though I don't know how universal support is or whether an exception is thrown if it is not supported. Ruby documentation says it doesn't work on all platforms.
