### PR TITLE
Don't require rollbar/rails on initializer

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -1,4 +1,3 @@
-require 'rollbar/rails'
 Rollbar.configure do |config|
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.

--- a/lib/rollbar/rails.rb
+++ b/lib/rollbar/rails.rb
@@ -1,22 +1,5 @@
-require 'rollbar'
-
 module Rollbar
   module Rails
-    def self.initialize
-      rails_logger = if defined?(::Rails.logger)
-                       ::Rails.logger
-                     elsif defined?(RAILS_DEFAULT_LOGGER)
-                       RAILS_DEFAULT_LOGGER
-                     end
 
-      Rollbar.preconfigure do |config|
-        config.logger = rails_logger
-        config.environment = defined?(::Rails.env) && ::Rails.env || defined?(RAILS_ENV) && RAILS_ENV
-        config.root = defined?(::Rails.root) && ::Rails.root || defined?(RAILS_ROOT) && RAILS_ROOT
-        config.framework = defined?(::Rails.version) && "Rails: #{::Rails.version}" || defined?(::Rails::VERSION::STRING) && "Rails: #{::Rails::VERSION::STRING}"
-      end
-    end
   end
 end
-
-Rollbar::Rails.initialize

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
 
+
 describe HomeController do
   let(:logger_mock) { double("Rails.logger").as_null_object }
   let(:notifier) { Rollbar.notifier }
 
   before do
     reset_configuration
-    Rollbar::Rails.initialize
+    preconfigure_rails_notifier
     Rollbar.configure do |config|
       config.access_token = 'aaaabbbbccccddddeeeeffff00001111'
       config.logger = logger_mock
@@ -31,7 +32,7 @@ describe HomeController do
 
     it 'should use the default "unspecified" environment if rails env ends up being empty' do
       old_env, ::Rails.env = ::Rails.env, ''
-      Rollbar::Rails.initialize
+      preconfigure_rails_notifier
 
       data = Rollbar.notifier.send(:build_payload, 'error', 'message', nil, nil)
       data['data'][:environment].should == 'unspecified'

--- a/spec/dummyapp/config/initializers/rollbar.rb
+++ b/spec/dummyapp/config/initializers/rollbar.rb
@@ -1,5 +1,3 @@
-require 'rollbar/rails'
-
 Rollbar.configure do |config|
   config.access_token = 'aaaabbbbccccddddeeeeffff00001111'
   config.request_timeout = 60

--- a/spec/support/notifier_helpers.rb
+++ b/spec/support/notifier_helpers.rb
@@ -10,6 +10,21 @@ module NotifierHelpers
     end
   end
 
+  def preconfigure_rails_notifier
+    rails_logger = if defined?(::Rails.logger)
+                     ::Rails.logger
+                   elsif defined?(RAILS_DEFAULT_LOGGER)
+                     RAILS_DEFAULT_LOGGER
+                   end
+
+    Rollbar.preconfigure do |config|
+      config.logger = rails_logger
+      config.environment = defined?(::Rails.env) && ::Rails.env || defined?(RAILS_ENV) && RAILS_ENV
+      config.root = defined?(::Rails.root) && ::Rails.root || defined?(RAILS_ROOT) && RAILS_ROOT
+      config.framework = defined?(::Rails.version) && "Rails: #{::Rails.version}" || defined?(::Rails::VERSION::STRING) && "Rails: #{::Rails::VERSION::STRING}"
+    end
+  end
+
   def test_access_token
     'bfec94a1ede64984b862880224edd0ed'
   end


### PR DESCRIPTION
Rollbar::Rails becomes an empty module. That functionality is given by
the Railtie.

However, seems that in the tests we were calling
`Rollbar::Rails.initialize`, so the method has been moved to a spec helper.