### PR TITLE
Allow scrub all parameters

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -25,10 +25,6 @@ require 'rollbar/exceptions'
 require 'rollbar/lazy_store'
 
 module Rollbar
-  ATTACHMENT_CLASSES = %w[
-    ActionDispatch::Http::UploadedFile
-    Rack::Multipart::UploadedFile
-  ].freeze
   PUBLIC_NOTIFIER_METHODS = %w(debug info warn warning error critical log logger
                                process_payload process_from_async_handler scope send_failsafe log_info log_debug
                                log_warning log_error silenced)

--- a/lib/rollbar/scrubbers.rb
+++ b/lib/rollbar/scrubbers.rb
@@ -1,4 +1,17 @@
 module Rollbar
   module Scrubbers
+    extend self
+
+    def scrub_value(value)
+      if Rollbar.configuration.randomize_scrub_length
+        random_filtered_value
+      else
+        '*' * (value.length rescue 8)
+      end
+    end
+
+    def random_filtered_value
+      '*' * (rand(5) + 3)
+    end
   end
 end

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -1,0 +1,97 @@
+require 'rollbar/scrubbers'
+
+
+module Rollbar
+  module Scrubbers
+    class Params
+      SKIPPED_CLASSES = [Tempfile]
+      ATTACHMENT_CLASSES = %w(ActionDispatch::Http::UploadedFile Rack::Multipart::UploadedFile).freeze
+      SCRUB_ALL = :scrub_all
+
+      def self.call(*args)
+        new.call(*args)
+      end
+
+      def call(params, extra_fields = [])
+        return {} unless params
+
+        config = Rollbar.configuration.scrub_fields
+
+        scrub(params, build_scrub_options(config, extra_fields))
+      end
+
+      private
+
+      def build_scrub_options(config, extra_fields)
+        ary_config = Array(config)
+
+        {
+          :fields_regex => build_fields_regex(ary_config, extra_fields),
+          :scrub_all => ary_config.include?(SCRUB_ALL)
+        }
+      end
+
+      def build_fields_regex(config, extra_fields)
+        fields = config.find_all { |f| f.is_a?(String) || f.is_a?(Symbol) }
+        fields += Array(extra_fields)
+
+        return unless fields.any?
+
+        Regexp.new(fields.map { |val| Regexp.escape(val.to_s).to_s }.join('|'), true)
+      end
+
+      def scrub(params, options)
+        fields_regex = options[:fields_regex]
+        scrub_all = options[:scrub_all]
+
+        params.to_hash.inject({}) do |result, (key, value)|
+          if fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s
+            result[key] = Rollbar::Scrubbers.scrub_value(value)
+          elsif value.is_a?(Hash)
+            result[key] = scrub(value, options)
+          elsif value.is_a?(Array)
+            result[key] = scrub_array(value, options)
+          elsif skip_value?(value)
+            result[key] = "Skipped value of class '#{value.class.name}'"
+          elsif scrub_all
+            result[key] = Rollbar::Scrubbers.scrub_value(value)
+          else
+            result[key] = rollbar_filtered_param_value(value)
+          end
+
+          result
+        end
+      end
+
+      def scrub_array(array, options)
+        array.map do |value|
+          value.is_a?(Hash) ? scrub(value, options) : rollbar_filtered_param_value(value)
+        end
+      end
+
+      def rollbar_filtered_param_value(value)
+        if ATTACHMENT_CLASSES.include?(value.class.name)
+          begin
+            attachment_value(value)
+          rescue
+            'Uploaded file'
+          end
+        else
+          value
+        end
+      end
+
+      def attachment_value(value)
+        {
+          :content_type => value.content_type,
+          :original_filename => value.original_filename,
+          :size => value.tempfile.size
+        }
+      end
+
+      def skip_value?(value)
+        SKIPPED_CLASSES.any? { |klass| value.is_a?(klass) }
+      end
+    end
+  end
+end

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -53,30 +53,4 @@ describe Rollbar::RequestDataExtractor do
       end
     end
   end
-
-  describe '#rollbar_scrubbed_value' do
-    context 'with random scrub length' do
-      before do
-        allow(Rollbar.configuration).to receive(:randomize_scrub_length).and_return(true)
-      end
-
-      let(:value) { 'herecomesaverylongvalue' }
-
-      it 'randomizes the scrubbed string' do
-        expect(subject.rollbar_scrubbed(value)).to match(/\*{3,8}/)
-      end
-    end
-
-    context 'with no-random scrub length' do
-      before do
-        allow(Rollbar.configuration).to receive(:randomize_scrub_length).and_return(false)
-      end
-
-      let(:value) { 'herecomesaverylongvalue' }
-
-      it 'randomizes the scrubbed string' do
-        expect(subject.rollbar_scrubbed(value)).to match(/\*{#{value.length}}/)
-      end
-    end
-  end
 end

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -1,0 +1,268 @@
+require 'spec_helper'
+require 'tempfile'
+require 'rollbar/scrubbers/params'
+
+require 'rspec/expectations'
+
+describe Rollbar::Scrubbers::Params do
+  describe '.call' do
+    it 'calls #call in a new instance' do
+      arguments = [:foo, :bar]
+      expect_any_instance_of(described_class).to receive(:call).with(*arguments)
+
+      described_class.call(*arguments)
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_config)
+    end
+
+    context 'with scrub fields configured' do
+      let(:scrub_config) do
+        [:secret, :password]
+      end
+
+      context 'with simple Hash' do
+        let(:params) do
+          {
+            :foo => 'bar',
+            :secret => 'the-secret',
+            :password => 'the-password',
+            :password_confirmation => 'the-password'
+          }
+        end
+        let(:result) do
+          {
+            :foo => 'bar',
+            :secret => /\*+/,
+            :password => /\*+/,
+            :password_confirmation => /\*+/
+          }
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+      end
+
+      context 'with nested Hash' do
+        let(:params) do
+          {
+            :foo => 'bar',
+            :extra => {
+              :secret => 'the-secret',
+              :password => 'the-password',
+              :password_confirmation => 'the-password'
+            }
+          }
+        end
+        let(:result) do
+          {
+            :foo => 'bar',
+            :extra => {
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
+            }
+          }
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+      end
+
+      context 'with nested Array' do
+        let(:params) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => 'the-secret',
+              :password => 'the-password',
+              :password_confirmation => 'the-password'
+            }]
+          }
+        end
+        let(:result) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
+            }]
+          }
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+      end
+
+      context 'with skipped instance' do
+        let(:tempfile) { Tempfile.new('foo') }
+        let(:params) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => 'the-secret',
+              :password => 'the-password',
+              :password_confirmation => 'the-password',
+              :skipped => tempfile
+            }]
+          }
+        end
+        let(:result) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/,
+              :skipped => "Skipped value of class 'Tempfile'"
+            }]
+          }
+        end
+
+        after { tempfile.close }
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+      end
+
+      context 'with attachment instance' do
+        let(:tempfile) { double(:size => 100) }
+        let(:attachment) do
+          double(:class => double(:name => 'ActionDispatch::Http::UploadedFile'),
+                 :tempfile => tempfile,
+                 :content_type => 'content-type',
+                 'original_filename' => 'filename')
+        end
+        let(:params) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => 'the-secret',
+              :password => 'the-password',
+              :password_confirmation => 'the-password',
+              :attachment => attachment
+            }]
+          }
+        end
+        let(:result) do
+          {
+            :foo => 'bar',
+            :extra => [{
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/,
+              :attachment => {
+                :content_type => 'content-type',
+                :original_filename => 'filename',
+                :size => 100
+              }
+            }]
+          }
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+
+        context 'if getting the attachment values fails' do
+          let(:tempfile) { Object.new }
+          let(:attachment) do
+            double(:class => double(:name => 'ActionDispatch::Http::UploadedFile'),
+                   :tempfile => tempfile,
+                   :content_type => 'content-type',
+                   'original_filename' => 'filename')
+          end
+          let(:params) do
+            {
+              :foo => 'bar',
+              :extra => [{
+                :secret => 'the-secret',
+                :password => 'the-password',
+                :password_confirmation => 'the-password',
+                :attachment => attachment
+              }]
+            }
+          end
+          let(:result) do
+            {
+              :foo => 'bar',
+              :extra => [{
+                :secret => /\*+/,
+                :password => /\*+/,
+                :password_confirmation => /\*+/,
+                :attachment => 'Uploaded file'
+              }]
+            }
+          end
+
+          it 'scrubs the required parameters' do
+            expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          end
+        end
+      end
+
+      context 'without params' do
+        let(:params) do
+          nil
+        end
+        let(:result) do
+          {}
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        end
+      end
+    end
+
+    context 'with :scrub_all option' do
+      let(:scrub_config) { :scrub_all }
+      let(:params) do
+        {
+          :foo => 'bar',
+          :password => 'the-password',
+          :bar => 'foo',
+          :extra => {
+            :foo => 'more-foo',
+            :bar => 'more-bar'
+          }
+        }
+      end
+      let(:result) do
+        {
+          :foo => /\*+/,
+          :password => /\*+/,
+          :bar => /\*+/,
+          :extra => {
+            :foo => /\*+/,
+            :bar => /\*+/
+          }
+        }
+      end
+
+      it 'scrubs the required parameters' do
+        expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+      end
+    end
+  end
+end
+
+describe Rollbar::Scrubbers::Params::ATTACHMENT_CLASSES do
+  it 'has the correct values' do
+    expect(described_class).to be_eql(%w(ActionDispatch::Http::UploadedFile Rack::Multipart::UploadedFile).freeze)
+  end
+end
+
+describe Rollbar::Scrubbers::Params::SKIPPED_CLASSES do
+  it 'has the correct values' do
+    expect(described_class).to be_eql([Tempfile])
+  end
+end

--- a/spec/rollbar/scrubbers_spec.rb
+++ b/spec/rollbar/scrubbers_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require 'rollbar/scrubbers'
+
+describe Rollbar::Scrubbers do
+  describe '.scrub_value' do
+    context 'with random scrub length' do
+      before do
+        allow(Rollbar.configuration).to receive(:randomize_scrub_length).and_return(true)
+      end
+
+      let(:value) { 'herecomesaverylongvalue' }
+
+      it 'randomizes the scrubbed string' do
+        expect(described_class.scrub_value(value)).to match(/\*{3,8}/)
+      end
+    end
+
+    context 'with no-random scrub length' do
+      before do
+        allow(Rollbar.configuration).to receive(:randomize_scrub_length).and_return(false)
+      end
+
+      let(:value) { 'herecomesaverylongvalue' }
+
+      it 'randomizes the scrubbed string' do
+        expect(described_class.scrub_value(value)).to match(/\*{#{value.length}}/)
+      end
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,23 @@
+RSpec::Matchers.define :be_eql_hash_with_regexes do |expected|
+  def check_value(actual_value, expected_value)
+    if expected_value.is_a?(Hash)
+      expected_value.all? { |k, _| check_value(actual_value[k], expected_value[k]) }
+    elsif expected_value.is_a?(Array)
+      expected_value.each_with_index.map do |v, i|
+        check_value(actual_value[i], v)
+      end.all?
+    elsif expected_value.is_a?(Regexp)
+      actual_value.match(expected_value)
+    else
+      actual_value == expected_value
+    end
+  end
+
+  match do |actual|
+    expected.all? do |key, expected_value|
+      actual_value = actual[key]
+
+      check_value(actual_value, expected_value)
+    end
+  end
+end


### PR DESCRIPTION
This PR allows set the `scrub_fields` configuration option to have value
`:scrub_all` so every parameter will be scrubbed:


```ruby
Rollbar.configure do |config|
# ...
  config.scrub_fields = :scrub_all
end
```

This is useful if the privacity policy if very heavy.

Closes #413