### PR TITLE
add nil check for rake.patch! for future robustness

### DIFF
--- a/lib/rollbar/rake.rb
+++ b/lib/rollbar/rake.rb
@@ -20,6 +20,7 @@ module Rollbar
     end
 
     def self.patch?
+	  return false if rake_version.nil?
       major, minor, *_ = rake_version.split('.').map(&:to_i)
 
       major > 0 || major == 0 && minor > 8


### PR DESCRIPTION
refs #411

In the future, `Rake` class possibly change version API, this change prevent nil error in the future.