### PR TITLE
allows access_token override in extras

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -301,6 +301,9 @@ module Rollbar
         }
       }
 
+      access_token = configuration.access_token
+      access_token = extra.delete(:access_token) if extra && extra[:access_token].present?
+
       data[:body] = build_payload_body(message, exception, extra)
       data[:project_package_paths] = configuration.project_gem_paths if configuration.project_gem_paths
       data[:code_version] = configuration.code_version if configuration.code_version
@@ -317,7 +320,7 @@ module Rollbar
       data.delete(:context) unless data[:context]
 
       payload = {
-        'access_token' => configuration.access_token,
+        'access_token' => access_token,
         'data' => data
       }
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -302,6 +302,10 @@ describe Rollbar do
           payload.keys.should match_array(['access_token', 'data'])
         end
 
+        it 'should have the correct access_token' do
+          payload['access_token'].should == Rollbar.configuration.access_token
+        end
+
         it 'should have the correct data keys' do
           payload['data'].keys.should include(:timestamp, :environment, :level, :language, :framework, :server,
             :notifier, :body)
@@ -325,6 +329,14 @@ describe Rollbar do
         it 'should have the correct level and message body' do
           payload['data'][:level].should == 'info'
           payload['data'][:body][:message][:body].should == 'message'
+        end
+
+        context 'with access_token passed in' do
+          let(:extra_data) { {:key => 'value', :hash => {:inner_key => 'inner_value'}, :access_token => 'my-other-access-token'} }
+
+          it 'should use the access_token passed in' do
+            payload['access_token'].should == 'my-other-access-token'
+          end
         end
       end
 


### PR DESCRIPTION
This allows an access_token to be provided when logging. This is useful to put rollbars into the correct project.