### PR TITLE
use `instance_eval` instead of `module_eval`

### DIFF
--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -38,7 +38,7 @@ module Rails
     def eval_runner
       string_to_eval = File.read(runner_path)
 
-      ::Rails.module_eval(<<-EOL,__FILE__,__LINE__ + 2)
+      ::Rails.instance_eval(<<-EOL,__FILE__,__LINE__ + 2)
           #{string_to_eval}
       EOL
     end

--- a/spec/bin/rollbar_runner_spec.rb
+++ b/spec/bin/rollbar_runner_spec.rb
@@ -13,23 +13,9 @@ describe Rails::RollbarRunner do
   context 'with file contains define method in top level' do
     # refs: https://github.com/rollbar/rollbar-gem/issues/273
 
-    before do
-      with_dummyapp_dir do
-        File.open('./lib/test_ruunner.rb', 'w') do |file|
-          file.write <<-EOS
-def hello
-  puts 'world'
-end
-
-hello
-EOS
-        end
-      end
-    end
-
     it 'do not raise exceptions' do
       with_dummyapp_dir do
-        expect( `rollbar-rails-runner ./lib/test_ruunner.rb` ).to eq "world\n"
+        expect( `bundle exec rollbar-rails-runner ./lib/test_ruunner_with_define_method_in_top_level.rb` ).to eq "world\n"
       end
     end
   end

--- a/spec/bin/rollbar_runner_spec.rb
+++ b/spec/bin/rollbar_runner_spec.rb
@@ -14,8 +14,10 @@ describe Rails::RollbarRunner do
     # refs: https://github.com/rollbar/rollbar-gem/issues/273
 
     it 'do not raise exceptions' do
-      with_dummyapp_dir do
-        expect( `bundle exec rollbar-rails-runner ./lib/test_ruunner_with_define_method_in_top_level.rb` ).to eq "world\n"
+      Bundler.with_clean_env do
+        with_dummyapp_dir do
+          expect( `bundle exec rollbar-rails-runner ./lib/test_ruunner_with_define_method_in_top_level.rb` ).to eq "world\n"
+        end
       end
     end
   end

--- a/spec/bin/rollbar_runner_spec.rb
+++ b/spec/bin/rollbar_runner_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'rails/rollbar_runner'
+
+DUMMYAPP_DIR = File.expand_path('../../dummyapp', __FILE__)
+
+def with_dummyapp_dir(&block)
+  FileUtils.cd(DUMMYAPP_DIR) do
+    yield
+  end
+end
+
+describe Rails::RollbarRunner do
+  context 'with file contains define method in top level' do
+    # refs: https://github.com/rollbar/rollbar-gem/issues/273
+
+    before do
+      with_dummyapp_dir do
+        File.open('./lib/test_ruunner.rb', 'w') do |file|
+          file.write <<-EOS
+def hello
+  puts 'world'
+end
+
+hello
+EOS
+        end
+      end
+    end
+
+    it 'do not raise exceptions' do
+      with_dummyapp_dir do
+        expect( `rollbar-rails-runner ./lib/test_ruunner.rb` ).to eq "world\n"
+      end
+    end
+  end
+end

--- a/spec/dummyapp/lib/test_ruunner_with_define_method_in_top_level.rb
+++ b/spec/dummyapp/lib/test_ruunner_with_define_method_in_top_level.rb
@@ -1,0 +1,5 @@
+def hello
+  puts 'world'
+end
+
+hello


### PR DESCRIPTION
related with #273 

`rails runner` execute the file with `Rails` module in rails 3.*, 4.0 and the difference with `module_eval` and `instance_eval` is context of evaling code.
- module_eval
  - it will execute with `eigenclass` of `self` context. inside of eval code `def` will define class method.
- instance_eval
  - it will execute with `class` of `self` context. inside of eval code `def` will define instance method.
