### PR TITLE
Only resolve encoding_class once

### DIFF
--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -1,3 +1,5 @@
+require 'rollbar/encoding/encoder'
+
 module Rollbar
   module Encoding
     def self.encode(object)
@@ -5,17 +7,7 @@ module Rollbar
 
       return object unless can_be_encoded
 
-      encoding_class.new(object).encode
-    end
-
-    def self.encoding_class
-      if String.instance_methods.include?(:encode)
-        require 'rollbar/encoding/encoder'
-        Encoder
-      else
-        require 'rollbar/encoding/legacy_encoder'
-        LegacyEncoder
-      end
+      Encoder.new(object).encode
     end
   end
 end


### PR DESCRIPTION
Repeated invocations of either require or instance_methods seems to
consume a lot of memory.

We’re ok to just support the encoder as a test.