### PR TITLE
Remove MultiJson and use just native or gem JSON.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+services:
+  - redis-server
 language: ruby
 # Broken bundler on travis CI - https://github.com/bundler/bundler/issues/2784
 before_install:

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -11,6 +11,7 @@ rescue LoadError
 end
 
 require 'rollbar/version'
+require 'rollbar/json'
 require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
 require 'rollbar/exception_reporter'
@@ -508,7 +509,7 @@ module Rollbar
 
     def send_payload(payload)
       log_info '[Rollbar] Sending payload'
-      payload = MultiJson.load(payload) if payload.is_a?(String)
+      payload = Rollbar::JSON.load(payload) if payload.is_a?(String)
 
       if configuration.use_eventmachine
         send_payload_using_eventmachine(payload)
@@ -648,7 +649,7 @@ module Rollbar
         rescue
           next unless handler == failover_handlers.last
 
-          log_error "[Rollbar] All failover handlers failed while processing payload: #{MultiJson.dump(payload)}"
+          log_error "[Rollbar] All failover handlers failed while processing payload: #{Rollbar::JSON.dump(payload)}"
         end
       end
     end
@@ -660,10 +661,10 @@ module Rollbar
       result = Truncation.truncate(stringified_payload)
       return result unless Truncation.truncate?(result)
 
-      original_size = MultiJson.dump(payload).bytesize
+      original_size = Rollbar::JSON.dump(payload).bytesize
       final_size = result.bytesize
       send_failsafe("Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Final size: #{final_size}", nil)
-      log_error "[Rollbar] Payload too large to be sent: #{MultiJson.dump(payload)}"
+      log_error "[Rollbar] Payload too large to be sent: #{Rollbar::JSON.dump(payload)}"
 
       nil
     end

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -711,10 +711,15 @@ module Rollbar
 
       yield(configuration)
 
+      configure_json_backend
       require_hooks
       require_core_extensions
 
       reset_notifier!
+    end
+
+    def configure_json_backend
+      Rollbar::JSON.setup(configuration)
     end
 
     def reconfigure

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -20,6 +20,7 @@ require 'rollbar/railtie' if defined?(Rails::VERSION)
 require 'rollbar/delay/girl_friday'
 require 'rollbar/delay/thread'
 require 'rollbar/truncation'
+require 'rollbar/core_ext/socket'
 
 unless ''.respond_to? :encode
   require 'iconv'

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -11,6 +11,7 @@ module Rollbar
     attr_accessor :delayed_job_enabled
     attr_accessor :default_logger
     attr_accessor :disable_monkey_patch
+    attr_accessor :disable_core_monkey_patch
     attr_accessor :dj_threshold
     attr_accessor :enabled
     attr_accessor :endpoint
@@ -38,6 +39,7 @@ module Rollbar
     attr_accessor :use_eventmachine
     attr_accessor :web_base
     attr_accessor :write_to_file
+    attr_accessor :use_multi_json
 
     attr_reader :project_gem_paths
 
@@ -53,6 +55,7 @@ module Rollbar
       @default_logger = lambda { Logger.new(STDERR) }
       @delayed_job_enabled = true
       @disable_monkey_patch = false
+      @disable_core_monkey_patch = false
       @dj_threshold = 0
       @enabled = nil  # set to true when configure is called
       @endpoint = DEFAULT_ENDPOINT
@@ -83,6 +86,7 @@ module Rollbar
       @use_eventmachine = false
       @web_base = DEFAULT_WEB_BASE
       @write_to_file = false
+      @use_multi_json = false
     end
 
     def initialize_copy(orig)

--- a/lib/rollbar/core_ext/socket.rb
+++ b/lib/rollbar/core_ext/socket.rb
@@ -1,0 +1,7 @@
+require 'socket'
+
+class Socket
+  def as_json
+    to_s
+  end
+end

--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -1,0 +1,45 @@
+module Rollbar
+  module JSON
+    extend self
+
+    attr_accessor :backend_name
+    attr_accessor :dump_method
+    attr_accessor :load_method
+
+    def load_native_json
+      require 'json' unless defined?(::JSON)
+
+      generate_method = ::JSON.method(:generate)
+
+      if ::JSON.respond_to?(:dump_default_options)
+        options = ::JSON.dump_default_options
+      else
+        # Default options from json 1.1.9 up to 1.6.1
+        options = { :allow_nan => true, :max_nesting => false }
+      end
+
+      self.dump_method = proc { |obj| generate_method.call(obj, options)  }
+      self.load_method    = ::JSON.method(:load)
+      self.backend_name   = :json
+
+      true
+    rescue StandardError, ScriptError => err
+      Rollbar.log_debug('%p while loading JSON library: %s' % [err, err.message])
+    end
+
+    def dump(object)
+      dump_method.call(object)
+    end
+
+    def load(string)
+      load_method.call(string)
+    end
+
+    def setup
+      load_native_json
+    end
+  end
+end
+
+Rollbar::JSON.setup
+

--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -9,8 +9,6 @@ module Rollbar
     def load_native_json
       require 'json' unless defined?(::JSON)
 
-      generate_method = ::JSON.method(:generate)
-
       if ::JSON.respond_to?(:dump_default_options)
         options = ::JSON.dump_default_options
       else
@@ -18,13 +16,25 @@ module Rollbar
         options = { :allow_nan => true, :max_nesting => false }
       end
 
-      self.dump_method = proc { |obj| generate_method.call(obj, options)  }
-      self.load_method    = ::JSON.method(:load)
+      self.dump_method = proc { |obj| ::JSON.generate(obj, options)  }
+      self.load_method    = proc { |obj| ::JSON.load(obj) }
       self.backend_name   = :json
 
       true
     rescue StandardError, ScriptError => err
       Rollbar.log_debug('%p while loading JSON library: %s' % [err, err.message])
+    end
+
+    def load_multi_json
+      require 'multi_json'
+
+      self.dump_method = proc { |obj| MultiJson.dump(obj) }
+      self.load_method = proc { |obj| MultiJson.load(obj) }
+      self.backend_name = :multi_json
+    rescue LoadError
+      Rollbar.log_error('[Rollbar] error occurred loading multi_json. Using native JSON instead')
+
+      load_native_json
     end
 
     def dump(object)
@@ -35,11 +45,13 @@ module Rollbar
       load_method.call(string)
     end
 
-    def setup
-      load_native_json
+    def setup(configuration)
+      if configuration.use_multi_json
+        load_multi_json
+      else
+        load_native_json
+      end
     end
   end
 end
-
-Rollbar::JSON.setup
 

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -121,7 +121,7 @@ module Rollbar
       return {} unless correct_method
       return {} unless rack_req.env['CONTENT_TYPE'] =~ %r{application/json}i
 
-      MultiJson.decode(rack_req.body.read)
+      Rollbar::JSON.load(rack_req.body.read)
     rescue
       {}
     ensure

--- a/lib/rollbar/truncation/mixin.rb
+++ b/lib/rollbar/truncation/mixin.rb
@@ -4,7 +4,7 @@ module Rollbar
   module Truncation
     module Mixin
       def dump(payload)
-        MultiJson.dump(payload)
+        Rollbar::JSON.dump(payload)
       end
 
       def truncate?(result)

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Rollbar::VERSION
 
+  gem.add_development_dependency 'multi_json'
   gem.add_development_dependency 'rails', '>= 3.0.0'
   gem.add_development_dependency 'rspec-rails', '>= 2.14.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.0.0'

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Rollbar::VERSION
 
-  gem.add_runtime_dependency 'multi_json', '~> 1.3'
-
   gem.add_development_dependency 'rails', '>= 3.0.0'
   gem.add_development_dependency 'rspec-rails', '>= 2.14.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.0.0'

--- a/spec/rollbar/delay/resque_spec.rb
+++ b/spec/rollbar/delay/resque_spec.rb
@@ -12,7 +12,7 @@ describe Rollbar::Delay::Resque do
     end
 
     it 'process the payload' do
-      loaded_hash = MultiJson.load(MultiJson.dump(payload))
+      loaded_hash = Rollbar::JSON.load(Rollbar::JSON.dump(payload))
 
       expect(Rollbar).to receive(:process_payload_safely).with(loaded_hash)
       described_class.call(payload)

--- a/spec/rollbar/json_spec.rb
+++ b/spec/rollbar/json_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'rollbar/json'
+require 'rollbar/configuration'
+
+describe Rollbar::JSON do
+  let(:configuration) do
+    Rollbar::Configuration.new
+  end
+
+  describe '.dump' do
+    context 'with multi_json' do
+      before do
+        configuration.use_multi_json = true
+        Rollbar::JSON.setup(configuration)
+      end
+
+      it 'has multi_json as backend' do
+        expect(Rollbar::JSON.backend_name).to be_eql(:multi_json)
+      end
+
+      it 'calls MultiJson.dump' do
+        expect(MultiJson).to receive(:dump).once
+
+        Rollbar::JSON.dump(:foo => :bar)
+      end
+    end
+
+    context 'with JSON' do
+      before do
+        configuration.use_multi_json = false
+        Rollbar::JSON.setup(configuration)
+      end
+
+      it 'has JSON as backend' do
+        expect(Rollbar::JSON.backend_name).to be_eql(:json)
+      end
+
+      it 'calls JSON.generate' do
+        expect(::JSON).to receive(:generate).once
+
+        Rollbar::JSON.dump(:foo => :bar)
+      end
+    end
+  end
+
+  describe '.load' do
+    context 'with multi_json' do
+      before do
+        configuration.use_multi_json = true
+        Rollbar::JSON.setup(configuration)
+      end
+
+      it 'calls MultiJson.load' do
+        expect(MultiJson).to receive(:load).once
+
+        Rollbar::JSON.load(:foo => :bar)
+      end
+    end
+
+    context 'with multi_json' do
+      before do
+        configuration.use_multi_json = false
+        Rollbar::JSON.setup(configuration)
+      end
+
+      it 'calls MultiJson.load' do
+        expect(::JSON).to receive(:load).once
+
+        Rollbar::JSON.load(:foo => :bar)
+      end
+    end
+  end
+
+  describe '.load_multi_json' do
+    context 'if fails loading multi_json' do
+      before do
+        allow(Rollbar::JSON).to receive(:require).with('multi_json').and_raise(LoadError)
+      end
+
+      it 'finally loads native JSON' do
+        expect(Rollbar::JSON).to receive(:load_native_json).once
+
+        Rollbar::JSON.load_multi_json
+      end
+    end
+  end
+end

--- a/spec/rollbar/truncation/frames_strategy_spec.rb
+++ b/spec/rollbar/truncation/frames_strategy_spec.rb
@@ -16,7 +16,7 @@ describe Rollbar::Truncation::FramesStrategy do
       end
 
       it 'returns a new payload with 300 frames' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         new_frames = result['data']['body']['trace']['frames']
 
@@ -38,7 +38,7 @@ describe Rollbar::Truncation::FramesStrategy do
       end
 
       it 'returns a new payload with 300 frames for each chain item' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         new_frames1 = result['data']['body']['trace_chain'][0]['frames']
         new_frames2 = result['data']['body']['trace_chain'][1]['frames']
@@ -61,7 +61,7 @@ describe Rollbar::Truncation::FramesStrategy do
       end
 
       it 'returns the original payload' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         expect(result).to be_eql(payload)
       end

--- a/spec/rollbar/truncation/min_body_strategy_spec.rb
+++ b/spec/rollbar/truncation/min_body_strategy_spec.rb
@@ -14,7 +14,7 @@ describe Rollbar::Truncation::MinBodyStrategy do
       end
 
       it 'truncates the exception message and frames array' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         trace = result['data']['body']['trace']
         expect(trace['frames']).to have(2).items
@@ -33,7 +33,7 @@ describe Rollbar::Truncation::MinBodyStrategy do
       end
 
       it 'truncates the exception message and frames array' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         traces = result['data']['body']['trace_chain']
         expect(traces[0]['frames']).to have(2).items
@@ -48,7 +48,7 @@ describe Rollbar::Truncation::MinBodyStrategy do
       let(:payload_fixture) { 'payloads/sample.trace_chain.json' }
 
       it "doesn't truncate anything and returns same payload" do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         expect(result).to be_eql(payload)
       end

--- a/spec/rollbar/truncation/strings_strategy_spec.rb
+++ b/spec/rollbar/truncation/strings_strategy_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 require 'spec_helper'
 require 'rollbar/truncation/frames_strategy'
@@ -19,7 +19,7 @@ describe Rollbar::Truncation::StringsStrategy do
     end
 
     it 'should truncate all nested strings in the payload' do
-      result = MultiJson.load(described_class.call(payload))
+      result = Rollbar::JSON.load(described_class.call(payload))
 
       expect(result['truncated'].size).to be_eql(1024)
       expect(result['hash']['inner_truncated'].size).to be_eql(1024)
@@ -36,7 +36,7 @@ describe Rollbar::Truncation::StringsStrategy do
       end
 
       it 'should truncate utf8 strings properly' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
         expect(result['truncated']).to match(/^Ŝǻмρļẻ śţяịņģa*\.{3}/)
       end
     end
@@ -50,7 +50,7 @@ describe Rollbar::Truncation::StringsStrategy do
       end
 
       it 'truncates to 512 size strings' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         expect(result['0'].size).to be_eql(512)
       end
@@ -65,7 +65,7 @@ describe Rollbar::Truncation::StringsStrategy do
       end
 
       it 'truncates to 256 size strings, the third threshold' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         expect(result['0'].size).to be_eql(256)
       end
@@ -80,7 +80,7 @@ describe Rollbar::Truncation::StringsStrategy do
       end
 
       it 'just return the value for third threshold' do
-        result = MultiJson.load(described_class.call(payload))
+        result = Rollbar::JSON.load(described_class.call(payload))
 
         expect(result['0'].size).to be_eql(256)
       end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1199,7 +1199,7 @@ describe Rollbar do
       let(:async_handler) do
         proc do |payload|
           # simulate previous gem version
-          string_payload = MultiJson.dump(payload)
+          string_payload = Rollbar::JSON.dump(payload)
 
           Rollbar.process_payload(string_payload)
         end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -477,7 +477,7 @@ describe Rollbar do
       end
 
       context "with Redis instance in payload and ActiveSupport is enabled" do
-        let(:redis) { ::Redis.connect }
+        let(:redis) { ::Redis.new }
         let(:payload) do
           {
             :key => {

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -5,6 +5,6 @@ module FixtureHelpers
   end
 
   def load_payload_fixture(relative_path)
-    MultiJson.load(File.read(fixture_file(relative_path)))
+    Rollbar::JSON.load(File.read(fixture_file(relative_path)))
   end
 end


### PR DESCRIPTION
We are having some problems serializing the payload under some scenarios. One scenario very common is when customers are using https://github.com/roidrage/redis-session-store.

We are adding to the payload `env['rack.session.options']` from Rack env. When using Redis as session store that value will have a `Redis::Client` instance.

Beside this, when ActiveSupport `Object` JSON extensions are loaded, serializing the payload cause an infinite loop in most of cases. This can vary depending on the serializing library the customer has installed in his project.

I cannot achieve the exact reasons of this, but I think it's a problem serializing `TCPSocket`. I've changed https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/json.rb adding this:

```ruby
class Socket
  def as_json
    to_s
  end
end
```

And it worked correctly, providing a huge session options `Hash`. this is not exacty what we want. And at the same time, the serializing was quite slow.

The problem is exploited since `MultiJson` will call other libraries, and those libraries will call `object.to_json` most of the cases.

In Oj they have taken account of that in some of their functions, https://github.com/ohler55/oj/blob/master/ext/oj/oj.c#L1819.

But MultiJson has `to_json: true` by default in Oj adapter, https://github.com/intridea/multi_json/blob/master/lib/multi_json/adapters/oj.rb#L9.

I've decided to just load JSON library and use it, seems to be the best solution in many other libraries I've reviewed. JSON will be wrapped by `Rollbar::JSON`, that loads it and calls `JSON.generate` and `JSON.load`.