### PR TITLE
Remove .hound.yml file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-ruby:
-  config_file: .rubocop.yml


### PR DESCRIPTION
Hound uses different configuration than default rubocop and having a
file overriding everything seems to be a bit ugly.