### PR TITLE
Fix internal Rollbar error caused when ActiveRecord was present, but not used

### DIFF
--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -60,7 +60,7 @@ module Rollbar
 
         def person_data_proc(env)
           block = proc { extract_person_data_from_controller(env) }
-          return block unless defined?(ActiveRecord::Base)
+          return block unless(defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?)
 
           proc { ActiveRecord::Base.connection_pool.with_connection(&block) }
         end


### PR DESCRIPTION
If the ActiveRecord gem was required in a Rails app, but not actually used or configured (in favor of some other ORM or no ORM), then Rollbar would internally error whenever it tried to send an exception message. This was being caused by the person tracking functionality seeing that ActiveRecord existed, but then it would raise a ActiveRecord::ConnectionNotEstablished error when it actually tried to use the connection. This in turn led to a rather non-obvious error in the logs:

```
[Rollbar] Reporting internal error encountered while sending data to Rollbar.
[Rollbar] Sending payload
[Rollbar] Got unexpected status code from Rollbar api: 422
[Rollbar] Response: {
  "err": 1,
  "message": "Invalid format. data.context object value found, but a string is required."
}
```

This should fix this person-tracking situation by first checking whether ActiveRecord is actually connected before trying to do ActiveRecord-specific functions.