### PR TITLE
Fix active_model require in validations plugin

### DIFF
--- a/lib/rollbar/plugins/validations.rb
+++ b/lib/rollbar/plugins/validations.rb
@@ -2,7 +2,7 @@ Rollbar.plugins.define('active_model') do
   dependency { !configuration.disable_monkey_patch }
   dependency { defined?(ActiveModel::Validations) }
   dependency do
-    require 'active_record/version'
+    require 'active_model/version'
 
     ActiveModel::VERSION::MAJOR >= 3
   end


### PR DESCRIPTION
Loading the validations plugin while active_model is present without
active_record causes an exception.