### PR TITLE
Send session data instead of session store options.

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -25,7 +25,7 @@ module Rollbar
       post_params = rollbar_filtered_params(sensitive_params, rollbar_post_params(rack_req))
       raw_body_params = rollbar_filtered_params(sensitive_params, mergeable_raw_body_params(rack_req))
       cookies = rollbar_filtered_params(sensitive_params, rollbar_request_cookies(rack_req))
-      session = rollbar_filtered_params(sensitive_params, env['rack.session.options'])
+      session = rollbar_filtered_params(sensitive_params, rollbar_request_session(rack_req))
       route_params = rollbar_filtered_params(sensitive_params, rollbar_route_params(env))
 
       params = request_params.merge(get_params).merge(post_params).merge(raw_body_params)
@@ -148,6 +148,14 @@ module Rollbar
       rescue
         {}
       end
+    end
+
+    def rollbar_request_session(rack_req)
+      session = rack_req.session
+
+      session.to_hash
+    rescue
+      {}
     end
 
     def rollbar_request_cookies(rack_req)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -368,7 +368,7 @@ describe HomeController do
       end
     end
 
-    context 'with multiple uploads' do
+    context 'with multiple uploads', :type => :request do
       it "saves attachment data for all uploads" do
         expect { post '/file_upload', :upload => [file1, file2] }.to raise_exception
         sent_params = Rollbar.last_report[:request][:params]['upload']
@@ -376,6 +376,17 @@ describe HomeController do
         expect(sent_params).to be_kind_of(Array)
         expect(sent_params).to have(2).items
       end
+    end
+  end
+
+  context 'with session data', :type => :request do
+    before { get '/set_session_data' }
+    it 'reports the session data' do
+      expect { get '/use_session_data' }.to raise_exception
+
+      session_data = Rollbar.last_report[:request][:session]
+
+      expect(session_data['some_value']).to be_eql('this-is-a-cool-value')
     end
   end
 

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -32,6 +32,16 @@ class HomeController < ApplicationController
     this = will_crash
   end
 
+  def set_session_data
+    session[:some_value] = 'this-is-a-cool-value'
+
+    render :json => {}
+  end
+
+  def use_session_data
+    oh = this_is_crashing!
+  end
+
   def current_user
     @current_user ||= User.find_by_id(cookies[:session_id])
   end

--- a/spec/dummyapp/config/routes.rb
+++ b/spec/dummyapp/config/routes.rb
@@ -1,12 +1,16 @@
 Dummy::Application.routes.draw do
-  root :to => "home#index"
+  root :to => 'home#index'
   resources :users do
     member { post :start_session }
   end
 
-  get "/cause_exception" => "home#cause_exception"
-  put "/deprecated_report_exception" => "home#deprecated_report_exception"
-  match "/report_exception" => "home#report_exception", :via => [:get, :post, :put]
-  get "/current_user" => "home#current_user"
-  post "/file_upload" => "home#file_upload"
+  get '/cause_exception' => 'home#cause_exception'
+  put '/deprecated_report_exception' => 'home#deprecated_report_exception'
+  match '/report_exception' => 'home#report_exception',
+        :via => [:get, :post, :put]
+  get '/current_user' => 'home#current_user'
+  post '/file_upload' => 'home#file_upload'
+
+  get '/set_session_data' => 'home#set_session_data'
+  get '/use_session_data' => 'home#use_session_data'
 end


### PR DESCRIPTION
We are sending session options instead of session data. I really don't
know the reason cause anybody could be interested on this instead of
request session data.

Session options in a Rails application can be something like this:

```ruby
Your::Application.config.session_store :cookie_store, {
  :key =>           '_session_id',
  :path =>          '/',
  :domain =>        nil,
  :expire_after =>  nil,
  :secure =>        false,
  :httponly =>      true,
  :cookie_only =>   true
}
```

Which is, in general, static, doesn't depend on the current request and
well, customers can always just see their configuration file.

I'd say the original intention was send session data.

This fix the serializing JSON problem we are having in some cases where there are socket objects
to Redis or other store backends in those session options.