### PR TITLE
Send correct hash value for delayed job 'handler' object.

### DIFF
--- a/spec/rollbar/delayed_job/job_data.rb
+++ b/spec/rollbar/delayed_job/job_data.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+require 'rollbar/delayed_job'
+require 'delayed/backend/test'
+
+describe Rollbar::Delayed::JobData do
+  describe '#to_hash' do
+    let(:handler) { { 'foo' => 'bar' } }
+
+    let(:attrs) do
+      {
+        'id' => 1,
+        'priority' => 0,
+        'attempts' => 1,
+        'handler' => handler.to_yaml
+      }
+    end
+
+    let(:job) do
+      ::Delayed::Backend::Test::Job.new(attrs)
+    end
+
+    subject { described_class.new(job) }
+
+    it 'returns the correct job data' do
+      expected_result = attrs.dup
+      expected_result.delete('id')
+      expected_result['handler'] = handler
+
+      result = subject.to_hash
+
+      expect(result).to be_eql(expected_result)
+    end
+  end
+end

--- a/spec/rollbar/delayed_job_spec.rb
+++ b/spec/rollbar/delayed_job_spec.rb
@@ -18,18 +18,42 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
     Delayed::Backend::Test::Job.delete_all
   end
 
-  let(:logger) { Rollbar.logger }
   let(:expected_args) do
     [kind_of(NoMethodError), { :use_exception_level_filters => true }]
   end
 
   context 'with delayed method without arguments failing' do
     it 'sends the exception' do
-      expect_any_instance_of(::Delayed::Job).to receive(:as_json).and_call_original
       expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
       expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*expected_args)
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
+    end
+  end
+
+
+  describe '.build_job_data' do
+    let(:job) { double(:payload_object => {}) }
+
+    context 'if report_dj_data is disabled' do
+      before do
+        allow(Rollbar.configuration).to receive(:report_dj_data).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(described_class.build_job_data(job)).to be_nil
+      end
+    end
+
+    context 'with report_dj_data enabled' do
+      before do
+        allow(Rollbar.configuration).to receive(:report_dj_data).and_return(true)
+      end
+
+      it 'returns a hash' do
+        result = described_class.build_job_data(job)
+        expect(result).to be_kind_of(Hash)
+      end
     end
   end
 end


### PR DESCRIPTION
It'll be useful for users send a Hash object there instead sending a
YAML string.