### PR TITLE
#314 Treat HTTP requests containing a JSON accept header as a JSON request

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -30,7 +30,7 @@ module Rollbar
 
       params =
         if json_request_missing_content_type?(env)
-          raw_body_params
+          get_params.merge(raw_body_params)
         else
           request_params.merge(get_params).merge(post_params).merge(raw_body_params)
         end

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -144,9 +144,17 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
         }
       end
 
-      it 'appear in the sent payload' do
+      it 'appears in the sent payload when application/json is the content type' do
         expect do
           post '/crash_post', params.to_json, { 'CONTENT_TYPE' => 'application/json' }
+        end.to raise_error(exception)
+
+        expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+      end
+
+      it 'appears in the sent payload when the accepts header contains json' do
+        expect do
+          post '/crash_post', params.to_json, { 'ACCEPT' => 'application/vnd.github.v3+json' }
         end.to raise_error(exception)
 
         expect(Rollbar.last_report[:request][:params]).to be_eql(params)


### PR DESCRIPTION
For the purposes of deciding if and how to treat the body of a request, respect any JSON type specified in the Accept header.