### PR TITLE
Use :use_exception_level_filters option in middlewares.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -127,8 +127,10 @@ module Rollbar
 
       return 'ignored' if ignored?(exception)
 
-      exception_level = filtered_level(exception)
-      level = exception_level if exception_level
+      if extra && extra.delete(:use_exception_level_filters) == true
+        exception_level = filtered_level(exception)
+        level = exception_level if exception_level
+      end
 
       begin
         report(level, message, exception, extra)

--- a/lib/rollbar/better_errors.rb
+++ b/lib/rollbar/better_errors.rb
@@ -15,7 +15,7 @@ module BetterErrors
         controller = env['action_controller.instance']
         request_data = controller.rollbar_request_data rescue nil
         person_data = controller.rollbar_person_data rescue nil
-        exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(exception)
+        exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(exception, :use_exception_level_filters => true)
       rescue => e
         Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
       end

--- a/lib/rollbar/delayed_job.rb
+++ b/lib/rollbar/delayed_job.rb
@@ -10,7 +10,7 @@ module Rollbar
         rescue Exception => e
           if job.attempts >= ::Rollbar.configuration.dj_threshold
             data = ::Rollbar.configuration.report_dj_data ? job : nil
-            ::Rollbar.scope(:request => data).error(e)
+            ::Rollbar.scope(:request => data).error(e, :use_exception_level_filters => true)
           end
           raise e
         end

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -4,7 +4,7 @@ module Rollbar
       exception_message = exception.respond_to?(:message) ? exception.message : 'No Exception Message'
       Rollbar.log_debug "[Rollbar] Reporting exception: #{exception_message}"
 
-      exception_data = Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception)
+      exception_data = Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception, :use_exception_level_filters => true)
 
       if exception_data.is_a?(Hash)
         env['rollbar.exception_uuid'] = exception_data[:uuid]

--- a/lib/rollbar/goalie.rb
+++ b/lib/rollbar/goalie.rb
@@ -1,7 +1,7 @@
 module Goalie
   class CustomErrorPages
     alias_method :orig_render_exception, :render_exception
-    
+
     private
 
     def render_exception(env, exception)
@@ -10,7 +10,7 @@ module Goalie
         controller = env['action_controller.instance']
         request_data = controller.rollbar_request_data rescue nil
         person_data = controller.rollbar_person_data rescue nil
-        exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(exception)
+        exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(exception, :use_exception_level_filters => true)
       rescue => e
         Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
       end

--- a/lib/rollbar/rake.rb
+++ b/lib/rollbar/rake.rb
@@ -9,7 +9,7 @@ module Rollbar
         alias_method :orig_display_error_message, :display_error_message
 
         def display_error_message(ex)
-          Rollbar.error(ex)
+          Rollbar.error(ex, :use_exception_level_filters => true)
           orig_display_error_message(ex)
         end
       end

--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -12,7 +12,7 @@ if Sidekiq::VERSION < '3'
           params = msg.reject{ |k| PARAM_BLACKLIST.include?(k) }
           scope = { :request => { :params => params } }
 
-          Rollbar.scope(scope).error(e)
+          Rollbar.scope(scope).error(e, :use_exception_level_filters => true)
           raise
         end
       end
@@ -30,7 +30,7 @@ else
       params = context.reject{ |k| PARAM_BLACKLIST.include?(k) }
       scope = { :request => { :params => params } }
 
-      Rollbar.scope(scope).error(e)
+      Rollbar.scope(scope).error(e, :use_exception_level_filters => true)
     end
   end
 end

--- a/spec/rollbar/delayed_job_spec.rb
+++ b/spec/rollbar/delayed_job_spec.rb
@@ -32,8 +32,12 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
     Delayed::Worker.backend = DummyBackend::Job
   end
 
+  let(:expected_args) do
+    [kind_of(FailingJob::TestException), { :use_exception_level_filters => true}]
+  end
+
   it 'sends the exception' do
-    expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(kind_of(FailingJob::TestException))
+    expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*expected_args)
 
     expect do
       Delayed::Job.enqueue(FailingJob.new)

--- a/spec/rollbar/middleware/rack/builder_spec.rb
+++ b/spec/rollbar/middleware/rack/builder_spec.rb
@@ -26,7 +26,7 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
   let(:uncaught_level) { Rollbar.configuration.uncaught_exception_level }
 
   it 'reports the error to Rollbar' do
-    expect(Rollbar).to receive(:log).with(uncaught_level, exception)
+    expect(Rollbar).to receive(:log).with(uncaught_level, exception, :use_exception_level_filters => true)
     expect { request.get('/will_crash') }.to raise_error(exception)
   end
 

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -42,7 +42,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
   end
 
   let(:expected_report_args) do
-    [uncaught_level, exception]
+    [uncaught_level, exception, { :use_exception_level_filters => true}]
   end
 
   describe '#call' do

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -42,7 +42,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
   end
 
   let(:expected_report_args) do
-    [uncaught_level, exception, { :use_exception_level_filters => true}]
+    [uncaught_level, exception, { :use_exception_level_filters => true }]
   end
 
   describe '#call' do

--- a/spec/rollbar/rake_spec.rb
+++ b/spec/rollbar/rake_spec.rb
@@ -12,7 +12,7 @@ describe Rollbar::Rake do
 
     it 'reports error to Rollbar' do
       expect(Rollbar::Rake).not_to receive(:skip_patch)
-      expect(Rollbar).to receive(:error).with(exception)
+      expect(Rollbar).to receive(:error).with(exception, :use_exception_level_filters => true)
       expect(application).to receive(:orig_display_error_message).with(exception)
 
       Rollbar::Rake.patch! # Really here Rake is already patched

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -276,7 +276,7 @@ describe Rollbar do
       Rollbar.last_report.should_not be_nil
     end
 
-    it 'should allow callables to set exception filtered level' do
+    it 'should allow callables to set exception filtered level with :use_exception_level_filters option' do
       callable_mock = double
       Rollbar.configure do |config|
         config.exception_level_filters = { 'NameError' => callable_mock }

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -731,18 +731,6 @@ describe Rollbar do
       Rollbar.error(exception).should == 'disabled'
     end
 
-    it 'should ignore ignored exception classes' do
-      Rollbar.configure do |config|
-        config.exception_level_filters = { 'NameError' => 'ignore' }
-      end
-
-      logger_mock.should_not_receive(:info)
-      logger_mock.should_not_receive(:warn)
-      logger_mock.should_not_receive(:error)
-
-      Rollbar.error(exception)
-    end
-
     context 'using :use_exception_level_filters option as true' do
       it 'sends the correct filtered level' do
         Rollbar.configure do |config|
@@ -751,6 +739,18 @@ describe Rollbar do
 
         Rollbar.error(exception, :use_exception_level_filters => true)
         expect(Rollbar.last_report[:level]).to be_eql('warning')
+      end
+
+      it 'ignore ignored exception classes' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'ignore' }
+        end
+
+        logger_mock.should_not_receive(:info)
+        logger_mock.should_not_receive(:warn)
+        logger_mock.should_not_receive(:error)
+
+        Rollbar.error(exception, :use_exception_level_filters => true)
       end
     end
 
@@ -761,6 +761,16 @@ describe Rollbar do
         end
 
         Rollbar.error(exception)
+        expect(Rollbar.last_report[:level]).to be_eql('error')
+      end
+
+      it 'ignore ignored exception classes' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'ignore' }
+        end
+
+        Rollbar.error(exception)
+
         expect(Rollbar.last_report[:level]).to be_eql('error')
       end
     end
@@ -826,6 +836,7 @@ describe Rollbar do
     it 'should allow callables to set exception filtered level' do
       callable_mock = double
       saved_filters = Rollbar.configuration.exception_level_filters
+
       Rollbar.configure do |config|
         config.exception_level_filters = { 'NameError' => callable_mock }
       end
@@ -835,7 +846,7 @@ describe Rollbar do
       logger_mock.should_not_receive(:warn)
       logger_mock.should_not_receive(:error)
 
-      Rollbar.error(exception)
+      Rollbar.error(exception, :use_exception_level_filters => true)
     end
 
     it 'should not report exceptions when silenced' do

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -743,13 +743,26 @@ describe Rollbar do
       Rollbar.error(exception)
     end
 
-    it 'sends the correct filtered level' do
-      Rollbar.configure do |config|
-        config.exception_level_filters = { 'NameError' => 'warning' }
-      end
+    context 'using :use_exception_level_filters option as true' do
+      it 'sends the correct filtered level' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'warning' }
+        end
 
-      Rollbar.error(exception)
-      expect(Rollbar.last_report[:level]).to be_eql('warning')
+        Rollbar.error(exception, :use_exception_level_filters => true)
+        expect(Rollbar.last_report[:level]).to be_eql('warning')
+      end
+    end
+
+    context 'if not using :use_exception_level_filters option' do
+      it 'sends the level defined by the used method' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'warning' }
+        end
+
+        Rollbar.error(exception)
+        expect(Rollbar.last_report[:level]).to be_eql('error')
+      end
     end
 
     it "should work with an IO object as rack.errors" do


### PR DESCRIPTION
Now by default we will not override the level using exception_level_filters if :use_exception_level_filters is not true.