### PR TITLE
Clean scope before every Sidekiq job execution

### DIFF
--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -4,6 +4,14 @@ module Rollbar
   class Sidekiq
     PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class]
 
+    class ClearScope
+      def call(worker, msg, queue)
+        Rollbar.reset_notifier!
+
+        yield
+      end
+    end
+
     def self.handle_exception(msg_or_context, e)
       return if skip_report?(msg_or_context, e)
 
@@ -14,11 +22,13 @@ module Rollbar
     end
 
     def self.skip_report?(msg_or_context, e)
-      msg_or_context.is_a?(Hash) && msg_or_context["retry"] && 
+      msg_or_context.is_a?(Hash) && msg_or_context["retry"] &&
         msg_or_context["retry_count"] && msg_or_context["retry_count"] < ::Rollbar.configuration.sidekiq_threshold
     end
 
     def call(worker, msg, queue)
+      Rollbar.reset_notifier!
+
       yield
     rescue Exception => e
       Rollbar::Sidekiq.handle_exception(msg, e)
@@ -28,12 +38,13 @@ module Rollbar
 end
 
 Sidekiq.configure_server do |config|
-  if Sidekiq::VERSION < '3'
+  if Sidekiq::VERSION.split('.')[0].to_i < 3
     config.server_middleware do |chain|
       chain.add Rollbar::Sidekiq
     end
   else
-    config.error_handlers << Proc.new do |e, context|
+    chain.add Rollbar::Sidekiq::ClearScope
+    config.error_handlers << proc do |e, context|
       Rollbar::Sidekiq.handle_exception(context, e)
     end
   end

--- a/spec/rollbar/sidekig/clear_scope_spec.rb
+++ b/spec/rollbar/sidekig/clear_scope_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+unless RUBY_VERSION == '1.8.7'
+  require 'sidekiq'
+  require 'rollbar/sidekiq'
+end
+
+describe Rollbar::Sidekiq::ClearScope, :reconfigure_notifier => false do
+  describe '#call' do
+    let(:middleware_block) { proc{} }
+
+    it 'sends the error to Rollbar::Sidekiq.handle_exception' do
+      expect(Rollbar).to receive(:reset_notifier!)
+
+      subject.call(nil, nil, nil, &middleware_block)
+    end
+  end
+end unless RUBY_VERSION == '1.8.7'

--- a/spec/rollbar/sidekiq_spec.rb
+++ b/spec/rollbar/sidekiq_spec.rb
@@ -59,7 +59,7 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
 
         described_class.handle_exception(msg_or_context, exception)
       end
-      
+
       it 'does not blow up and sends the error to rollbar if retry is true but there is no retry count' do
         allow(Rollbar).to receive(:scope).and_return(rollbar)
         expect(rollbar).to receive(:error)
@@ -70,7 +70,7 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
           described_class.handle_exception(msg_or_context, exception)
         }.to_not raise_error
       end
-      
+
     end
   end
 
@@ -82,6 +82,7 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
     subject { Rollbar::Sidekiq.new }
 
     it 'sends the error to Rollbar::Sidekiq.handle_exception' do
+      expect(Rollbar).to receive(:reset_notifier!)
       expect(Rollbar::Sidekiq).to receive(:handle_exception).with(msg, exception)
 
       expect { subject.call(nil, msg, nil, &middleware_block) }.to raise_error(exception)


### PR DESCRIPTION
For Sidekiq > 3.x we are using the error handlers for the error reporting while we use a middleware for Sidekiq < 3.x.

So, in order to clean the scope in both solutions, we add a middleware to do it for Sidekiq > 3.x and complete the existing middleware for Sidekiq < 3.x.