### PR TITLE
Verify peer when connecting to Rollbar over HTTPS

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -528,7 +528,7 @@ module Rollbar
 
       if uri.scheme == 'https'
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       end
 
       request = Net::HTTP::Post.new(uri.request_uri)


### PR DESCRIPTION
At the moment, when connecting over HTTPS to Rollbar (which is the default, rightly so) and `use_eventmachine` is set to `false` (the default), `Net::HTTP`'s `verify_mode` is set to `OpenSSL::SSL::VERIFY_NONE`. This effectively means that the Rollbar gem doesn't validate whether or not the Rollbar endpoint it's talking to has a valid SSL certificate. This makes the Rollbar gem susceptible to MITM attacks.

The implications of this are obviously significant; sensitive data is often (intentionally or otherwise) transmitted as part of exception data which could be intercepted by a malicious third-party and tampered with. If a developer has Rollbar notifications switched on in their development environment and they're building a sweet new application in a coffee shop with insecure wifi, it's perfectly possible for an attacker to steal their exception data and do something nasty.

This changes the `verify_mode` to be `OpenSSL::SSL::VERIFY_PEER`, which will verify that the Rollbar endpoint that data is being sent to has a valid SSL certificate before transmitting data across.