### PR TITLE
Added support for CSP nonce when secure_headers.gem is used.

### DIFF
--- a/lib/rollbar/js/frameworks/rails.rb
+++ b/lib/rollbar/js/frameworks/rails.rb
@@ -9,6 +9,24 @@ module Rollbar
         def prepare
           return if prepared?
 
+          if secure_headers?
+            insert_middleware_after_secure_headers
+          else
+            insert_middleware
+          end
+
+          self.prepared = true
+        end
+
+        def insert_middleware_after_secure_headers
+          instance = self
+
+          Rollbar::Railtie.initializer 'rollbar.middleware.js.frameworks.rails', :after => 'secure_headers.middleware' do |_app|
+            instance.insert_middleware
+          end
+        end
+
+        def insert_middleware
           require 'rollbar/js/middleware'
 
           config = {
@@ -16,8 +34,10 @@ module Rollbar
             :enabled => Rollbar.configuration.js_enabled
           }
           rails_config.middleware.use(::Rollbar::Js::Middleware, config)
+        end
 
-          self.prepared = true
+        def secure_headers?
+          defined?(::SecureHeaders)
         end
 
         def rails_config

--- a/lib/rollbar/js/middleware.rb
+++ b/lib/rollbar/js/middleware.rb
@@ -27,7 +27,7 @@ module Rollbar
       def _call(env, result)
         return result unless should_add_js?(env, result[0], result[1])
 
-        if response_string = add_js(result[2])
+        if response_string = add_js(env, result[2])
           env[JS_IS_INJECTED_KEY] = true
           response = ::Rack::Response.new(response_string, result[0], result[1])
 
@@ -67,7 +67,7 @@ module Rollbar
         env['action_controller.instance'].class.included_modules.include?(ActionController::Live)
       end
 
-      def add_js(response)
+      def add_js(env, response)
         body = join_body(response)
         close_old_response(response)
 
@@ -78,8 +78,8 @@ module Rollbar
 
         if head_open_end
           body = body[0..head_open_end] <<
-                 config_js_tag <<
-                 snippet_js_tag <<
+                 config_js_tag(env) <<
+                 snippet_js_tag(env) <<
                  body[head_open_end..-1]
         end
 
@@ -104,20 +104,27 @@ module Rollbar
         response.close if response.respond_to?(:close)
       end
 
-      def config_js_tag
-        script_tag("var _rollbarConfig = #{config[:options].to_json};")
+      def config_js_tag(env)
+        script_tag("var _rollbarConfig = #{config[:options].to_json};", env)
       end
 
-      def snippet_js_tag
-        script_tag(js_snippet)
+      def snippet_js_tag(env)
+        script_tag(js_snippet, env)
       end
 
       def js_snippet
         SNIPPET
       end
 
-      def script_tag(content)
-        html_safe_if_needed("\n<script type=\"text/javascript\">#{content}</script>")
+      def script_tag(content, env)
+        if defined?(::SecureHeaders)
+          nonce = ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
+          script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
+        else
+          script_tag_content = "\n<script type=\"text/javascript\">#{content}</script>"
+        end
+
+        html_safe_if_needed(script_tag_content)
       end
 
       def html_safe_if_needed(string)

--- a/spec/rollbar/js/frameworks/rails_spec.rb
+++ b/spec/rollbar/js/frameworks/rails_spec.rb
@@ -16,4 +16,20 @@ describe ApplicationController, :type => 'request' do
     expect(response.body).to include("var _rollbarConfig = #{Rollbar::configuration.js_options.to_json};")
     expect(response.body).to include(snippet_from_submodule)
   end
+
+  it 'renders the snippet and config in the response with nonce in script tag when SecureHeaders installed',
+     :type => 'request' do
+    SecureHeaders = double
+    allow(SecureHeaders).to receive(:content_security_policy_script_nonce) { 'lorem-ipsum-nonce' }
+
+    get '/test_rollbar_js'
+
+    snippet_from_submodule = File.read(File.expand_path('../../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
+
+    expect(response.body).to include('<script type="text/javascript" nonce="lorem-ipsum-nonce">')
+    expect(response.body).to include("var _rollbarConfig = #{Rollbar::configuration.js_options.to_json};")
+    expect(response.body).to include(snippet_from_submodule)
+
+    Object.send(:remove_const, :SecureHeaders)
+  end
 end


### PR DESCRIPTION
The `script_tag` method in Rollbar::Js::Middleware hardcoded the
<script> tag. This was causing problems, when `secure_headers.gem`
had CSP nonce enabled, and `'unsafe-inline'` disabled.

This patch fixes that, and also ensures that `Rollbar::Js::Middleware`
id loaded AFTER `SecureHeaders::Middleware` (to actually obtain the
nonce from the @env through `Rack::Request`).