### PR TITLE
Mock the requests to Rollbar API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
   - gem update --system 2.1.11
   - gem --version
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -32,6 +30,13 @@ gemfile:
   - gemfiles/rails42.gemfile
   - gemfiles/rails50.gemfile
 matrix:
+  include:
+    - rvm: 1.8.7
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk6
+    - rvm: 1.9.2
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk6
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-18mode

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -38,4 +38,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => "../"

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -40,4 +40,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => "../"

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -40,4 +40,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => "../"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -38,4 +38,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -38,4 +38,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -44,4 +44,6 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
+gem 'webmock', :require => false
+
 gemspec :path => '../'

--- a/gemfiles/ruby_1_8_and_1_9_2.gemfile
+++ b/gemfiles/ruby_1_8_and_1_9_2.gemfile
@@ -40,6 +40,4 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
 end
 
-gem 'webmock', :require => false
-
 gemspec :path => '../'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,12 @@ require File.expand_path('../dummyapp/config/environment', __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
 
+begin
+  require 'webmock/rspec'
+  WebMock.disable_net_connect!(:allow => 'codeclimate.com')
+rescue LoadError
+end
+
 namespace :dummy do
   load 'spec/dummyapp/Rakefile'
 end
@@ -60,6 +66,8 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     DatabaseCleaner.clean
     Rollbar.reset_notifier!
+
+    stub_request(:any, /api.rollbar.com/).to_rack(RollbarAPI.new) if defined?(WebMock)
   end
 
   config.after(:each) do

--- a/spec/support/rollbar_api.rb
+++ b/spec/support/rollbar_api.rb
@@ -1,0 +1,28 @@
+require 'rack/request'
+
+class RollbarAPI
+  def call(env)
+    request = Rack::Request.new(env)
+
+    success(request)
+  end
+
+  def success(request)
+    headers = {
+      'Content-Type' => 'application/json'
+    }
+    [200, headers, [success_body(request)]]
+  end
+
+  def success_body(request)
+    json = JSON.parse(request.body.read)
+
+    {
+      :err => 0,
+      :result => {
+        :id => rand(1_000_000),
+        :uuid => json['data']['uuid']
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
Working and developing in the gem using real requests to the API becomes a nightmare when there are some connection issues. The tests fails in Travis and we loose a lot of time rebuilding the failed jobs.

With this change we mock all the requests to a mocked Rollbar API. Since for now the tests only expect to receive 200 codes, the mock API just return 200 codes with the expected response body. This can be changed in the future easier.

The time to run the tests now is between 1.5s and 2s. Not the build in travis that needs to run bundle install, etc...

For Ruby 1.8.7 and Ruby 1.9.2 we cannot install webmock. This is a nother smell that we should start thinking in stop official support for those Rubies at some point.