### PR TITLE
Send arguments with exception in active job plugin

### DIFF
--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -32,6 +32,7 @@ end
 
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
+gem 'rack-protection', :git => 'https://github.com/sinatra/rack-protection'
 gem 'resque'
 gem 'delayed_job', :require => false
 gem 'redis'

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -3,7 +3,7 @@ module Rollbar
   module ActiveJob
     def self.included(base)
       base.send :rescue_from, Exception do |exception|
-        Rollbar.error(exception, :job => self.class.name, :job_id => job_id)
+        Rollbar.error(exception, :job => self.class.name, :job_id => job_id, :arguments => arguments)
         raise exception
       end
     end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -9,6 +9,11 @@ describe Rollbar::ActiveJob do
     include Rollbar::ActiveJob
 
     attr_reader :job_id
+    attr_accessor :arguments
+
+    def initialize(*arguments)
+      @arguments = arguments
+    end
 
     def perform(exception, job_id)
       @job_id = job_id
@@ -21,14 +26,15 @@ describe Rollbar::ActiveJob do
 
   let(:exception) { StandardError.new('oh no') }
   let(:job_id) { "123" }
+  let(:argument) { 12 }
 
   it "reports the error to Rollbar" do
-    expected_params = { :job => "TestJob", :job_id => job_id }
+    expected_params = { :job => "TestJob", :job_id => job_id, :arguments => [argument] }
     expect(Rollbar).to receive(:error).with(exception, expected_params)
-    TestJob.new.perform(exception, job_id) rescue nil
+    TestJob.new(argument).perform(exception, job_id) rescue nil
   end
 
   it "reraises the error so the job backend can handle the failure and retry" do
-    expect { TestJob.new.perform(exception, job_id) }.to raise_error exception
+    expect { TestJob.new(argument).perform(exception, job_id) }.to raise_error exception
   end
 end


### PR DESCRIPTION
Hi! We are using  active job plugin and we have troubles to understand what's wrong in our code without arguments of this job. 
In Active Job, [arguments](https://github.com/rails/rails/blob/master/activejob/lib/active_job/core.rb#L9) it's method like job_id that you are using 
