### PR TITLE
Document exception level filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,14 @@ By default, all uncaught exceptions are reported at the "error" level, except fo
 - ```AbstractController::ActionNotFound```
 - ```ActionController::RoutingError```
 
-If you'd like to customize this list, see the example code in ```config/initializers/rollbar.rb```. Supported levels: "critical", "error", "warning", "info", "debug", "ignore". Set to "ignore" to cause the exception not to be reported at all.
+If you'd like to customize this list, modify the example code in ```config/initializers/rollbar.rb```. Supported levels: "critical", "error", "warning", "info", "debug", "ignore". Set to "ignore" to cause the exception not to be reported at all. For example, to ignore 404s, and treat `NoMethodError`s as critical bugs you can use the following code:
+
+```ruby
+config.exception_level_filters.merge!({
+  'ActiveRecord::RecordNotFound': 'ignore'
+  'NoMethodError': 'critical'
+})
+```
 
 This behavior applies to uncaught exceptions, not direct calls to `Rollbar.error()`, `Rollbar.warning()`, etc. If you are making a direct call to one of the log methods and want exception level filters to apply, pass an extra keyword argument:
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ By default, all uncaught exceptions are reported at the "error" level, except fo
 - ```AbstractController::ActionNotFound```
 - ```ActionController::RoutingError```
 
-If you'd like to customize this list, modify the example code in ```config/initializers/rollbar.rb```. Supported levels: "critical", "error", "warning", "info", "debug", "ignore". Set to "ignore" to cause the exception not to be reported at all. For example, to ignore 404s, and treat `NoMethodError`s as critical bugs you can use the following code:
+If you'd like to customize this list, modify the example code in ```config/initializers/rollbar.rb```. Supported levels: "critical", "error", "warning", "info", "debug", "ignore". Set to "ignore" to cause the exception not to be reported at all. For example, to ignore 404s and treat `NoMethodError`s as critical bugs, you can use the following code:
 
 ```ruby
 config.exception_level_filters.merge!({


### PR DESCRIPTION
Previously we told people to go see another document without a link. That's not very user friendly. This also makes `404` "Ctrl+F"able.