### PR TITLE
Fix Rollbar::Util.deep_merge so it has default values for arguments

### DIFF
--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -65,11 +65,11 @@ module Rollbar
       end
     end
 
-    def self.deep_merge(hash1, hash2)
+    def self.deep_merge(hash1 = {}, hash2 = {})
       hash2.each_key do |k|
-        if hash1[k].is_a? ::Hash and hash2[k].is_a? ::Hash
+        if hash1[k].is_a?(::Hash) && hash2[k].is_a?(::Hash)
           hash1[k] = deep_merge(hash1[k], hash2[k])
-        elsif hash1[k].is_a? Array and hash2[k].is_a? Array
+        elsif hash1[k].is_a?(Array) && hash2[k].is_a?(Array)
           hash1[k] += deep_copy(hash2[k])
         elsif hash2[k]
           hash1[k] = deep_copy(hash2[k])

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -2,7 +2,6 @@
 
 require 'logger'
 require 'socket'
-require 'spec_helper'
 require 'girl_friday'
 require 'redis'
 require 'active_support/core_ext/object'
@@ -13,6 +12,8 @@ begin
   require 'sucker_punch/testing/inline'
 rescue LoadError
 end
+
+require 'spec_helper'
 
 describe Rollbar do
   let(:notifier) { Rollbar.notifier }


### PR DESCRIPTION
We want the default value for the arguments in
`Rollbar::Util.deep_merge` to be empty Hashes.

Fixes #358