### PR TITLE
Send class name on internal failsafe messages.

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -544,23 +544,28 @@ module Rollbar
     end
 
     def send_failsafe(message, exception)
+      body = 'Failsafe from rollbar-gem: '
       log_error "[Rollbar] Sending failsafe response due to #{message}."
+
       if exception
         begin
+          body += "#{exception.class.name}: #{message}"
           log_error "[Rollbar] #{exception.class.name}: #{exception}"
-        rescue => e
+        rescue
+        end
+      else
+        begin
+          body += message.to_s
+        rescue
         end
       end
 
-      config = configuration
-      environment = config.environment
-
       failsafe_data = {
         :level => 'error',
-        :environment => environment.to_s,
+        :environment => configuration.environment.to_s,
         :body => {
           :message => {
-            :body => "Failsafe from rollbar-gem: #{message}"
+            :body => body
           }
         },
         :notifier => {
@@ -581,6 +586,8 @@ module Rollbar
       rescue => e
         log_error "[Rollbar] Error sending failsafe : #{e}"
       end
+
+      failsafe_payload
     end
 
     def schedule_payload(payload)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1562,16 +1562,26 @@ describe Rollbar do
   end
 
   context "send_failsafe" do
+    let(:exception) { StandardError.new }
+
     it "should not crash when given a message and exception" do
-      begin
-        1 / 0
-      rescue => e
-        notifier.send(:send_failsafe, "test failsafe", e)
-      end
+      sent_payload = notifier.send(:send_failsafe, "test failsafe", exception)
+
+      expected_message = 'Failsafe from rollbar-gem: StandardError: test failsafe'
+      expect(sent_payload['data'][:body][:message][:body]).to be_eql(expected_message)
     end
 
     it "should not crash when given all nils" do
       notifier.send(:send_failsafe, nil, nil)
+    end
+
+    context 'without exception object' do
+      it 'just sends the given message' do
+        sent_payload = notifier.send(:send_failsafe, "test failsafe", nil)
+
+        expected_message = 'Failsafe from rollbar-gem: test failsafe'
+        expect(sent_payload['data'][:body][:message][:body]).to be_eql(expected_message)
+      end
     end
   end
 


### PR DESCRIPTION
This will help us with the future errors and customer support.