### PR TITLE
Add threads reaper

### DIFF
--- a/lib/rollbar/delay/thread.rb
+++ b/lib/rollbar/delay/thread.rb
@@ -1,9 +1,64 @@
+require 'thread'
+require 'timeout'
+
 module Rollbar
   module Delay
     class Thread
-      def self.call(payload)
-        new.call(payload)
-      end
+      EXIT_SIGNAL  = :exit
+      EXIT_TIMEOUT = 3
+
+      Error        = Class.new(StandardError)
+      TimeoutError = Class.new(Error)
+
+      class << self
+        attr_reader :reaper
+
+        def call(payload)
+          spawn_threads_reaper
+          threads << new.call(payload)
+        end
+
+        private
+
+        def threads
+          @threads ||= Queue.new
+        end
+
+        def spawn_threads_reaper
+          return if @spawned
+          @spawned = true
+
+          @reaper ||= build_reaper_thread
+          configure_exit_handler
+        end
+
+        def build_reaper_thread
+          ::Thread.start do
+            loop do
+              thread = threads.pop
+
+              if thread == EXIT_SIGNAL
+                break
+              else
+                thread.join
+              end
+            end
+          end
+        end
+
+        def configure_exit_handler
+          at_exit do
+            begin
+              Timeout.timeout(EXIT_TIMEOUT) do
+                threads << EXIT_SIGNAL
+                reaper.join
+              end
+            rescue Timeout::Error
+              raise TimeoutError, "unable to reap all threads within #{EXIT_TIMEOUT} seconds"
+            end
+          end
+        end
+      end # class << self
 
       def call(payload)
         ::Thread.new do

--- a/lib/rollbar/delay/thread.rb
+++ b/lib/rollbar/delay/thread.rb
@@ -15,7 +15,10 @@ module Rollbar
 
         def call(payload)
           spawn_threads_reaper
-          threads << new.call(payload)
+
+          thread = new.call(payload)
+          threads << thread
+          thread
         end
 
         private
@@ -37,11 +40,9 @@ module Rollbar
             loop do
               thread = threads.pop
 
-              if thread == EXIT_SIGNAL
-                break
-              else
-                thread.join
-              end
+              break if thread == EXIT_SIGNAL
+
+              thread.join
             end
           end
         end


### PR DESCRIPTION
In some situations using threaded way of reporting errors when main process exits payloads are not delivered because all threads are killed straightaway.

For example rake tasks:
```ruby
Rollbar.use_threaded

task :foo do
  begin
    raise 'bar'
  rescue => error
    Rollbar.error(error)
  end
end
```

Another way is to add a method that would do something like this code, but it looks ugly for me: 
```ruby
begin
  tmp = Rollbar.configuration.use_async
  Rollbar.configuration.use_async = false
  yield
ensure
  Rollbar.configuration.use_async = tmp
end
```