### PR TITLE
Send rollbar_comment during deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,8 @@ set :rollbar_role, Proc.new { :app }
 Optionally, you can add a comment to your deploy with `rollbar_comment`. E.g.:
 
 ```ruby
+# Example: Interactively ask the user for a deploy comment.
+#   Alternativeely, you could generate a comment by (e.g.) querying your SCM repo
 set :rollbar_comment, Proc.new {
   ask :comment, "Describing this deploy"
   fetch(:comment)

--- a/README.md
+++ b/README.md
@@ -844,6 +844,15 @@ set :rollbar_env, Proc.new { fetch :stage }
 set :rollbar_role, Proc.new { :app }
 ```
 
+Optionally, you can add a comment to your deploy with `rollbar_comment`. E.g.:
+
+```ruby
+set :rollbar_comment, Proc.new {
+  ask :comment, "Describing this deploy"
+  fetch(:comment)
+}
+```
+
 NOTE: We've seen problems with Capistrano version `3.0.x` where the revision reported is incorrect. Version `3.1.0` and higher works correctly.
 
 ### Capistrano 2

--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -14,7 +14,9 @@ namespace :rollbar do
         :local_username => fetch(:rollbar_user),
         :access_token   => fetch(:rollbar_token),
         :environment    => fetch(:rollbar_env),
-        :revision       => fetch(:rollbar_revision) }
+        :revision       => fetch(:rollbar_revision),
+        :comment        => fetch(:rollbar_comment),
+      }
 
       debug "Building Rollbar POST to #{uri} with #{params.inspect}"
 


### PR DESCRIPTION
Pretty self-explanatory.

FWIW I'm using this with the `capistrano-pending` gem to publish a changelog as the comment (I'm not on Github so I don't get the free commit log):

```
set :rollbar_comment, Proc.new { `cap #{fetch :stage} deploy:pending`.split("\n").grep(/^    /).join("\n\n") }
```
