### PR TITLE
Tiny patch to JS middleware injection

### DIFF
--- a/lib/rollbar/js/middleware.rb
+++ b/lib/rollbar/js/middleware.rb
@@ -77,7 +77,7 @@ module Rollbar
         return nil unless head_open_end
 
         if head_open_end
-          body = body[0..head_open_end] <<
+          body = body[0..(head_open_end - 1)] <<
                  config_js_tag <<
                  snippet_js_tag <<
                  body[head_open_end..-1]


### PR DESCRIPTION
I noticed a small bug in `Rollbar::Js::Middleware#add_js` which, due to string slicing indices, causes the character immediately following the end of the `<head>` tag to be inserted once before the Rollbar JS script tags are inserted, as well as appearing immediately after the tags.

This is normally not noticeable/problematic if you've got some whitespace following the end of the `<head>` tag, like a carriage return, but if you don't (for example, using a minifier which strips out extraneous whitespace), you get this happening:

```
<head><
<script type="text/javascript">... config js tag ...</script>
<script type="text/javascript">... script js tag ...</script><meta ...>
```

(note the additional `<` that's been inserted after the head tag, which renders in the page)

Simple fix, as `head_open_end` contains the index of the character immediately following the `<head>`, we shouldn't include it in the first slice range. 