### PR TITLE
Fix whitespace

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -2,21 +2,22 @@ require 'rollbar/rails'
 Rollbar.configure do |config|
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
-  <% if (defined? EY::Config) %>
+  
+<%- if (defined? EY::Config) -%>
   # Here we'll disable in 'test' and 'development':
   if Rails.env.test? or Rails.env.development?
     config.enabled = false
   else
     config.access_token = EY::Config.get('rollbar', 'ROLLBAR_ACCESS_TOKEN')
   end
-  <% else %>
+<%- else -%>
   config.access_token = <%= access_token_expr %>
 
   # Here we'll disable in 'test':
   if Rails.env.test?
     config.enabled = false
   end
-  <% end %>
+<%- end -%>
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,


### PR DESCRIPTION
Default generation command was producing [extraneous whitespace](http://baq.us/1__tmux_1B2F0E45.png).