### PR TITLE
Make scrubbing length configurable

### DIFF
--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -14,4 +14,7 @@ gem 'rubinius-developer_tools', :platform => :rbx
 gem 'rails', '3.0.20'
 gem 'hitimes', '< 1.2.2'
 
+gem 'celluloid', '< 0.17.0' if RUBY_VERSION == '1.9.2'
+
+
 gemspec :path => '../'

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -35,6 +35,7 @@ module Rollbar
     attr_accessor :scrub_fields
     attr_accessor :scrub_user
     attr_accessor :scrub_password
+    attr_accessor :randomize_scrub_length
     attr_accessor :uncaught_exception_level
     attr_accessor :scrub_headers
     attr_accessor :use_async
@@ -82,6 +83,7 @@ module Rollbar
                        :confirm_password, :password_confirmation, :secret_token]
       @scrub_user = true
       @scrub_password = true
+      @randomize_scrub_length = true
       @uncaught_exception_level = 'error'
       @scrub_headers = ['Authorization']
       @safely = false

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -32,7 +32,8 @@ module Rollbar
 
       url_scrubber = Rollbar::Scrubbers::URL.new(:scrub_fields => sensitive_params,
                                                  :scrub_user => Rollbar.configuration.scrub_user,
-                                                 :scrub_password => Rollbar.configuration.scrub_password)
+                                                 :scrub_password => Rollbar.configuration.scrub_password,
+                                                 :randomize_scrub_length => Rollbar.configuration.randomize_scrub_length)
       url = url_scrubber.call(rollbar_url(env))
 
       params = request_params.merge(get_params).merge(post_params).merge(raw_body_params)
@@ -53,6 +54,14 @@ module Rollbar
       end
 
       data
+    end
+
+    def rollbar_scrubbed(value)
+      if Rollbar.configuration.randomize_scrub_length
+        random_filtered_value
+      else
+        '*' * (value.length rescue 8)
+      end
     end
 
     private
@@ -219,8 +228,8 @@ module Rollbar
       Rollbar.configuration.scrub_headers || []
     end
 
-    def rollbar_scrubbed(value)
-      '*' * (value.length rescue 8)
+    def random_filtered_value
+      '*' * (rand(5) + 3)
     end
 
     def skip_value?(value)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -67,10 +67,9 @@ describe HomeController do
         }
 
         filtered = controller.send( :rollbar_headers, headers )
-        filtered.should == {
-          "Authorization" => "*********",
-          "User-Agent" => "spec"
-        }
+
+        expect(filtered['Authorization']).to match(/\**/)
+        expect(filtered['User-Agent']).to be_eql('spec')
       end
 
       it 'should filter custom headers' do
@@ -85,11 +84,9 @@ describe HomeController do
         }
 
         filtered = controller.send( :rollbar_headers, headers )
-        filtered.should == {
-          "Auth" => "**********",
-          "Token" => "***********",
-          "Content-Type" => "text/html"
-        }
+        expect(filtered['Auth']).to match(/\**/)
+        expect(filtered['Token']).to match(/\**/)
+        expect(filtered['Content-Type']).to be_eql('text/html')
       end
 
     end
@@ -188,11 +185,11 @@ describe HomeController do
 
       filtered = Rollbar.last_report[:request][:params]
 
-      filtered["passwd"].should == "******"
-      filtered["password"].should == "******"
-      filtered["secret"].should == "******"
-      filtered["notpass"].should == "visible"
-      filtered["secret_token"].should == "*" * 32
+      expect(filtered["passwd"]).to match(/\**/)
+      expect(filtered["password"]).to match(/\**/)
+      expect(filtered["secret"]).to match(/\**/)
+      expect(filtered["notpass"]).to match(/\**/)
+      expect(filtered["secret_token"]).to match(/\**/)
     end
 
     it "should scrub custom scrub_fields" do
@@ -214,9 +211,9 @@ describe HomeController do
       filtered["passwd"].should == "visible"
       # config.filter_parameters is set to [:password] in
       # spec/dummyapp/config/application.rb
-      filtered["password"].should == "*******"
-      filtered["secret"].should == "******"
-      filtered["notpass"].should == "******"
+      expect(filtered["password"]).to match(/\**/)
+      expect(filtered["secret"]).to match(/\**/)
+      expect(filtered["notpass"]).to match(/\**/)
     end
   end
 

--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -6,7 +6,8 @@ describe Rollbar::Scrubbers::URL do
   let(:options) do
     { :scrub_fields => [:password, :secret],
       :scrub_user => false,
-      :scrub_password => false
+      :scrub_password => false,
+      :randomize_scrub_length => true
     }
   end
 
@@ -77,6 +78,24 @@ describe Rollbar::Scrubbers::URL do
 
             expect(subject.call(url)).to match(expected_url)
           end
+        end
+      end
+
+      context 'with no-random scrub length' do
+        let(:options) do
+          { :scrub_fields => [:password, :secret],
+            :scrub_user => false,
+            :scrub_password => false,
+            :randomize_scrub_length => false
+          }
+        end
+        let(:password) { 'longpasswordishere' }
+        let(:url) { "http://foo.com/some-interesting-path?foo=bar&password=#{password}#fragment" }
+
+        it 'scrubs with same length than the scrubbed param' do
+          expected_url = /http:\/\/foo.com\/some-interesting-path\?foo=bar&password=\*{#{password.length}}#fragment/
+
+          expect(subject.call(url)).to match(expected_url)
         end
       end
     end


### PR DESCRIPTION
`Rollbar.configuration.randomize_scrub_length = false` will make us
using `'*' * value.length` as scrubbing value.

When `randomize_scrub_length` option is true, by default, we use a
random string between 3 and 8 chars.

Note: randomize code is duplicated in URL scrubber and the request extractor module. Once we refactor that module we can unify that logic.