### PR TITLE
set the error context to the worker class name

### DIFF
--- a/lib/rollbar/sidekiq.rb
+++ b/lib/rollbar/sidekiq.rb
@@ -20,7 +20,10 @@ module Rollbar
         :request => { :params => params },
         :framework => "Sidekiq: #{::Sidekiq::VERSION}"
       }
-      scope[:context] = "sidekiq##{params['queue']}" if params.is_a?(Hash)
+      if params.is_a?(Hash)
+        scope[:context] = params['class']
+        scope[:queue] = params['queue']
+      end
 
       Rollbar.scope(scope).error(e, :use_exception_level_filters => true)
     end

--- a/spec/rollbar/sidekiq_spec.rb
+++ b/spec/rollbar/sidekiq_spec.rb
@@ -33,13 +33,14 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
       described_class.handle_exception(msg_or_context, exception)
     end
 
-    context 'when a sidekiq queue is set' do
+    context 'when a sidekiq worker class is set' do
       it 'adds the sidekiq#queue-name to the error report context' do
-        msg_or_context = {"retry" => true, "retry_count" => 1, "queue" => "default"}
+        msg_or_context = {"retry" => true, "retry_count" => 1, 'queue' => 'default', 'class' => 'MyWorkerClass'}
         expected_args = {
           :request => { :params => msg_or_context },
           :framework => "Sidekiq: #{Sidekiq::VERSION}",
-          :context => 'sidekiq#default'
+          :context => 'MyWorkerClass',
+          :queue => 'default'
         }
 
         allow(rollbar).to receive(:error)


### PR DESCRIPTION
@jondeandres @brianr as I mentioned in #432, on second thought I think putting the worker class name in the `context` parameter will be much more useful for searching & filtering. The Sidekiq queue name still comes through in `request.params.queue`, but this is less important for searching.