### PR TITLE
Move `ActiveRecord` patching into `require_hooks`

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -14,7 +14,6 @@ require 'rollbar/version'
 require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
 require 'rollbar/exception_reporter'
-require 'rollbar/active_record_extension' if defined?(ActiveRecord)
 require 'rollbar/util'
 require 'rollbar/railtie' if defined?(Rails)
 require 'rollbar/delay/girl_friday'
@@ -718,6 +717,7 @@ module Rollbar
       return if configuration.disable_monkey_patch
       wrap_delayed_worker
 
+      require 'rollbar/active_record_extension' if defined?(ActiveRecord)
       require 'rollbar/sidekiq' if defined?(Sidekiq)
       require 'rollbar/goalie' if defined?(Goalie)
       require 'rollbar/rack' if defined?(Rack)


### PR DESCRIPTION
This allows it to respect the `disable_monkey_patch` configuration option like the extensions for Rack, Rake, Sidekiq, etc. already do.

We have a project that still uses an ActiveRecord 2* version and this patch doesn't apply itself correctly to versions from that era. More generally, we're also just trying to reduce the amount of monkey patching that we're doing overall.

Are there any known issues with activating the `ActiveRecord` patch at the same time as the others? Thanks!