### PR TITLE
Ignore exception cause when it's not another exception

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -442,7 +442,7 @@ module Rollbar
       traces = [trace_data(exception)]
       visited = [exception]
 
-      while exception.respond_to?(:cause) && (cause = exception.cause) && !visited.include?(cause)
+      while exception.respond_to?(:cause) && (cause = exception.cause) && cause.is_a?(Exception) && !visited.include?(cause)
         traces << trace_data(cause)
         visited << cause
         exception = cause

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -646,6 +646,13 @@ describe Rollbar do
             chain[1][:exception][:message].should match(/the cause/)
           end
 
+          it 'ignores the cause when it is not an Exception' do
+            exception_with_custom_cause = Exception.new('custom cause')
+            allow(exception_with_custom_cause).to receive(:cause) { "Foo" }
+            body = notifier.send(:build_payload_body_exception, message, exception_with_custom_cause, extra)
+            body[:trace].should_not be_nil
+          end
+
           context 'with cyclic nested exceptions' do
             let(:exception1) { Exception.new('exception1') }
             let(:exception2) { Exception.new('exception2') }


### PR DESCRIPTION
Custom error classes might define `#cause` as a string or similar, which would in turn result in an internal Rollbar error.