### PR TITLE
Scrub sidekiq params if needed

### DIFF
--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -49,6 +49,8 @@ module Rollbar
         fields_regex = options[:fields_regex]
         scrub_all = options[:scrub_all]
 
+        return scrub_array(params, options) if params.is_a?(Array)
+
         params.to_hash.inject({}) do |result, (key, value)|
           if value.is_a?(Hash)
             result[key] = scrub(value, options)

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -27,6 +27,33 @@ describe Rollbar::Scrubbers::Params do
         [:secret, :password]
       end
 
+      context 'with Array object' do
+        let(:params) do
+          [
+            {
+              :foo => 'bar',
+              :secret => 'the-secret',
+              :password => 'the-password',
+              :password_confirmation => 'the-password'
+            }
+          ]
+        end
+        let(:result) do
+          [
+            {
+              :foo => 'bar',
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
+            }
+          ]
+        end
+
+        it 'scrubs the required parameters' do
+          expect(subject.call(options).first).to be_eql_hash_with_regexes(result.first)
+        end
+      end
+
       context 'with simple Hash' do
         let(:params) do
           {


### PR DESCRIPTION
We are not using Rollbar::Scrubbers::Params in sidekiq plugin so
currently the notifier could be sending sensible data to the Rollbar
API.

With this change we pass the sidekiq params through the params scrubber