### PR TITLE
Reset the notifier when we use Rollbar.preconfigure

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -744,6 +744,8 @@ module Rollbar
     # to configure it without initializing any of the third party hooks
     def preconfigure
       yield(configuration)
+
+      reset_notifier!
     end
 
     def configure

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1799,6 +1799,28 @@ describe Rollbar do
     end
   end
 
+  describe '.preconfigure'do
+    before do
+      Rollbar.unconfigure
+      Rollbar.reset_notifier!
+    end
+
+    it 'resets the notifier' do
+      Rollbar.configure do |config|
+        config.access_token = 'foo'
+      end
+
+      Thread.new {}
+
+      Rollbar.preconfigure do |config|
+        config.root = 'bar'
+      end
+
+      notifier_config = Rollbar.notifier.configuration
+      expect(notifier_config.root).to be_eql('bar')
+    end
+  end
+
   # configure with some basic params
   def configure
     reconfigure_notifier


### PR DESCRIPTION
This fix the problem we had with gems using `Thread.new` before our
railtie is loaded.

The order to reproduce the bug was:

1. Load Rollbar gem and the Thread monkey patch
2. Rollbar.configure is executed
3. Another gem is loaded and executes Thread.new

  3.1 This sets Rollbar.notifier to the current configuration
4. Our railtie is loaded

 4.1 The railtie uses preconfigure that changes Rollbar.configuration
 4.2 Because we already have a Rollbar.notifier, the new configuration
      is not propagated

So now, on `Rollbar.preconfigure` we reset the notifier, so for next
time it's used it will take the last configuration, included the railtie one.