### PR TITLE
Send request body on DELETE request

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -10,6 +10,7 @@ require 'rollbar/json'
 module Rollbar
   module RequestDataExtractor
     ALLOWED_HEADERS_REGEX = /^HTTP_|^CONTENT_TYPE$|^CONTENT_LENGTH$/
+    ALLOWED_BODY_PARSEABLE_METHODS = %w(POST PUT PATCH DELETE).freeze
 
     def extract_person_data_from_controller(env)
       if env.has_key?('rollbar.person_data')
@@ -168,7 +169,7 @@ module Rollbar
     end
 
     def rollbar_raw_body_params(rack_req)
-      correct_method = rack_req.post? || rack_req.put? || rack_req.patch?
+      correct_method = ALLOWED_BODY_PARSEABLE_METHODS.include?(rack_req.request_method)
 
       return {} unless correct_method
       return {} unless json_request?(rack_req)

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -169,6 +169,42 @@ describe Rollbar::RequestDataExtractor do
       end
     end
 
+    context 'with JSON DELETE body' do
+      let(:params) { { 'key' => 'value' } }
+      let(:body) { params.to_json }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  'CONTENT_TYPE' => 'application/json',
+                                  :input => body,
+                                  :method => 'DELETE')
+
+
+      end
+
+      it 'extracts the correct user IP' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:body]).to be_eql(body)
+      end
+    end
+
+    context 'with JSON PUT body' do
+      let(:params) { { 'key' => 'value' } }
+      let(:body) { params.to_json }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  'CONTENT_TYPE' => 'application/json',
+                                  :input => body,
+                                  :method => 'PUT')
+
+
+      end
+
+      it 'extracts the correct user IP' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:body]).to be_eql(body)
+      end
+    end
+
     context 'with POST params' do
       let(:params) { { 'key' => 'value' } }
       let(:env) do


### PR DESCRIPTION
It seems that customers are sending body data in their DELETE
request. In general those bodies are ignored by few servers but not
always and not all of them.

So, just allow DELETE requests to be body parseable.