### PR TITLE
Fix Rollbar::JSON for MultiJson <= 1.6.0

### DIFF
--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -59,7 +59,7 @@ module Rollbar
     #
     # In this method we just get the last module name.
     def multi_json_adapter_module_name
-      MultiJson.current_adapter.name[/^MultiJson::Adapters::(.*)$/, 1]
+      detect_multi_json_adapter.name[/^MultiJson::Adapters::(.*)$/, 1]
     end
   end
 end

--- a/spec/rollbar/json_spec.rb
+++ b/spec/rollbar/json_spec.rb
@@ -75,10 +75,6 @@ describe Rollbar::JSON do
     end
   end
 
-  describe '.detect_multi_json_adapter' do
-    
-  end
-
   describe '.adapter_options' do
     it 'calls .options in adapter module' do
       expect(described_class.options_module).to receive(:options)
@@ -88,25 +84,26 @@ describe Rollbar::JSON do
   end
 
   describe '.options_module' do
-    before { described_class.options_module = nil }
+    before do
+      described_class.options_module = nil
+      allow(MultiJson).to receive(:current_adapter).and_return(multi_json_module)
+    end
 
     context 'with a defined rollbar adapter' do
+      let(:multi_json_module) { MultiJson::Adapters::MockAdapter }
       let(:expected_adapter) { Rollbar::JSON::MockAdapter }
 
       it 'returns the correct options' do
-        MultiJson.with_adapter(MultiJson::Adapters::MockAdapter) do
-          expect(described_class.options_module).to be(expected_adapter)
-        end
+        expect(described_class.options_module).to be(expected_adapter)
       end
     end
 
     context 'without a defined rollbar adapter' do
+      let(:multi_json_module) { MultiJson::Adapters::MissingCustomOptions }
       let(:expected_adapter) { Rollbar::JSON::Default }
 
       it 'returns the correct options' do
-        MultiJson.with_adapter(MultiJson::Adapters::MissingCustomOptions) do
-          expect(described_class.options_module).to be(expected_adapter)
-        end
+        expect(described_class.options_module).to be(expected_adapter)
       end
     end
   end


### PR DESCRIPTION
Seems that for versions <= 1.6.0 for MultiJson, `MultiJson.current_adapter` argument is mandatory and not optional.