### PR TITLE
Improve Rake support to avoid conflicts with other services

### DIFF
--- a/lib/rollbar/plugins/rake.rb
+++ b/lib/rollbar/plugins/rake.rb
@@ -5,17 +5,38 @@ Rollbar.plugins.define('rake') do
 
   module Rollbar
     module Rake
-      def self.patch!
-        skip_patch && return unless patch?
+      class << self
+        attr_accessor :patched
+      end
 
-        ::Rake::Application.class_eval do
-          alias_method :orig_display_error_message, :display_error_message
-
-          def display_error_message(ex)
-            Rollbar.error(ex, :use_exception_level_filters => true)
-            orig_display_error_message(ex)
+      module Handler
+        def self.included(base)
+          base.class_eval do
+            alias_method :orig_display_error_message, :display_error_message
+            alias_method :display_error_message, :display_error_message_with_rollbar
           end
         end
+
+        def display_error_message_with_rollbar(ex)
+          Rollbar.error(ex, :use_exception_level_filters => true)
+          orig_display_error_message(ex)
+        end
+      end
+
+      def self.patch!
+        unless patch?
+          skip_patch
+
+          return
+        end
+
+        ::Rake.application.instance_eval do
+          class << self
+            include ::Rollbar::Rake::Handler
+          end
+        end
+
+        self.patched = true
       end
 
       def self.skip_patch
@@ -23,11 +44,16 @@ Rollbar.plugins.define('rake') do
       end
 
       def self.patch?
+        return false if patched?
         return false unless rake_version
 
         major, minor, = rake_version.split('.').map(&:to_i)
 
         major > 0 || major == 0 && minor > 8
+      end
+
+      def self.patched?
+        patched
       end
 
       def self.rake_version

--- a/spec/rollbar/plugins/rake_spec.rb
+++ b/spec/rollbar/plugins/rake_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 Rollbar.plugins.load!
 
 describe Rollbar::Rake do
-  let(:application) { Rake::Application.new }
+  let(:application) { Rake.application }
   let(:exception) { Exception.new }
 
   context 'with supported rake version' do
@@ -12,7 +12,6 @@ describe Rollbar::Rake do
     end
 
     it 'reports error to Rollbar' do
-      expect(Rollbar::Rake).not_to receive(:skip_patch)
       expect(Rollbar).to receive(:error).with(exception, :use_exception_level_filters => true)
       expect(application).to receive(:orig_display_error_message).with(exception)
 


### PR DESCRIPTION
We are monkey patching Rake::Application so we can report Rake task
errors. In the way we were doing it we had conflicts with other gems
doing the same.