### PR TITLE
Fix Rollbar::Notifier#report_custom_data_error

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -372,7 +372,7 @@ module Rollbar
     def report_custom_data_error(e)
       data = safely.error(e)
 
-      return {} unless data[:uuid]
+      return {} unless data.is_a?(Hash) && data[:uuid]
 
       uuid_url = uuid_rollbar_url(data)
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -427,14 +427,23 @@ describe Rollbar do
           notifier.configure do |config|
             config.custom_data_method = custom_method
           end
-
-          expect(notifier).to receive(:report_custom_data_error).once.and_return(custom_data_report)
         end
 
         it 'doesnt crash the report' do
+          expect(notifier).to receive(:report_custom_data_error).once.and_return(custom_data_report)
           payload = notifier.send(:build_payload, 'info', 'message', nil, extra)
 
           expect(payload['data'][:body][:message][:extra]).to be_eql(expected_extra)
+        end
+
+        context 'and for some reason the safely.error returns a String' do
+          it 'returns an empty Hash' do
+            allow_any_instance_of(Rollbar::Notifier).to receive(:error).and_return('ignored')
+
+            payload = notifier.send(:build_payload, 'info', 'message', nil, extra)
+
+            expect(payload['data'][:body][:message][:extra]).to be_eql(extra)
+          end
         end
       end
 


### PR DESCRIPTION
Ensure that we receive a Hash object so we can take the uuid from
there. In any other case just return an empty Hash.

[branch #5660]