### PR TITLE
Adds support for setting Net:HTTP open_timeout through config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,6 +180,10 @@ Rollbar load the traces before sending them.
 Set to `false` to skip automatic bundling of job metadata like queue, job class
 name, and job options.
 
+### open_timeout
+
+**Default** `3`
+
 ### request_timeout
 
 **Default** `3`

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -596,6 +596,7 @@ module Rollbar
 
       uri = URI.parse(configuration.endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.open_timeout = configuration.open_timeout
       http.read_timeout = configuration.request_timeout
 
       if uri.scheme == 'https'

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -31,6 +31,7 @@ module Rollbar
     attr_accessor :person_email_method
     attr_accessor :populate_empty_backtraces
     attr_accessor :report_dj_data
+    attr_accessor :open_timeout
     attr_accessor :request_timeout
     attr_accessor :root
     attr_accessor :js_options
@@ -88,6 +89,7 @@ module Rollbar
       @project_gems = []
       @populate_empty_backtraces = false
       @report_dj_data = true
+      @open_timeout = 3
       @request_timeout = 3
       @js_enabled = false
       @js_options = {}

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -12,6 +12,7 @@ describe HomeController do
     Rollbar.configure do |config|
       config.access_token = test_access_token
       config.logger = logger_mock
+      config.open_timeout = 60
       config.request_timeout = 60
     end
   end

--- a/spec/dummyapp/config/initializers/rollbar.rb
+++ b/spec/dummyapp/config/initializers/rollbar.rb
@@ -1,5 +1,6 @@
 Rollbar.configure do |config|
   config.access_token = 'aaaabbbbccccddddeeeeffff00001111'
+  config.open_timeout = 60
   config.request_timeout = 60
   config.js_enabled = true
   config.js_options = {

--- a/spec/support/notifier_helpers.rb
+++ b/spec/support/notifier_helpers.rb
@@ -6,6 +6,7 @@ module NotifierHelpers
       config.logger = ::Rails.logger
       config.root = ::Rails.root
       config.framework = "Rails: #{::Rails::VERSION::STRING}"
+      config.open_timeout = 60
       config.request_timeout = 60
     end
   end


### PR DESCRIPTION
This allows you to configure a timeout for when your server can't talk to Rollbar and keeps your app from hanging.