### PR TITLE
Rollbar JavaScript: Make <head> lookup stricter to avoid matching <header>

### DIFF
--- a/lib/rollbar/js/middleware.rb
+++ b/lib/rollbar/js/middleware.rb
@@ -90,7 +90,7 @@ module Rollbar
       end
 
       def find_end_of_head_open(body)
-        head_open = body.index('<head')
+        head_open = body.index(/<head\W/)
         body.index('>', head_open) + 1 if head_open
       end
 

--- a/spec/rollbar/js/middleware_spec.rb
+++ b/spec/rollbar/js/middleware_spec.rb
@@ -79,6 +79,14 @@ END
         end
       end
 
+      context 'having a html 200 response without head but with an header tag', :add_js => false do
+        let(:body) { ['<header>foobar</header>'] }
+        let(:status) { 200 }
+        let(:headers) do
+          { 'Content-Type' => content_type }
+        end
+      end
+
       context 'having a html 302 response', :add_js => false do
         let(:body) { ['foobar'] }
         let(:status) { 302 }


### PR DESCRIPTION
When loading an HTML partial including a \<header\> tag via AJAX, the Rollbar JS is inserted inside that said \<header\> tag, the lookup for the \<head\> tag being too permissive.

<img width="461" alt="screen shot 2016-03-04 at 11 18 00 am" src="https://cloud.githubusercontent.com/assets/232621/13537670/d2dcd606-e1fa-11e5-93b5-2fb56eb3463e.png">
