### PR TITLE
Add Rubocop config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCops:
+  Exclude:
+    - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+  SupportedStyles:
+    - hash_rockets
+
+Metrics/LineLength:
+  Max: 1000
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/Lambda:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false


### PR DESCRIPTION
Since we are still supporting Ruby 1.8, I've added disabled some
settings so we don't have errors on them.

LineLength is set to 1000 for now, since we have lot of long lines. Once
we do a first work fixing the style we can then enable it and be focus
on long lines

Style/DoubleNegation is disabled as a personal preference :D

vendor/** and gemfiles/vendor** are excluded

[branch #2981]