### PR TITLE
add sidekiq-specific framework and context params

### DIFF
--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -16,7 +16,11 @@ module Rollbar
       return if skip_report?(msg_or_context, e)
 
       params = msg_or_context.reject{ |k| PARAM_BLACKLIST.include?(k) }
-      scope = { :request => { :params => params } }
+      scope = {
+        :request => { :params => params },
+        :framework => "Sidekiq: #{::Sidekiq::VERSION}"
+      }
+      scope[:context] = "sidekiq##{params['queue']}" if params.is_a?(Hash)
 
       Rollbar.scope(scope).error(e, :use_exception_level_filters => true)
     end

--- a/spec/rollbar/sidekiq_spec.rb
+++ b/spec/rollbar/sidekiq_spec.rb
@@ -10,7 +10,12 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
     let(:msg_or_context) { ['hello', 'error_backtrace', 'backtrace', 'goodbye'] }
     let(:exception) { StandardError.new('oh noes') }
     let(:rollbar) { double }
-    let(:expected_args) { { :request => { :params => ['hello', 'goodbye'] } } }
+    let(:expected_args) do
+      {
+        :request => { :params => ['hello', 'goodbye'] },
+        :framework => "Sidekiq: #{Sidekiq::VERSION}"
+      }
+    end
 
     subject { described_class }
 
@@ -26,6 +31,21 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
       expect(rollbar).to receive(:error).with(exception, :use_exception_level_filters => true)
 
       described_class.handle_exception(msg_or_context, exception)
+    end
+
+    context 'when a sidekiq queue is set' do
+      it 'adds the sidekiq#queue-name to the error report context' do
+        msg_or_context = {"retry" => true, "retry_count" => 1, "queue" => "default"}
+        expected_args = {
+          :request => { :params => msg_or_context },
+          :framework => "Sidekiq: #{Sidekiq::VERSION}",
+          :context => 'sidekiq#default'
+        }
+
+        allow(rollbar).to receive(:error)
+        expect(Rollbar).to receive(:scope).with(expected_args) {rollbar}
+        described_class.handle_exception(msg_or_context, exception)
+      end
     end
 
     context 'when set a sidekiq_threshold' do


### PR DESCRIPTION
This should make Rollbar more easily able to filter out errors coming from Sidekiq by setting the framework to "Sidekiq" and adding the `context` attribute to the error report similar to the way Bugsnag does by default.