### PR TITLE
Send GET, POST and raw body in their correct place

### DIFF
--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -70,7 +70,7 @@ module Rollbar
 
           route_params = request_data[:params]
           # make sure route is a hash built by RequestDataExtractor
-          return "#{route_params[:controller]}" + '#' + "#{route_params[:action]}" if route_params.is_a?(Hash) && !route_params.empty?
+          return route_params[:controller].to_s + '#' + route_params[:action].to_s if route_params.is_a?(Hash) && !route_params.empty?
         end
       end
     end

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -66,11 +66,11 @@ module Rollbar
         end
 
         def context(request_data)
-          return unless request_data[:route]
+          return unless request_data[:params]
 
-          route = request_data[:route]
+          route_params = request_data[:params]
           # make sure route is a hash built by RequestDataExtractor
-          return "#{route[:controller]}" + '#' + "#{route[:action]}" if route.is_a?(Hash) && !route.empty?
+          return "#{route_params[:controller]}" + '#' + "#{route_params[:action]}" if route_params.is_a?(Hash) && !route_params.empty?
         end
       end
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -356,7 +356,7 @@ describe HomeController do
       expect { get '/foo/bar', { :foo => :bar } }.to raise_exception(ActionController::RoutingError)
 
       report = Rollbar.last_report
-      expect(report[:request][:params]['foo']).to be_eql('bar')
+      expect(report[:request][:GET]['foo']).to be_eql('bar')
     end
   end
 
@@ -378,7 +378,7 @@ describe HomeController do
       it "saves attachment data" do
         expect { post '/file_upload', { :upload => file1 } }.to raise_exception(NameError)
 
-        upload_param = Rollbar.last_report[:request][:params]['upload']
+        upload_param = Rollbar.last_report[:request][:POST]['upload']
 
         expect(upload_param).to have_key(:filename)
         expect(upload_param).to have_key(:type)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -53,7 +53,6 @@ describe HomeController do
       data.should have_key(:headers)
       data.should have_key(:session)
       data.should have_key(:method)
-      data.should have_key(:route)
     end
 
     it "should build empty person data when no one is logged-in" do
@@ -169,21 +168,10 @@ describe HomeController do
     end
 
     context "rollbar_route_params", :type => 'request' do
-      it "should save route params in request[:route]" do
-        route = controller.send(:rollbar_request_data)[:route]
-
-        route.should have_key(:controller)
-        route.should have_key(:action)
-        route.should have_key(:format)
-
-        route[:controller].should == 'home'
-        route[:action].should == 'index'
-      end
-
       it "should save controller and action in the payload body" do
         post '/report_exception'
 
-        route = controller.send(:rollbar_request_data)[:route]
+        route = controller.send(:rollbar_request_data)[:params]
 
         route[:controller].should == 'home'
         route[:action].should == 'report_exception'
@@ -206,7 +194,7 @@ describe HomeController do
 
       post '/report_exception', params
 
-      filtered = Rollbar.last_report[:request][:params]
+      filtered = Rollbar.last_report[:request][:POST]
 
       expect(filtered["passwd"]).to match(/\**/)
       expect(filtered["password"]).to match(/\**/)
@@ -229,7 +217,7 @@ describe HomeController do
 
       post '/report_exception', params
 
-      filtered = Rollbar.last_report[:request][:params]
+      filtered = Rollbar.last_report[:request][:POST]
 
       filtered["passwd"].should == "visible"
       # config.filter_parameters is set to [:password] in
@@ -262,7 +250,7 @@ describe HomeController do
       put '/report_exception', { :putparam => "putval" }
 
       Rollbar.last_report.should_not be_nil
-      Rollbar.last_report[:request][:params]["putparam"].should == "putval"
+      Rollbar.last_report[:request][:POST]["putparam"].should == "putval"
     end
 
     context 'using deprecated report_exception' do
@@ -272,7 +260,7 @@ describe HomeController do
         put '/deprecated_report_exception', { :putparam => "putval" }
 
         Rollbar.last_report.should_not be_nil
-        Rollbar.last_report[:request][:params]["putparam"].should == "putval"
+        Rollbar.last_report[:request][:POST]["putparam"].should == "putval"
       end
     end
 
@@ -284,7 +272,7 @@ describe HomeController do
       post '/report_exception', params, { 'CONTENT_TYPE' => 'application/json' }
 
       Rollbar.last_report.should_not be_nil
-      Rollbar.last_report[:request][:params]['jsonparam'].should == 'jsonval'
+      expect(Rollbar.last_report[:request][:body]).to be_eql(params)
     end
   end
 
@@ -392,7 +380,7 @@ describe HomeController do
     context 'with multiple uploads', :type => :request do
       it "saves attachment data for all uploads" do
         expect { post '/file_upload', { :upload => [file1, file2] } }.to raise_exception(NameError)
-        sent_params = Rollbar.last_report[:request][:params]['upload']
+        sent_params = Rollbar.last_report[:request][:POST]['upload']
 
         expect(sent_params).to be_kind_of(Array)
         expect(sent_params.size).to be(2)
@@ -420,7 +408,7 @@ describe HomeController do
         post '/cause_exception', params, { 'ACCEPT' => 'application/vnd.github.v3+json' }
       end.to raise_exception(NameError)
 
-      expect(Rollbar.last_report[:request][:params]['foo']).to be_eql('bar')
+      expect(Rollbar.last_report[:request][:POST]['foo']).to be_eql('bar')
     end
   end
 

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -115,7 +115,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           get '/foo', params
         end.to raise_error(exception)
 
-        expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+        expect(Rollbar.last_report[:request][:GET]).to be_eql(params)
       end
     end
 
@@ -132,7 +132,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           post '/crash_post', params
         end.to raise_error(exception)
 
-        expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+        expect(Rollbar.last_report[:request][:POST]).to be_eql(params)
       end
     end
 
@@ -149,7 +149,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           post '/crash_post', params.to_json, { 'CONTENT_TYPE' => 'application/json' }
         end.to raise_error(exception)
 
-        expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+        expect(Rollbar.last_report[:request][:body]).to be_eql(params.to_json)
       end
 
       it 'appears in the sent payload when the accepts header contains json' do
@@ -157,7 +157,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           post '/crash_post', params, { 'ACCEPT' => 'application/vnd.github.v3+json' }
         end.to raise_error(exception)
 
-        expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+        expect(Rollbar.last_report[:request][:POST]).to be_eql(params)
       end
     end
 

--- a/spec/rollbar/plugins/rack_spec.rb
+++ b/spec/rollbar/plugins/rack_spec.rb
@@ -41,11 +41,11 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
         request.get('/will_crash', :params => params)
       end.to raise_error(exception)
 
-      expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+      expect(Rollbar.last_report[:request][:GET]).to be_eql(params)
     end
   end
 
-  context 'with POST parameters' do
+  context 'with JSON body parameters' do
     let(:params) do
       { 'key' => 'value' }
     end
@@ -55,7 +55,7 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
         request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
-      expect(Rollbar.last_report[:request][:params]).to be_eql(params)
+      expect(Rollbar.last_report[:request][:body]).to be_eql(params.to_json)
     end
   end
 
@@ -69,8 +69,8 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
         request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
-      reported_params = Rollbar.last_report[:request][:params]
-      expect(reported_params['body.multi']).to be_eql([{'key' => 'value'}, 'string', 10])
+      reported_body = Rollbar.last_report[:request][:body]
+      expect(reported_body).to be_eql({ 'body.multi' => [{'key' => 'value'}, 'string', 10] }.to_json)
     end
   end
 
@@ -82,8 +82,8 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
         request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
-      reported_params = Rollbar.last_report[:request][:params]
-      expect(reported_params['body.value']).to be_eql(1000)
+      reported_body = Rollbar.last_report[:request][:body]
+      expect(reported_body).to be_eql({ 'body.value' => params }.to_json)
     end
   end
 

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -71,7 +71,7 @@ describe Rollbar::RequestDataExtractor do
   describe '#extract_request_data_from_rack' do
     it 'returns a Hash object' do
       expect(Rollbar::Scrubbers::URL).to receive(:call).with(kind_of(Hash)).and_call_original
-      expect(Rollbar::Scrubbers::Params).to receive(:call).with(kind_of(Hash)).and_call_original.exactly(7)
+      expect(Rollbar::Scrubbers::Params).to receive(:call).with(kind_of(Hash)).and_call_original.exactly(6)
 
       result = subject.extract_request_data_from_rack(env)
 

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -150,5 +150,55 @@ describe Rollbar::RequestDataExtractor do
         end
       end
     end
+
+    context 'with JSON POST body' do
+      let(:params) { { 'key' => 'value' } }
+      let(:body) { params.to_json }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  'CONTENT_TYPE' => 'application/json',
+                                  :input => body,
+                                  :method => 'POST')
+
+
+      end
+
+      it 'extracts the correct user IP' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:body]).to be_eql(body)
+      end
+    end
+
+    context 'with POST params' do
+      let(:params) { { 'key' => 'value' } }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  :params => params,
+                                  :method => 'POST')
+
+
+      end
+
+      it 'extracts the correct user IP' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:POST]).to be_eql(params)
+      end
+    end
+
+    context 'with GET params' do
+      let(:params) { { 'key' => 'value' } }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  :params => params,
+                                  :method => 'GET')
+
+
+      end
+
+      it 'extracts the correct user IP' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:GET]).to be_eql(params)
+      end
+    end
   end
 end


### PR DESCRIPTION
We are sending the GET, POST, JSON body and the Rails request parameters in `params`. According to our API specification we can send `GET`, `POST`, `body` and `params` keys in the request data.

This PR just fix that sending the correct data in the correct places.