### PR TITLE
Namespace Rake out of Rollbar::Rake

### DIFF
--- a/lib/rollbar/rake.rb
+++ b/lib/rollbar/rake.rb
@@ -28,8 +28,8 @@ module Rollbar
     def self.rake_version
       if Object.const_defined?('RAKEVERSION')
         return RAKEVERSION
-      elsif Rake.const_defined?('VERSION')
-        return Rake::VERSION
+      elsif ::Rake.const_defined?('VERSION')
+        return ::Rake::VERSION
       end
     end
   end


### PR DESCRIPTION
`Rake` is namespaced as `Rollbar::Rake` which causes `self.rake_version` to return `nil`. 

[As of 11.0.0](https://github.com/ruby/rake/commit/f593062cbd58a8d6a678d3b244bc6fdd2d4ef6f2) Rake removed `RAKEVERSION`.