### PR TITLE
Add immediate ActiveModel::Validations monkey patch

### DIFF
--- a/lib/rollbar/plugins/validations.rb
+++ b/lib/rollbar/plugins/validations.rb
@@ -7,7 +7,7 @@ Rollbar.plugins.define('active_model') do
     ActiveModel::VERSION::MAJOR >= 3
   end
 
-  execute do
+  execute! do
     module Rollbar
       # Module that defines methods to be used by instances using
       # ActiveModel::Validations
@@ -25,7 +25,7 @@ Rollbar.plugins.define('active_model') do
     end
   end
 
-  execute do
+  execute! do
     ActiveModel::Validations.module_eval do
       include Rollbar::ActiveRecordExtension
     end


### PR DESCRIPTION
This will try to prevent that models are loaded before our active model extensions are loaded.