### PR TITLE
Add a default integration with ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,18 @@ Rollbar.configure do |config|
 end
 ```
 
+## ActiveJob integration
+
+Include the module `Rollbar::ActiveJob` in you jobs to report any uncaught errors in a job to Rollbar.
+
+```ruby
+class YourAwesomeJob < ActiveJob::Base
+  include Rollbar::ActiveJob
+end
+```
+
+If you need to customize the reporting write your own `rescue_from` handler instead of using the `Rollbar::ActiveJob` module.
+
 ## Delayed::Job integration
 
 If `delayed_job` is defined, Rollbar will automatically install a plugin that reports any uncaught exceptions that occur in jobs.

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -723,6 +723,7 @@ module Rollbar
 
       require 'rollbar/active_record_extension' if defined?(ActiveRecord)
       require 'rollbar/sidekiq' if defined?(Sidekiq)
+      require 'rollbar/active_job' if defined?(ActiveJob)
       require 'rollbar/goalie' if defined?(Goalie)
       require 'rollbar/rack' if defined?(Rack)
       require 'rollbar/rake' if defined?(Rake)

--- a/lib/rollbar/active_job.rb
+++ b/lib/rollbar/active_job.rb
@@ -3,7 +3,7 @@ module Rollbar
   module ActiveJob
     def self.included(base)
       base.send :rescue_from, Exception do |exception|
-        Rollbar.error(exception, job: self.class.name, job_id: job_id)
+        Rollbar.error(exception, :job => self.class.name, :job_id => job_id)
       end
     end
   end

--- a/lib/rollbar/active_job.rb
+++ b/lib/rollbar/active_job.rb
@@ -1,0 +1,10 @@
+module Rollbar
+  # Report any uncaught errors in a job to Rollbar
+  module ActiveJob
+    def self.included(base)
+      base.send :rescue_from, Exception do |exception|
+        Rollbar.error(exception, job: self.class.name, job_id: job_id)
+      end
+    end
+  end
+end

--- a/spec/rollbar/active_job_spec.rb
+++ b/spec/rollbar/active_job_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'active_support/rescuable'
+require 'rollbar/active_job'
+
+describe Rollbar::ActiveJob do
+  class TestJob
+    # To mix in rescue_from
+    include ActiveSupport::Rescuable
+    include Rollbar::ActiveJob
+
+    attr_reader :job_id
+
+    def perform(exception, job_id)
+      @job_id = job_id
+      # ActiveJob calls rescue_with_handler when a job raises an exception
+      rescue_with_handler(exception) || raise(exception)
+    end
+  end
+
+  let(:exception) { StandardError.new('oh no') }
+  let(:job_id) { "123" }
+
+  it "reports the error to Rollbar" do
+    expected_params = { :job => "TestJob", :job_id => job_id }
+    expect(Rollbar).to receive(:error).with(exception, expected_params)
+    expect { TestJob.new.perform(exception, job_id) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
ActiveJob is now the default Rails queue API. This PR adds a default integration into ActiveJob so that including a module into a job will report uncaught errors to Rollbar.

The integration is documented in the README.

A test for the integration is added.