### PR TITLE
Allow to send a custom message on the extra hash

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -293,6 +293,7 @@ module Rollbar
         }
       }
 
+      data[:custom] = extra.delete(:custom) if extra && extra[:custom]
       data[:body] = build_payload_body(message, exception, extra)
       data[:project_package_paths] = configuration.project_gem_paths if configuration.project_gem_paths
       data[:code_version] = configuration.code_version if configuration.code_version


### PR DESCRIPTION
I didn't find any way to send a custom message in the implementation, so I added this line to send it on the extra hash.
You will have to use it like this

~~~ ruby
Rollbar.info "title", custom: {some: 'value'}
~~~

I didn't created any test because i not sure if it is the correct approach. What do you think?