### PR TITLE
Remove whitespace from config template

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -2,7 +2,7 @@ require 'rollbar/rails'
 Rollbar.configure do |config|
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
-  
+
 <%- if (defined? EY::Config) -%>
   # Here we'll disable in 'test' and 'development':
   if Rails.env.test? or Rails.env.development?


### PR DESCRIPTION
Lots of apps using this template will have style guide analysers (like rubocop) that complain about this sort of minor thing.