### PR TITLE
Fix URL scrubbing and change to a functional object

### DIFF
--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -15,10 +15,12 @@ module Rollbar
         new.call(*args)
       end
 
-      def call(params, extra_fields = [])
+      def call(options = {})
+        params = options[:params]
         return {} unless params
 
-        config = Rollbar.configuration.scrub_fields
+        config = options[:config]
+        extra_fields = options[:extra_fields]
 
         scrub(params, build_scrub_options(config, extra_fields))
       end

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -14,18 +14,64 @@ describe Rollbar::RequestDataExtractor do
     Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'localhost:81', 'HTTP_X_FORWARDED_HOST' => 'example.org:9292')
   end
 
-  describe '#extract_request_data_from_rack' do
-    let(:scrubber) { double }
+  describe '#scrub_url' do
+    let(:url) { 'http://this-is-the-url.com/foobar?param1=value1' }
+    let(:sensitive_params) { [:param1, :param2] }
+    let(:scrub_fields) { [:password, :secret] }
 
-    it 'returns a Hash object' do
-      scrubber_config = {
-        :scrub_fields => kind_of(Array),
-        :scrub_user => Rollbar.configuration.scrub_user,
-        :scrub_password => Rollbar.configuration.scrub_password,
-        :randomize_scrub_length => Rollbar.configuration.randomize_scrub_length
+    before do
+      allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_fields)
+      allow(Rollbar.configuration).to receive(:scrub_user).and_return(true)
+      allow(Rollbar.configuration).to receive(:scrub_password).and_return(true)
+      allow(Rollbar.configuration).to receive(:randomize_secret_length).and_return(true)
+    end
+
+    it 'calls the scrubber with the correct options' do
+      expected_options = {
+        :url => url,
+        :scrub_fields => [:password, :secret, :param1, :param2],
+        :scrub_user => true,
+        :scrub_password => true,
+        :randomize_scrub_length => true
       }
-      expect(Rollbar::Scrubbers::URL).to receive(:new).with(scrubber_config).and_return(scrubber)
-      expect(scrubber).to receive(:call).with(kind_of(String))
+
+      expect(Rollbar::Scrubbers::URL).to receive(:call).with(expected_options)
+
+      subject.scrub_url(url, sensitive_params)
+    end
+  end
+
+  describe '#scrub_params' do
+    let(:params) do
+      {
+        :param1 => 'value1',
+        :param2 => 'value2'
+      }
+    end
+    let(:sensitive_params) { [:param1, :param2] }
+    let(:scrub_fields) { [:password, :secret] }
+
+    before do
+      allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_fields)
+    end
+
+    it 'calls the scrubber with the correct options' do
+      expected_options = {
+        :params => params,
+        :config => scrub_fields,
+        :extra_fields => sensitive_params
+      }
+
+      expect(Rollbar::Scrubbers::Params).to receive(:call).with(expected_options)
+
+      subject.scrub_params(params, sensitive_params)
+    end
+  end
+
+  describe '#extract_request_data_from_rack' do
+    it 'returns a Hash object' do
+      expect(Rollbar::Scrubbers::URL).to receive(:call).with(kind_of(Hash)).and_call_original
+      expect(Rollbar::Scrubbers::Params).to receive(:call).with(kind_of(Hash)).and_call_original.exactly(7)
 
       result = subject.extract_request_data_from_rack(env)
 

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -15,8 +15,11 @@ describe Rollbar::Scrubbers::Params do
   end
 
   describe '#call' do
-    before do
-      allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_config)
+    let(:options) do
+      {
+        :params => params,
+        :config => scrub_config
+      }
     end
 
     context 'with scrub fields configured' do
@@ -43,7 +46,7 @@ describe Rollbar::Scrubbers::Params do
         end
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
       end
 
@@ -70,7 +73,7 @@ describe Rollbar::Scrubbers::Params do
         end
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
       end
 
@@ -97,7 +100,7 @@ describe Rollbar::Scrubbers::Params do
         end
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
       end
 
@@ -129,7 +132,7 @@ describe Rollbar::Scrubbers::Params do
         after { tempfile.close }
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
       end
 
@@ -169,7 +172,7 @@ describe Rollbar::Scrubbers::Params do
         end
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
 
         context 'if getting the attachment values fails' do
@@ -204,7 +207,7 @@ describe Rollbar::Scrubbers::Params do
           end
 
           it 'scrubs the required parameters' do
-            expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+            expect(subject.call(options)).to be_eql_hash_with_regexes(result)
           end
         end
       end
@@ -218,7 +221,7 @@ describe Rollbar::Scrubbers::Params do
         end
 
         it 'scrubs the required parameters' do
-          expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+          expect(subject.call(options)).to be_eql_hash_with_regexes(result)
         end
       end
     end
@@ -249,7 +252,7 @@ describe Rollbar::Scrubbers::Params do
       end
 
       it 'scrubs the required parameters' do
-        expect(subject.call(params)).to be_eql_hash_with_regexes(result)
+        expect(subject.call(options)).to be_eql_hash_with_regexes(result)
       end
     end
   end


### PR DESCRIPTION
After one scrubbing refactor we starting not passing the scrubing
configuration to the URL scrubber. This is fixed with this PR.

Also, since params scrubbers was designed as a functional object, URL
scrubber is not also a functional object without state. Just to maintain
the style for them.

Some tests have been added to the scrubbers and the request data
extractor module