### PR TITLE
Add note about requiring hashrocket syntax

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -55,6 +55,7 @@ Rollbar.configure do |config|
   # Enable delayed reporting (using Sidekiq)
   # config.use_sidekiq
   # You can supply custom Sidekiq options:
+  # Hashrocket syntax required
   # config.use_sidekiq 'queue' => 'default'
 
   # If you run your staging application instance in production environment then


### PR DESCRIPTION
I spent some time figuring out why my errors weren't being sent off to Rollbar. It turns out defining the queue as `config.use_sidekiq queue: 'default'` isn't valid. Hashrocket syntax is required.