### PR TITLE
Configuration to disable script nonce

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -116,14 +116,17 @@ module Rollbar
       end
 
       def script_tag(content, env)
-        if defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce)
-          nonce = ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
-          script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
-        else
-          script_tag_content = "\n<script type=\"text/javascript\">#{content}</script>"
-        end
+        nonce = script_nonce(env)
+        nonce_attr = " nonce=\"#{nonce}\"" if nonce
+        script_tag_content = "\n<script type=\"text/javascript\"#{nonce_attr}>#{content}</script>"
 
         html_safe_if_needed(script_tag_content)
+      end
+
+      def script_nonce(env)
+        if defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce)
+          ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
+        end
       end
 
       def html_safe_if_needed(string)

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -124,6 +124,7 @@ module Rollbar
       end
 
       def script_nonce(env)
+        return if !!config[:without_script_nonce]
         if defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce)
           ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
         end

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -122,6 +122,22 @@ END
           expect(new_body).to include("var _rollbarConfig = #{config[:options].to_json};")
           expect(new_body).to include(snippet)
         end
+
+        context 'having script nonce disabled in configuration' do
+          let(:config) do
+            {
+              :enabled => true,
+              :without_script_nonce => true
+            }
+          end
+
+          it 'renders the script tag without the nonce' do
+            res_status, res_headers, response = subject.call(env)
+            new_body = response.body.join
+
+            expect(new_body).to include('<script type="text/javascript">')
+          end
+        end
       end
 
       context 'having a html 200 response and SecureHeaders < 3.0.0 defined' do


### PR DESCRIPTION
The auto-added script tag nonce attributes are not compatible with a secure_headers configuration in which `'unsafe-inline'` is present in the CSP for `script-src`. See #462.

Some work has been done in other PRs to address this issue --- see #478; this PR is a suggestion for a simplest-possible solution to the problem. Specifically, allow the Rollbar configuration to mandate that the nonce attribute should not be used.