### PR TITLE
Add bin/rollbar-rails-runner executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,16 @@ end
 
 How this works: first, Rollbar config (which is now at `config/rollbar.rb` is required). Later, `Rails.application/initialize` statement is wrapped with a `begin/rescue` and any exceptions within will be reported to Rollbar.
 
+## Rails runner command
+
+We cannot monkey patch the code executed by `rails runner` so errors are reported to Rollbar, but we provide a command `rollbar-rails-runner` that you can use for the same purpose. Example:
+
+```shell
+$ bundle exec rollbar-rails-runner 'puts User.count'
+45
+```
+If any error occurs during that command, the exception will be reported.
+
 ## Deploy Tracking with Capistrano
 
 ### Capistrano 3

--- a/README.md
+++ b/README.md
@@ -559,13 +559,14 @@ How this works: first, Rollbar config (which is now at `config/rollbar.rb` is re
 
 ## Rails runner command
 
-We cannot monkey patch the code executed by `rails runner` so errors are reported to Rollbar, but we provide a command `rollbar-rails-runner` that you can use for the same purpose. Example:
+We aren't able to instrument `rails runner` directly, but we do provide a wrapper, `rollbar-rails-runner`, which you can use to capture errors when running commands in a `rails runner`-like way. For example:
 
 ```shell
 $ bundle exec rollbar-rails-runner 'puts User.count'
 45
 ```
-If any error occurs during that command, the exception will be reported.
+
+If an error occurs during that command, the exception will be reported to Rollbar.
 
 ## Deploy Tracking with Capistrano
 

--- a/bin/rollbar-rails-runner
+++ b/bin/rollbar-rails-runner
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'rollbar/rails_runner'
+
+Rollbar::RailsRunner.new.run

--- a/lib/rollbar/rails_runner.rb
+++ b/lib/rollbar/rails_runner.rb
@@ -18,6 +18,12 @@ module Rollbar
       end
     end
 
+    attr_reader :command
+
+    def initialize
+      @command = ARGV[0]
+    end
+
     def run
       prepare_environment
 
@@ -34,13 +40,13 @@ module Rollbar
 
       Module.module_eval(<<-EOL,__FILE__,__LINE__ + 2)
           #{string_to_eval}
-        EOL
+      EOL
     end
 
     def rollbar_managed
       yield
     rescue => e
-      Rollbar.error(e)
+      Rollbar.scope(:context => command).error(e)
       raise
     end
 

--- a/lib/rollbar/rails_runner.rb
+++ b/lib/rollbar/rails_runner.rb
@@ -5,6 +5,19 @@ APP_PATH = File.expand_path('config/application', Dir.pwd)
 
 module Rollbar
   class RailsRunner
+    class GemResolver
+      def railties_gem
+        Gem::Specification.find_by_name('railties')
+      end
+    end
+
+    class LegacyGemResolver
+      def railties_gem
+        searcher = Gem::GemPathSearcher.new
+        searcher.find('rails')
+      end
+    end
+
     def run
       prepare_environment
 
@@ -36,7 +49,9 @@ module Rollbar
     end
 
     def railties_gem
-      gem = Gem::Specification.find_by_name('railties')
+      resolver_class = Gem::Specification.respond_to?(:find_by_name) ? GemResolver : LegacyGemResolver
+      gem = resolver_class.new.railties_gem
+
       abort 'railties gem not found' unless gem
 
       gem

--- a/lib/rollbar/rails_runner.rb
+++ b/lib/rollbar/rails_runner.rb
@@ -1,0 +1,51 @@
+require 'rails'
+require 'rollbar'
+
+APP_PATH = File.expand_path('config/application', Dir.pwd)
+
+module Rollbar
+  class RailsRunner
+    def run
+      prepare_environment
+
+      rollbar_managed { eval_runner }
+    end
+
+    def prepare_environment
+      require File.expand_path('../environment', APP_PATH)
+      ::Rails.application.require_environment!
+    end
+
+    def eval_runner
+      string_to_eval = File.read(runner_path)
+
+      Module.module_eval(<<-EOL,__FILE__,__LINE__ + 2)
+          #{string_to_eval}
+        EOL
+    end
+
+    def rollbar_managed
+      yield
+    rescue => e
+      Rollbar.error(e)
+      raise
+    end
+
+    def runner_path
+      railties_gem_dir + '/lib/rails/commands/runner.rb'
+    end
+
+    def railties_gem
+      gem = Gem::Specification.find_by_name('railties')
+      abort 'railties gem not found' unless gem
+
+      gem
+    end
+
+    def railties_gem_dir
+      railties_gem.gem_dir
+    end
+  end
+end
+
+

--- a/lib/rollbar/rails_runner.rb
+++ b/lib/rollbar/rails_runner.rb
@@ -46,7 +46,7 @@ module Rollbar
     def rollbar_managed
       yield
     rescue => e
-      Rollbar.scope(:context => command).error(e)
+      Rollbar.scope(:custom => { :command => command }).error(e)
       raise
     end
 

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Rollbar, Inc."]
   gem.email         = ["support@rollbar.com"]
   gem.description   = %q{Rails plugin to catch and send exceptions to Rollbar}
+  gem.executables   = ['rollbar-rails-runner']
   gem.summary       = %q{Reports exceptions to Rollbar}
   gem.homepage      = "https://github.com/rollbar/rollbar-gem"
   gem.license       = 'MIT'


### PR DESCRIPTION
This provides a ` rollbar-rails-runner` command that wraps `rails runner` with Rollbar gem so the errors are
reported to our API.