### PR TITLE
Parse configuration.payload_options when reporting internal errors.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -228,14 +228,7 @@ module Rollbar
       if data[:person]
         person_id = data[:person][configuration.person_id_method.to_sym]
         return 'ignored' if configuration.ignored_person_ids.include?(person_id)
-
-        is_proc = data[:person].respond_to?(:call)
-        data[:person] = data[:person].call if is_proc
       end
-
-      data[:request] = data[:request].call if data[:request].respond_to?(:call)
-      data[:context] = data[:context].call if data[:context].respond_to?(:call)
-      data.delete(:context) unless data[:context]
 
       schedule_payload(payload)
 
@@ -299,6 +292,14 @@ module Rollbar
       data[:uuid] = SecureRandom.uuid if defined?(SecureRandom) && SecureRandom.respond_to?(:uuid)
 
       Rollbar::Util.deep_merge(data, configuration.payload_options)
+
+      data[:person] = data[:person].call if data[:person].respond_to?(:call)
+      data[:request] = data[:request].call if data[:request].respond_to?(:call)
+      data[:context] = data[:context].call if data[:context].respond_to?(:call)
+
+      # Our API doesn't allow null context values, so just delete
+      # the key if value is nil.
+      data.delete(:context) unless data[:context]
 
       payload = {
         'access_token' => configuration.access_token,

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1490,6 +1490,23 @@ describe Rollbar do
     end
   end
 
+  context 'when reporting internal error with nil context' do
+    let(:context_proc) { proc {} }
+    let(:scoped_notifier) { notifier.scope(:context => context_proc) }
+    let(:exception) { Exception.new }
+    let(:logger_mock) { double("Rails.logger").as_null_object }
+
+    it 'reports successfully' do
+      Rollbar.configure do |config|
+        config.logger = logger_mock
+      end
+
+      logger_mock.should_receive(:info).with('[Rollbar] Sending payload').once
+      logger_mock.should_receive(:info).with('[Rollbar] Success').once
+      scoped_notifier.send(:report_internal_error, exception)
+    end
+  end
+
   context "request_data_extractor" do
     before(:each) do
       class DummyClass

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 require 'logger'
 require 'socket'
@@ -1497,6 +1497,8 @@ describe Rollbar do
     let(:logger_mock) { double("Rails.logger").as_null_object }
 
     it 'reports successfully' do
+      configure
+
       Rollbar.configure do |config|
         config.logger = logger_mock
       end


### PR DESCRIPTION
This avoids sending null values for 'context' key in data. Our API only
supports string values for context.