### PR TITLE
add missing require

### DIFF
--- a/lib/rollbar/plugins/rake.rb
+++ b/lib/rollbar/plugins/rake.rb
@@ -1,3 +1,5 @@
+require 'rake'
+
 Rollbar.plugins.define('rake') do
   dependency { !configuration.disable_monkey_patch }
   dependency { defined?(Rake) }


### PR DESCRIPTION
Without this, `Rake::VERSION` can not be acquired, patch is always skip.