### PR TITLE
check threshold before a job is reported to Rollbar

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -35,6 +35,7 @@ module Rollbar
     attr_accessor :scrub_fields
     attr_accessor :uncaught_exception_level
     attr_accessor :scrub_headers
+    attr_accessor :sidekiq_threshold
     attr_accessor :use_async
     attr_accessor :use_eventmachine
     attr_accessor :web_base
@@ -80,6 +81,7 @@ module Rollbar
                        :confirm_password, :password_confirmation, :secret_token]
       @uncaught_exception_level = 'error'
       @scrub_headers = ['Authorization']
+      @sidekiq_threshold = 0
       @safely = false
       @use_async = false
       @use_eventmachine = false


### PR DESCRIPTION
This PR implements a simple `Sidekiq` threshold similar to the existing for `DelayedJob` (#318).

If you want to reduce the noise of your `Rollbar` inbox for `Sidekiq` jobs that fails only on the first attempt but not the next ones you can define in the Rollbar configuration this threshold so only notify from a number of retry of the current failing job.

By default is disabled the threshold is 0. And for jobs that are not going to be retried we notify always to Rollbar.

Any feedback is welcome, thanks in advance