### PR TITLE
JSON.generate returns NoMethodError key?, need to handle exception an…

### DIFF
--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -26,7 +26,18 @@ module Rollbar
     end
 
     def dump(object)
-      dump_method.call(object)
+      # JSON.generate defined above returnes a NoMethodError for key? for some activerecord definitions
+      begin
+        dump_method.call(object)
+      rescue => e
+        # If exception caught, try to_json 
+        result = object.try(:to_json)
+        if result.nil?
+          raise e
+        else
+          result
+        end
+      end
     end
 
     def load(string)


### PR DESCRIPTION
…d try to_json for activerecord

Closes #296 

JSON.generate only allows objects or arrays to be converted to JSON syntax. to_json, however, accepts many Ruby classes even though it acts only as a method for serialization. Need to capture exception from JSON.generate and try to_json in that instance to handle some activerecord objects