### PR TITLE
Better diagnostic when failsafe is on

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -618,6 +618,8 @@ module Rollbar
           nearest_frame = backtrace[0]
 
           exception_info = exception.class.name
+          # #to_s and #message defaults to class.to_s. Add message only if add valuable info.
+          exception_info += %Q{: "#{exception.message}"} if exception.message != exception.class.to_s
           exception_info += " in #{nearest_frame}" if nearest_frame
 
           body += "#{exception_info}: #{message}"

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1575,6 +1575,17 @@ describe Rollbar do
       notifier.send(:send_failsafe, nil, nil)
     end
 
+    context 'with a non default exception message' do
+      let(:exception) { StandardError.new 'Something is wrong' }
+
+      it 'adds it to exception info' do
+        sent_payload = notifier.send(:send_failsafe, "test failsafe", exception)
+
+        expected_message = 'Failsafe from rollbar-gem. StandardError: "Something is wrong": test failsafe'
+        expect(sent_payload['data'][:body][:message][:body]).to be_eql(expected_message)
+      end
+    end
+
     context 'without exception object' do
       it 'just sends the given message' do
         sent_payload = notifier.send(:send_failsafe, "test failsafe", nil)


### PR DESCRIPTION
First commit is about [this comment](https://github.com/rollbar/rollbar-gem/issues/330#issuecomment-152162956) there's no reason to swallow exception message, so add it to report.

Second commit is about an issue I have in reports with your code. I don't know where that method is used, but I get this error in my reports

```
Failsafe from rollbar-gem. NoMethodError in [...]/rollbar-2.6.3/lib/rollbar/util.rb:70:in `block in deep_merge': build_payload in exception_data
```

Looking at [current implementation](https://github.com/rollbar/rollbar-gem/blob/master/lib/rollbar/util.rb#L70) the only possible reason for this message is that `hash1[k]` is nil for some `k` (since you're iterating on `hash2` keys). The same issue could happen two line below when doing the same check for `Array`.

I'd like to get this merged because this error could potentially swallow other application errors.

Thanks.