### PR TITLE
Suggest using ROLLBAR_ENV for staging apps

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -56,4 +56,11 @@ Rollbar.configure do |config|
   # config.use_sidekiq
   # You can supply custom Sidekiq options:
   # config.use_sidekiq 'queue' => 'default'
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'] || Rails.env
 end


### PR DESCRIPTION
Running staging app instances in `production` environment is considered a good practice in order to keep staging as close to production as possible. This encourages [12 Factor Apps](http://12factor.net/).