### PR TITLE
Filter uploaded files as part of array param

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -166,19 +166,25 @@ module Rollbar
           result[key] = rollbar_filtered_params(sensitive_params, value)
         elsif value.is_a?(Array)
           result[key] = value.map do |v|
-            v.is_a?(Hash) ? rollbar_filtered_params(sensitive_params, v) : v
+            v.is_a?(Hash) ? rollbar_filtered_params(sensitive_params, v) : rollbar_filtered_param_value(v)
           end
-        elsif ATTACHMENT_CLASSES.include?(value.class.name)
-          result[key] = {
-            :content_type => value.content_type,
-            :original_filename => value.original_filename,
-            :size => value.tempfile.size
-          } rescue 'Uploaded file'
         else
-          result[key] = value
+          result[key] = rollbar_filtered_param_value(value)
         end
 
         result
+      end
+    end
+
+    def rollbar_filtered_param_value(value)
+      if ATTACHMENT_CLASSES.include?(value.class.name)
+        {
+          :content_type => value.content_type,
+          :original_filename => value.original_filename,
+          :size => value.tempfile.size
+        } rescue 'Uploaded file'
+      else
+        value
       end
     end
 


### PR DESCRIPTION
When request parameter is an array of `ActionDispatch::Http::UploadedFile` then uploaded files are not filtered in `rollbar_filtered_params` which in turn can cause `Failsafe from rollbar-gem: error in process_payload` when uploading binary files.

Example request parameters for `<input type="file" multiple name="files[]" />` used with jquery-fileupload:

```
Parameters: {"utf8"=>"✓", "authenticity_token"=>"[FILTERED]", "files"=>[#<ActionDispatch::Http::UploadedFile:0x007fec8f110fe8 @tempfile=#<Tempfile:/var/folders/bp/mg0pdsts6x17l3ft6h2dbj000000gn/T/RackMultipart20150715-8767-kojuih.png>, @original_filename="file.png", @content_type="image/png", @headers="Content-Disposition: form-data; name=\"files[]\"; filename=\"file.png\"\r\nContent-Type: image/png\r\n">]}
```