### PR TITLE
Notify deploy only on primary :rollbar_role server

### DIFF
--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -6,7 +6,7 @@ namespace :rollbar do
 
   desc 'Send the deployment notification to Rollbar.'
   task :deploy do
-    on roles fetch(:rollbar_role) do
+    on primary fetch(:rollbar_role) do
       warn("You need to upgrade capistrano to '>= 3.1' version in order to correctly report deploys to Rollbar. (On 3.0, the reported revision will be incorrect.)") if Capistrano::VERSION =~ /^3\.0/
 
       uri    = URI.parse 'https://api.rollbar.com/api/1/deploy/'


### PR DESCRIPTION
Hi, I've seen that on every deploy on a multi app node the deploy gets noticed once for each node which get the deploy, so on a tree app node connected to rollbar there's three notifications of the same deploy which makes tree notices on a slack channel if you have slack and rollbar paired.

So perhaps it's a good idea notify the deploy only on primary server.

*Important note*: I've made this PR using the github editor and my knowledge of capistrano so it is not properly tested. I planed only to open an issue but the change is so small that I've created it as PR.