### PR TITLE
Reraise the error so ActiveJob backend can retry

### DIFF
--- a/lib/rollbar/active_job.rb
+++ b/lib/rollbar/active_job.rb
@@ -1,9 +1,10 @@
 module Rollbar
-  # Report any uncaught errors in a job to Rollbar
+  # Report any uncaught errors in a job to Rollbar and reraise
   module ActiveJob
     def self.included(base)
       base.send :rescue_from, Exception do |exception|
         Rollbar.error(exception, :job => self.class.name, :job_id => job_id)
+        raise exception
       end
     end
   end

--- a/spec/rollbar/active_job_spec.rb
+++ b/spec/rollbar/active_job_spec.rb
@@ -24,6 +24,10 @@ describe Rollbar::ActiveJob do
   it "reports the error to Rollbar" do
     expected_params = { :job => "TestJob", :job_id => job_id }
     expect(Rollbar).to receive(:error).with(exception, expected_params)
-    expect { TestJob.new.perform(exception, job_id) }.not_to raise_error
+    TestJob.new.perform(exception, job_id) rescue nil
+  end
+
+  it "reraises the error so the job backend can handle the failure and retry" do
+    expect { TestJob.new.perform(exception, job_id) }.to raise_error exception
   end
 end


### PR DESCRIPTION
When using ActiveJob, some backends have a default behavior when rescueing an error like requeueing the job and retrying. Reporting the error to Rollbar should not change this behavior.