### PR TITLE
Include validations plugin in activerecord base

### DIFF
--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -32,6 +32,7 @@ end
 
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
+gem 'rack-protection', :git => 'https://github.com/sinatra/rack-protection'
 gem 'resque'
 gem 'delayed_job', :require => false
 gem 'redis'

--- a/lib/rollbar/plugins/validations.rb
+++ b/lib/rollbar/plugins/validations.rb
@@ -29,5 +29,15 @@ Rollbar.plugins.define('active_model') do
     ActiveModel::Validations.module_eval do
       include Rollbar::ActiveRecordExtension
     end
+
+    # If ActiveRecord::Base has been already loaded,
+    # it's including a not updated version of ActiveModel::Validations
+    # We then want to include Rollbar::ActiveRecordExtension
+    # in ActiveRecord::Base
+    if defined?(ActiveRecord::Base)
+      ActiveRecord::Base.class_eval do
+        include Rollbar::ActiveRecordExtension
+      end
+    end
   end
 end


### PR DESCRIPTION
In case `ActiveRecord::Base` has been already loaded before our
validations plugin is loading, `ActiveRecord::Base` will already include
ActiveModel::Validations but will not have our validations method.

We want in this case to  include it also in `ActiveRecord::Base` so it can
be used by the customers without `NoMethodError` exceptions