### PR TITLE
Remove recommendation for Oj on jRuby as no longer supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ Add this line to your application's Gemfile:
 gem 'rollbar', '~> 2.7.0'
 ```
 
-If you are not using JRuby we suggest using [Oj](https://github.com/ohler55/oj) for JSON serialization. In order to install Oj you can add this line to your Gemfile:
-
-```ruby
-gem 'oj', '~> 2.12.14'
-```
-
 And then execute:
 
 ```bash


### PR DESCRIPTION
[Documentation about compatibility and removal of jRuby support.](https://github.com/ohler55/oj#compatibility)