### PR TITLE
Added support for rollbar.js when SecureHeaders 2.x installed. Fixes #442

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -116,7 +116,7 @@ module Rollbar
       end
 
       def script_tag(content, env)
-        if defined?(::SecureHeaders)
+        if defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce)
           nonce = ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
           script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
         else

--- a/lib/rollbar/plugins/rails.rb
+++ b/lib/rollbar/plugins/rails.rb
@@ -25,7 +25,7 @@ Rollbar.plugins.define('rails-rollbar.js') do
         module Frameworks
           class Rails
             def load
-              if secure_headers?
+              if secure_headers_middleware?
                 insert_middleware_after_secure_headers
               else
                 insert_middleware
@@ -50,8 +50,8 @@ Rollbar.plugins.define('rails-rollbar.js') do
               rails_config.middleware.use(::Rollbar::Middleware::Js, config)
             end
 
-            def secure_headers?
-              defined?(::SecureHeaders)
+            def secure_headers_middleware?
+              defined?(::SecureHeaders::Middleware)
             end
 
             def rails_config


### PR DESCRIPTION
As a original author of the PR, I feel obliged to provide the fix.

However, `SecureHeaders 2.x` is nothing more than Rails controller hack, while Rollbar is a Rack Middleware. This means (and please correct me I'm wrong), the `rollbar.gem` doesn't have access to controller (or more exactly, controller instance variable `@content_security_policy_nonce` which holds the nonce) at the point when it invokes the `script_tag` method.

So what I did, I simply disabled the nonce fix for secure headers < 3 (or in more general, a non-middleware SecureHeaders version) - it's not perfect, but at least script tag is rendered properly again.