### PR TITLE
refactor sidekiq handler

### DIFF
--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 
-PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class]
-
 module Rollbar
   class Sidekiq
+    PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class]
+
     def self.handle_exception(msg_or_context, e)
       params = msg_or_context.reject{ |k| PARAM_BLACKLIST.include?(k) }
       scope = { :request => { :params => params } }

--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -20,14 +20,12 @@ module Rollbar
   end
 end
 
-if Sidekiq::VERSION < '3'
-  Sidekiq.configure_server do |config|
+Sidekiq.configure_server do |config|
+  if Sidekiq::VERSION < '3'
     config.server_middleware do |chain|
       chain.add Rollbar::Sidekiq
     end
-  end
-else
-  Sidekiq.configure_server do |config|
+  else
     config.error_handlers << Proc.new do |e, context|
       Rollbar::Sidekiq.handle_exception(context, e)
     end

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'girl_friday', '>= 0.11.1'
   gem.add_development_dependency 'sucker_punch', '>= 1.0.0' if RUBY_VERSION != '1.8.7'
   gem.add_development_dependency 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
-  gem.add_development_dependency 'genspec', '>= 0.2.7'
+  gem.add_development_dependency 'genspec', '>= 0.2.8'
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'resque'
   gem.add_development_dependency 'delayed_job'

--- a/spec/rollbar/sidekiq_spec.rb
+++ b/spec/rollbar/sidekiq_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+unless RUBY_VERSION == '1.8.7'
+  require 'sidekiq'
+  require 'rollbar/sidekiq'
+end
+
+describe "Sidekiq integration", :reconfigure_notifier => false do
+  before{ skip if RUBY_VERSION == '1.8.7' }
+
+  describe "Rollbar::Sidekiq.handle_exception" do
+    let(:msg_or_context) { ["hello", "error_backtrace", "backtrace", "goodbye"] }
+    let(:exception) { StandardError.new("oh noes") }
+    let(:rollbar) { double }
+    subject do
+      Rollbar::Sidekiq.handle_exception(msg_or_context, exception)
+    end
+
+    it "constructs scope from filtered params" do
+      rollbar.stub(:error)
+      Rollbar.should_receive(:scope).with(
+        { :request => { :params => ["hello", "goodbye"] } }
+      ) {rollbar}
+      subject
+    end
+    it "sends the passed-in error to rollbar" do
+      Rollbar.stub(:scope) { rollbar }
+      rollbar.should_receive(:error).with(exception, :use_exception_level_filters => true)
+      subject
+    end
+  end
+
+  describe "middleware" do
+    let(:middleware) { Rollbar::Sidekiq.new }
+    let(:msg) { ["hello"] }
+    let(:exception) { StandardError.new("oh noes") }
+    subject do
+      middleware.call(nil, msg, nil) do
+        raise exception
+      end
+    end
+
+    it "sends the error to Rollbar::Sidekiq.handle_exception" do
+      Rollbar::Sidekiq.should_receive(:handle_exception).with(msg, exception)
+      subject rescue nil
+    end
+
+    it "re-raises the exception" do
+      assert_raises StandardError do
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
* DRYed up the code by moving the error handling code into its own method that can be reused
* DRYed up the code by removing redundant invocations of `Sidekiq.configure_server do |config|`
* moved PARAM_BLACKLIST out of the global namespace

(the first one is what inspired me to do the refactoring in the first place, because in my project i need to change the behavior and currently have to do a monkeypatch which replicates all the code. after this refactoring, i can use `alias_method_chain`)

let me know what you think!

/cc @dadadadave