### PR TITLE
Use the new Delayed::Job plugin system to register Rollbar plugin

### DIFF
--- a/spec/rollbar/delayed_job_spec.rb
+++ b/spec/rollbar/delayed_job_spec.rb
@@ -12,9 +12,13 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
     end
   end
 
+  before(:all) do
+    # technically, this is called once when rollbar hooks are required
+    Rollbar::Delayed.wrap_worker!
+  end
+
   before do
     Delayed::Backend::Test.prepare_worker
-    Rollbar::Delayed.wrap_worker!
 
     Delayed::Worker.backend = :test
     Delayed::Backend::Test::Job.delete_all


### PR DESCRIPTION
Problem: previous Rollbar DelayedJob plugin used Worker Lifecycle
directly to register the around hook. DelayedJob now clears and
reinitializes the Lifecycle object upon Worker initializations.
This means that commands like `rake jobs:work` will first register
Rollbar hook, then initialize Worker which will clear the hook.

Solution: use the new plugins system to allow Worker to setup its
Lifecycle object and register all plugins when it needs to.