### PR TITLE
Fix when MultiJson is using adapters other than Oj

### DIFF
--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -43,7 +43,7 @@ module Rollbar
     def find_options_module
       module_name = multi_json_adapter_module_name
 
-      if constants.find{ |const| const.to_s == module_name }
+      if const_defined?("::Rollbar::JSON::#{module_name}")
         const_get(module_name)
       else
         Default

--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -43,9 +43,9 @@ module Rollbar
     def find_options_module
       module_name = multi_json_adapter_module_name
 
-      begin
+      if constants.find{ |const| const.to_s == module_name }
         const_get(module_name)
-      rescue NameError
+      else
         Default
       end
     end

--- a/spec/rollbar/json_spec.rb
+++ b/spec/rollbar/json_spec.rb
@@ -24,6 +24,11 @@ module MultiJson
   end
 end
 
+module MissingCustomOptions
+  # Consider the fact that there's MultiJson::Adapters::Yajl but not
+  # Rollbar::JSON::Yajl, it should not look for ::Yajl but only
+  # Rollbar::JSON::Yajl.
+end
 
 describe Rollbar::JSON do
   let(:payload) do


### PR DESCRIPTION
Whenever Yajl is used for MultiJson, before this patch,
Rollbar would find ::Yajl instead of Rollbar::JSON::Yajl,
and ::Yajl does exist but it does not respond to `options`,
causing failures.

It's surprising that Rollbar::JSON.const_get(:Yajl) would
find ::Yajl instead, it's like using Rollbar::JSON::Yajl to
refer to ::Yajl, this is really unfortunate for Ruby.
But given current status, we cannot rely on const_get in
this case. Therefore we'll need to search on constants
instead.

This has another advantage -- we no longer need to rescue,
saving an exception.