### PR TITLE
Allow access to controller variables from custom_data_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Rollbar.configuration.user_ip_obfuscator_secret = "a-private-secret-here"
 
 ## Including additional runtime data
 
-You can provide a callable that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that takes no arguments and returns a hash.
+You can provide a callable that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that takes no arguments and returns a hash. This lambda has access to controller variables and methods.
 
 Add the following in ```config/initializers/rollbar.rb```:
 
@@ -368,6 +368,19 @@ config.custom_data_method = lambda {
 This data will appear in the Occurrences tab and on the Occurrence Detail pages in the Rollbar interface.
 
 If your `custom_data_method` crashes while reporting an error, Rollbar will report that new error and will attach its uuid URL to the parent error report.
+
+## Configuring additional data at the controller level
+
+Sometimes it's useful to be able to define additional runtime data to include at the controller level, rather than through a global initializer.
+
+Add the following to your controller:
+
+```ruby
+include Rollbar::Rails
+on_exception_log_values :@response_body, :@an_instance_variable, :a_private_method
+```
+
+Variables and methods can be referenced in this list, and will be evaluated before being sent to Rollbar.
 
 ## Exception level filters
 

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -370,7 +370,7 @@ module Rollbar
     end
 
     def custom_data_method?
-      !!(configuration.custom_data_method || configuration.custom_values)
+      !!(Rollbar.configuration.custom_data_method || Rollbar.configuration.custom_values.count > 0)
     end
 
     def report_custom_data_error(e)

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -8,6 +8,7 @@ module Rollbar
     attr_accessor :branch
     attr_accessor :code_version
     attr_accessor :custom_data_method
+    attr_accessor :custom_values
     attr_accessor :delayed_job_enabled
     attr_accessor :default_logger
     attr_accessor :disable_monkey_patch
@@ -57,6 +58,7 @@ module Rollbar
       @async_handler = nil
       @code_version = nil
       @custom_data_method = nil
+      @custom_values = []
       @default_logger = lambda { Logger.new(STDERR) }
       @delayed_job_enabled = true
       @disable_monkey_patch = false

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -58,7 +58,7 @@ module Rollbar
       @async_handler = nil
       @code_version = nil
       @custom_data_method = nil
-      @custom_values = []
+      @custom_values = {}
       @default_logger = lambda { Logger.new(STDERR) }
       @delayed_job_enabled = true
       @disable_monkey_patch = false

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -42,7 +42,8 @@ module Rollbar
           {
             :request => proc { request_data(env) },
             :person => person_data_proc(env),
-            :context => proc { context(request_data(env)) }
+            :context => proc { context(request_data(env)) },
+            :extra => proc { request_custom_data(env) }
           }
         end
 
@@ -63,6 +64,10 @@ module Rollbar
           return block unless(defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?)
 
           proc { ActiveRecord::Base.connection_pool.with_connection(&block) }
+        end
+
+        def request_custom_data(env)
+          Thread.current[:'_rollbar.rails.custom_data'] ||= extract_custom_data_from_rack(env)
         end
 
         def context(request_data)

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -14,6 +14,7 @@ module Rollbar
 
         def call(env)
           self.request_data = nil
+          self.request_custom_data = nil
 
           Rollbar.reset_notifier!
 
@@ -68,6 +69,10 @@ module Rollbar
 
         def request_custom_data(env)
           Thread.current[:'_rollbar.rails.custom_data'] ||= extract_custom_data_from_rack(env)
+        end
+
+        def request_custom_data=(value)
+          Thread.current[:'_rollbar.rails.custom_data'] = value
         end
 
         def context(request_data)

--- a/lib/rollbar/rails.rb
+++ b/lib/rollbar/rails.rb
@@ -7,7 +7,7 @@ module Rollbar
 
     module ClassMethods
       def on_exception_log_values(*vars)
-        Rollbar.configuration.custom_values = [*vars].map(&:to_s)
+        Rollbar.configuration.custom_values.merge!({ self.name.parameterize => [*vars].map(&:to_s) })
       end
     end
 

--- a/lib/rollbar/rails.rb
+++ b/lib/rollbar/rails.rb
@@ -1,5 +1,15 @@
 module Rollbar
   module Rails
 
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def on_exception_log_values(*vars)
+        Rollbar.configuration.custom_values = [*vars].map(&:to_s)
+      end
+    end
+
   end
 end

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -47,7 +47,7 @@ module Rollbar
         :cookies => cookies,
         :session => session,
         :method => rollbar_request_method(env),
-        :route => route_params,
+        :route => route_params
       }
 
       if env["action_dispatch.request_id"]
@@ -55,6 +55,24 @@ module Rollbar
       end
 
       data
+    end
+
+    def extract_custom_data_from_rack(env)
+      # Only extract custom data if we've defined a custom_data_method, or specific values on the controller
+      controller_values = Rollbar.configuration.custom_values
+      custom_data_block = Rollbar.configuration.custom_data_method
+
+      return {} if controller_values.empty? && !custom_data_block
+
+      controller = env["action_controller.instance"]
+      return {} if !controller
+
+      custom_data = custom_data_block ? controller.instance_exec(&custom_data_block) : {}
+      custom_data.tap do |h|
+        controller_values.each do |var|
+          h[var] = controller.instance_eval(var)
+        end
+      end
     end
 
     def rollbar_scrubbed(value)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -381,6 +381,7 @@ describe Rollbar do
       it 'should have custom message data when custom_data_method is configured' do
         Rollbar.configure do |config|
           config.custom_data_method = lambda { {:a => 1, :b => [2, 3, 4]} }
+          config.payload_options = { :extra => config.custom_data_method }
         end
 
         payload = notifier.send(:build_payload, 'info', 'message', nil, nil)
@@ -400,6 +401,7 @@ describe Rollbar do
 
         Rollbar.configure do |config|
           config.custom_data_method = custom_method
+          config.payload_options = { :extra => custom_method }
         end
 
         payload = notifier.send(:build_payload, 'info', 'message', nil, {:c => {:e => 'g'}, :f => 'f'})
@@ -425,6 +427,7 @@ describe Rollbar do
         before do
           notifier.configure do |config|
             config.custom_data_method = custom_method
+            config.payload_options = { :extra => custom_method }
           end
 
           expect(notifier).to receive(:report_custom_data_error).once.and_return(custom_data_report)
@@ -1755,6 +1758,7 @@ describe Rollbar do
     before do
       Rollbar.configure do |config|
         config.custom_data_method = proc { raise 'this-will-raise' }
+        config.payload_options = { :extra => config.custom_data_method }
       end
 
       expect_any_instance_of(Rollbar::Notifier).to receive(:error).and_return(report_data)


### PR DESCRIPTION
Related to #237 

When logging custom data, we'd like access to controller instance variables. This change lets the lambda be evaluated in the context of the controller, which gives access to its variables and methods.

Additionally, it's often useful to specify custom data at the controller level, rather than via a global initialiser. So there's support for this via the following proposed syntax:

``` ruby
include Rollbar::Rails
on_exception_log_values :@instance_var, :any_method
```
