### PR TITLE
Fix delayed_job tests for delayed_job >= 4.1

### DIFF
--- a/lib/rollbar/delayed_job.rb
+++ b/lib/rollbar/delayed_job.rb
@@ -33,6 +33,12 @@ module Rollbar
       self.wrapped = true
     end
 
+    def self.wrap_worker!
+      self.wrapped = false
+
+      wrap_worker
+    end
+
     def self.around_invoke_job(&block)
       ::Delayed::Worker.lifecycle.around(:invoke_job, &block)
     end

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -14,7 +14,13 @@ module Delayed
       end
 
       def self.worker
-        @worker ||= ::Delayed::Worker.new
+        prepare_worker unless @worker
+
+        @worker
+      end
+
+      def self.prepare_worker
+        @worker = ::Delayed::Worker.new
       end
 
       class Job

--- a/spec/rollbar/delayed_job_spec.rb
+++ b/spec/rollbar/delayed_job_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'delayed_job'
 require 'rollbar/delayed_job'
+require 'delayed/backend/test'
 
 describe Rollbar::Delayed, :reconfigure_notifier => true do
   class FailingJob
@@ -12,9 +13,10 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
   end
 
   before do
-    Rollbar::Delayed.wrap_worker
-    Delayed::Worker.backend = :test
+    Delayed::Backend::Test.prepare_worker
+    Rollbar::Delayed.wrap_worker!
 
+    Delayed::Worker.backend = :test
     Delayed::Backend::Test::Job.delete_all
   end
 


### PR DESCRIPTION
For every worker instance, in delayed_job >= 4.1, the lifecycle is
reset. Since we only used one worker instance but created after
lifecycle is prepared we lost the hooks for our reports.

Now this is fixed preparing the only instance of the worker we'll use
before run the test.