### PR TITLE
Guard against the retry key being set and no retry_count present

### DIFF
--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -14,7 +14,8 @@ module Rollbar
     end
 
     def self.skip_report?(msg_or_context, e)
-      msg_or_context.is_a?(Hash) && msg_or_context["retry"] && msg_or_context["retry_count"] < ::Rollbar.configuration.sidekiq_threshold
+      msg_or_context.is_a?(Hash) && msg_or_context["retry"] && 
+        msg_or_context["retry_count"] && msg_or_context["retry_count"] < ::Rollbar.configuration.sidekiq_threshold
     end
 
     def call(worker, msg, queue)

--- a/spec/rollbar/sidekiq_spec.rb
+++ b/spec/rollbar/sidekiq_spec.rb
@@ -59,6 +59,18 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
 
         described_class.handle_exception(msg_or_context, exception)
       end
+      
+      it 'does not blow up and sends the error to rollbar if retry is true but there is no retry count' do
+        allow(Rollbar).to receive(:scope).and_return(rollbar)
+        expect(rollbar).to receive(:error)
+
+        msg_or_context = {"retry" => true}
+
+        expect {
+          described_class.handle_exception(msg_or_context, exception)
+        }.to_not raise_error
+      end
+      
     end
   end
 


### PR DESCRIPTION
This fixes https://github.com/rollbar/rollbar-gem/issues/345