### PR TITLE
Rescue RequestDataExtractor#rollbar_ip so it doesn't crash.

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -99,6 +99,8 @@ module Rollbar
 
     def rollbar_user_ip(env)
       (env['action_dispatch.remote_ip'] || env['HTTP_X_REAL_IP'] || env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_ADDR']).to_s
+    rescue
+      nil
     end
 
     def rollbar_get_params(rack_req)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -339,6 +339,16 @@ describe HomeController do
     end
   end
 
+  context 'with ip parsing raising error' do
+    it 'raise a IpSpoofAttackError exception' do
+      controller.request.env['action_dispatch.remote_ip'] = GetIpRaising.new
+
+      expect do
+        expect(controller.send(:rollbar_request_data)[:user_ip]).to be_nil
+      end.not_to raise_exception(GetIpRaising::IpSpoofAttackError)
+    end
+  end
+
   after(:each) do
     Rollbar.configure do |config|
       config.logger = ::Rails.logger

--- a/spec/support/get_ip_raising.rb
+++ b/spec/support/get_ip_raising.rb
@@ -1,0 +1,7 @@
+class GetIpRaising
+  class IpSpoofAttackError < StandardError; end
+
+  def to_s
+    raise IpSpoofAttackError, 'spoofing IP!'
+  end
+end


### PR DESCRIPTION
For example when a IpSpoofAttackError exception is raised.

We were having the next unexpected behavior:

1. An attacker or some proxy configuration performs a suspicious request.
2. In https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L125 is raised a `IpSpoofAttackError` exception..
3. Our middleware initializes the reporting of the exception.
4. Our user_ip extraction crashes for the same reason that the app crashed, trying to get the client ip, with a `IpSpoofAttackError` exception.