### PR TITLE
Check Rails::VERSION instead of just Rails. Fix #220.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -15,7 +15,7 @@ require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
 require 'rollbar/exception_reporter'
 require 'rollbar/util'
-require 'rollbar/railtie' if defined?(Rails)
+require 'rollbar/railtie' if defined?(Rails::VERSION)
 require 'rollbar/delay/girl_friday'
 require 'rollbar/delay/thread'
 require 'rollbar/truncation'


### PR DESCRIPTION
Some gems define `Rails` module and when used in a non Rails
application, Rollbar crashes.