### PR TITLE
Allow Rollbar to work in Rails < 3 in Ruby mode

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -17,7 +17,7 @@ require 'rollbar/encoding'
 require 'rollbar/logger_proxy'
 require 'rollbar/exception_reporter'
 require 'rollbar/util'
-require 'rollbar/railtie' if defined?(Rails::VERSION)
+require 'rollbar/railtie' if defined?(Rails::VERSION) && Rails::VERSION::MAJOR >= 3
 require 'rollbar/delay/girl_friday' if defined?(GirlFriday)
 require 'rollbar/delay/thread'
 require 'rollbar/truncation'
@@ -872,7 +872,11 @@ module Rollbar
       return if configuration.disable_monkey_patch
       wrap_delayed_worker
 
-      require 'rollbar/active_record_extension' if defined?(ActiveRecord)
+      if defined?(ActiveRecord)
+        require 'active_record/version'
+        require 'rollbar/active_record_extension' if ActiveRecord::VERSION::MAJOR >= 3
+      end
+
       require 'rollbar/sidekiq' if defined?(Sidekiq)
       require 'rollbar/active_job' if defined?(ActiveJob)
       require 'rollbar/goalie' if defined?(Goalie)


### PR DESCRIPTION
Fo those who are still maintaining old Rails apps this is a way to integrate the Rollbar gem as if it was a plain Ruby project giving the ability to execute `Rollbar.error('foo')` manually in the code whenever is needed.