### PR TITLE
Fix min body truncation strategy. Fixes #195

### DIFF
--- a/lib/rollbar/truncation/min_body_strategy.rb
+++ b/lib/rollbar/truncation/min_body_strategy.rb
@@ -17,7 +17,7 @@ module Rollbar
           body['trace_chain'] = body['trace_chain'].map do |trace_data|
             truncate_trace_data(trace_data)
           end
-        else
+        elsif body['trace']
           body['trace'] = truncate_trace_data(body['trace'])
         end
 

--- a/spec/fixtures/payloads/message.json
+++ b/spec/fixtures/payloads/message.json
@@ -1,0 +1,25 @@
+{
+  "body": {
+    "message": {
+      "body": "Test message"
+    }
+  },
+  "uuid": "7160cbee-de83-4e5d-bdc9-3fe195b711e4",
+  "language": "ruby",
+  "level": "info",
+  "timestamp": 1429703495,
+  "server": {
+    "pid": 2515,
+    "host": "testing-worker-linux-docker-0201352d-3376-linux-15",
+    "root": "/home/travis/build/rollbar/rollbar-gem/spec/dummyapp"
+  },
+  "environment": "unspecified",
+  "framework": "Rails: 3.2.21",
+  "notifier": {
+    "version": "1.5.1",
+    "name": "rollbar-gem"
+  },
+  "metadata": {
+    "customer_timestamp": 1429703494
+  }
+}

--- a/spec/rollbar/truncation/min_body_strategy_spec.rb
+++ b/spec/rollbar/truncation/min_body_strategy_spec.rb
@@ -43,5 +43,15 @@ describe Rollbar::Truncation::MinBodyStrategy do
         expect(traces[1]['exception']['message']).to be_eql('a' * 255)
       end
     end
+
+    context 'with a message payload' do
+      let(:payload_fixture) { 'payloads/sample.trace_chain.json' }
+
+      it "doesn't truncate anything and returns same payload" do
+        result = MultiJson.load(described_class.call(payload))
+
+        expect(result).to be_eql(payload)
+      end
+    end
   end
 end


### PR DESCRIPTION
We were trying to truncate payloads without backtrace info. For simple
messages for example.