### PR TITLE
Handle new exception message structure from sidekiq >= 4.2.3

### DIFF
--- a/lib/rollbar/plugins/sidekiq/plugin.rb
+++ b/lib/rollbar/plugins/sidekiq/plugin.rb
@@ -3,7 +3,7 @@ require 'rollbar/scrubbers/params'
 module Rollbar
   class Sidekiq
     PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class]
-    NEW_MESSAGE_STRUCTURE_VERSION = '4.2.3'
+    NEW_MESSAGE_STRUCTURE_VERSION = '4.2.3'.freeze
 
     class ClearScope
       def call(worker, msg, queue)

--- a/lib/rollbar/plugins/sidekiq/plugin.rb
+++ b/lib/rollbar/plugins/sidekiq/plugin.rb
@@ -3,6 +3,7 @@ require 'rollbar/scrubbers/params'
 module Rollbar
   class Sidekiq
     PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class]
+    NEW_MESSAGE_STRUCTURE_VERSION = '4.2.3'
 
     class ClearScope
       def call(worker, msg, queue)
@@ -13,6 +14,7 @@ module Rollbar
     end
 
     def self.handle_exception(msg_or_context, e)
+      msg_or_context = fetch_message_by_version(msg_or_context)
       return if skip_report?(msg_or_context, e)
 
       params = msg_or_context.reject{ |k| PARAM_BLACKLIST.include?(k) }
@@ -27,6 +29,14 @@ module Rollbar
       end
 
       Rollbar.scope(scope).error(e, :use_exception_level_filters => true)
+    end
+
+    def self.fetch_message_by_version(msg_or_context)
+      if Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new(NEW_MESSAGE_STRUCTURE_VERSION)
+        msg_or_context[:job]
+      else
+        msg_or_context
+      end
     end
 
     def self.scrub_params(params)

--- a/spec/rollbar/plugins/sidekiq_spec.rb
+++ b/spec/rollbar/plugins/sidekiq_spec.rb
@@ -7,6 +7,27 @@ end
 Rollbar.plugins.load!
 
 describe Rollbar::Sidekiq, :reconfigure_notifier => false do
+  describe "#fetch_message_by_version" do
+    context "sidekiq version with new message structure" do
+      let(:msg_or_context) { { context: "Some context", job: { some: "job" } } }
+
+      it "should return job" do
+        puts Sidekiq::VERSION
+        stub_const("Sidekiq::VERSION", "4.2.3")
+        expect(described_class.fetch_message_by_version(msg_or_context)).to eq({ some: "job" })
+      end
+    end
+
+    context "sidekiq version with old message structure" do
+      let(:msg_or_context) { { some: "job" } }
+
+      it "should return job" do
+        stub_const("Sidekiq::VERSION", "4.2.2")
+        expect(described_class.fetch_message_by_version(msg_or_context)).to eq({ some: "job" })
+      end
+    end
+  end
+
   describe '.handle_exception' do
     let(:msg_or_context) { ['hello', 'error_backtrace', 'backtrace', 'goodbye'] }
     let(:exception) { StandardError.new('oh noes') }


### PR DESCRIPTION
## Problem
`config.sidekiq_threshold = x` doesn't work for sidekiq >= 4.2.3
In 4.2.3 sidekiq changed message format passed to `#handle_exception`. Now it always have format of `{context: 'Context', job: {...}}`.

## Solution
When sidekiq version is >= 4.2.3, fetch :job from message.

Made it work also with older sidekiq versions and wrote specs for this method.