### PR TITLE
Logger class

### DIFF
--- a/lib/rollbar/loggers.rb
+++ b/lib/rollbar/loggers.rb
@@ -1,0 +1,17 @@
+require "logger"
+
+module Rollbar
+  class Logger < Logger
+    def initialize
+      @level = ERROR
+    end
+
+    def add(severity, message = nil, progname = nil, &block)
+      return true if severity < @level
+      message ||= block_given? ? yield : progname
+      return true if message.blank?
+      rollbar_level = [:debug, :info, :warning, :error, :critical, :error][severity] || :error
+      Rollbar.log(rollbar_level, message)
+    end
+  end
+end


### PR DESCRIPTION
I'd like to take a stab at this; resolves #359.

Extending Rails' built-in logger so that it supports Rollbar seems like a pretty common use case to me. I've been using the minimal Logger class included in this PR in a Rails app of mine for a couple of weeks now and encountered no problems.

```ruby

Rails.logger.error "Hello" # Only logs to stdout/file.
Rails.logger.extend ActiveSupport::Logger.broadcast(Rollbar::Logger.new)
Rails.logger.error "Hello" # Now logs to stdout/file and reports to Rollbar too.
```

As mentioned, it is pretty minimal right now. So I am all ears to any suggestions for further improvements/features you may have. I hope we can at least get something basic merged into `master` soon.