### PR TITLE
Fix rake development version to < 11

### DIFF
--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'sinatra'
   gem.add_development_dependency 'resque'
   gem.add_development_dependency 'delayed_job'
-  gem.add_development_dependency 'rake', '>= 0.9.0'
+  gem.add_development_dependency 'rake', '< 11'
   gem.add_development_dependency 'redis'
   gem.add_runtime_dependency     'multi_json'
   gem.add_development_dependency 'oj', '~> 2.12.14' unless is_jruby


### PR DESCRIPTION
We want to do this right now and remove this once we fix the development
dependencies problems we are having right now.