### PR TITLE
Speed up encoding.

### DIFF
--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -19,7 +19,7 @@ if String.instance_methods.include?(:encode)
   require 'rollbar/encoding/encoder'
   Rollbar::Encoding.encoding_class = Rollbar::Encoding::Encoder
 else
-  Rollbar::Encoding.encoding_class = Rollbar::Encoding::LegacyEncoder
   require 'rollbar/encoding/legacy_encoder'
+  Rollbar::Encoding.encoding_class = Rollbar::Encoding::LegacyEncoder
 end
 

--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -7,7 +7,6 @@ module Rollbar
     def self.encode(object)
       can_be_encoded = object.is_a?(Symbol) || object.is_a?(String)
 
-      return if object.frozen?
       return object unless can_be_encoded
 
       encoding_class.new(object).encode

--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -5,7 +5,7 @@ module Rollbar
     end
 
     def self.encode(object)
-      can_be_encoded = object.is_a?(Symbol) || object.is_a?(String)
+      can_be_encoded = object.is_a?(String) || object.is_a?(Symbol)
 
       return object unless can_be_encoded
 

--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -1,21 +1,25 @@
 module Rollbar
   module Encoding
+    class << self
+      attr_accessor :encoding_class
+    end
+
     def self.encode(object)
       can_be_encoded = object.is_a?(Symbol) || object.is_a?(String)
 
+      return if object.frozen?
       return object unless can_be_encoded
 
       encoding_class.new(object).encode
     end
-
-    def self.encoding_class
-      if String.instance_methods.include?(:encode)
-        require 'rollbar/encoding/encoder'
-        Encoder
-      else
-        require 'rollbar/encoding/legacy_encoder'
-        LegacyEncoder
-      end
-    end
   end
 end
+
+if String.instance_methods.include?(:encode)
+  require 'rollbar/encoding/encoder'
+  Rollbar::Encoding.encoding_class = Rollbar::Encoding::Encoder
+else
+  Rollbar::Encoding.encoding_class = Rollbar::Encoding::LegacyEncoder
+  require 'rollbar/encoding/legacy_encoder'
+end
+

--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -4,6 +4,16 @@ module Rollbar
       attr_accessor :encoding_class
     end
 
+    def self.setup
+      if String.instance_methods.include?(:encode)
+        require 'rollbar/encoding/encoder'
+        self.encoding_class = Rollbar::Encoding::Encoder
+      else
+        require 'rollbar/encoding/legacy_encoder'
+        self.encoding_class = Rollbar::Encoding::LegacyEncoder
+      end
+    end
+
     def self.encode(object)
       can_be_encoded = object.is_a?(String) || object.is_a?(Symbol)
 
@@ -14,11 +24,4 @@ module Rollbar
   end
 end
 
-if String.instance_methods.include?(:encode)
-  require 'rollbar/encoding/encoder'
-  Rollbar::Encoding.encoding_class = Rollbar::Encoding::Encoder
-else
-  require 'rollbar/encoding/legacy_encoder'
-  Rollbar::Encoding.encoding_class = Rollbar::Encoding::LegacyEncoder
-end
-
+Rollbar::Encoding.setup

--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -4,6 +4,8 @@ module Rollbar
       ALL_ENCODINGS = [::Encoding::UTF_8, ::Encoding::ISO_8859_1, ::Encoding::ASCII_8BIT, ::Encoding::US_ASCII]
       ASCII_ENCODINGS = [::Encoding::US_ASCII, ::Encoding::ASCII_8BIT, ::Encoding::ISO_8859_1]
       ENCODING_OPTIONS = { :invalid => :replace, :undef => :replace, :replace => '' }
+      UTF8 = 'UTF-8'.freeze
+      BINARY = 'binary'.freeze
 
       attr_accessor :object
 
@@ -12,9 +14,15 @@ module Rollbar
       end
 
       def encode
-        value = object.to_s
+        value = object.to_s.dup
+        encoding = value.encoding
 
-        encoded_value = force_encoding(value).encode(*encoding_args(value))
+        # This will be most of cases so avoid force anything for them
+        if encoding == ::Encoding::UTF_8 && value.valid_encoding?
+          encoded_value = value
+        else
+          encoded_value = force_encoding(value).encode(*encoding_args(value))
+        end
 
         object.is_a?(Symbol) ? encoded_value.to_sym : encoded_value
       end
@@ -22,8 +30,6 @@ module Rollbar
       private
 
       def force_encoding(value)
-        return value if value.frozen?
-
         value.force_encoding(detect_encoding(value)) if value.encoding == ::Encoding::UTF_8
 
         value
@@ -43,8 +49,8 @@ module Rollbar
       end
 
       def encoding_args(value)
-        args = ['UTF-8']
-        args << 'binary' if ASCII_ENCODINGS.include?(value.encoding)
+        args = [UTF8]
+        args << BINARY if ASCII_ENCODINGS.include?(value.encoding)
         args << ENCODING_OPTIONS
 
         args

--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -42,6 +42,7 @@ module Rollbar
 
         ALL_ENCODINGS.detect do |encoding|
           begin
+            # Seems #codepoints is faster than #valid_encoding?
             value.force_encoding(encoding).encode(::Encoding::UTF_8).codepoints
             true
           rescue

--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -30,6 +30,8 @@ module Rollbar
       private
 
       def force_encoding(value)
+        return value if value.frozen?
+
         value.force_encoding(detect_encoding(value)) if value.encoding == ::Encoding::UTF_8
 
         value

--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -14,7 +14,7 @@ module Rollbar
       end
 
       def encode
-        value = object.to_s.dup
+        value = object.to_s
         encoding = value.encoding
 
         # This will be most of cases so avoid force anything for them

--- a/lib/rollbar/encoding/legacy_encoder.rb
+++ b/lib/rollbar/encoding/legacy_encoder.rb
@@ -1,18 +1,20 @@
 require 'iconv'
 
 module Rollbar
-  class LegacyEncoder
-    attr_accessor :object
+  module Encoding
+    class LegacyEncoder
+      attr_accessor :object
 
-    def initialize(object)
-      @object = object
-    end
+      def initialize(object)
+        @object = object
+      end
 
-    def encode
-      value = object.to_s
-      encoded_value = ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', value)
+      def encode
+        value = object.to_s
+        encoded_value = ::Iconv.conv('UTF-8//IGNORE', 'UTF-8', value)
 
-      object.is_a?(Symbol) ? encoded_value.to_sym : encoded_value
+        object.is_a?(Symbol) ? encoded_value.to_sym : encoded_value
+      end
     end
   end
 end


### PR DESCRIPTION
Seems our `Encoding` and `Encode` classes were quite slow, I think I've speed-up it a bit. These are my benchmark results:

Iterations: 10

__master branch__
````shell
                           user     system      total        real
ascii_chars            5.610000   0.010000   5.620000 (  5.633157)
iso_8859_1             5.630000   0.000000   5.630000 (  5.633440)
utf8                   5.350000   0.010000   5.360000 (  5.361992)
russian_iso_8859_1     5.930000   0.000000   5.930000 (  5.941858)
```
__speed-up-encoding branch__
```shell
                           user     system      total        real
ascii_chars            0.600000   0.000000   0.600000 (  0.594938)
iso_8859_1             0.600000   0.000000   0.600000 (  0.607980)
utf8                   0.400000   0.010000   0.410000 (  0.408550)
russian_iso_8859_1     0.650000   0.000000   0.650000 (  0.642910)
```