### PR TITLE
Add Rollbar::Middleware::Rack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,28 +62,13 @@ $ heroku config:add ROLLBAR_ACCESS_TOKEN=POST_SERVER_ITEM_ACCESS_TOKEN
 That's all you need to use Rollbar with Rails.
 
 
-### Rack
+### Sinatra
 
 Initialize Rollbar with your access token somewhere during startup:
 
 ```ruby
 Rollbar.configure do |config|
   config.access_token = 'POST_SERVER_ITEM_ACCESS_TOKEN'
-  # other configuration settings
-  # ...
-end
-```
-
-<!-- RemoveNextIfProject -->
-Be sure to replace ```POST_SERVER_ITEM_ACCESS_TOKEN``` with your project's ```post_server_item``` access token, which you can find in the Rollbar.com interface.
-
-This monkey patches `Rack::Builder` to work with Rollbar automatically.
-
-For more control, disable the monkey patch:
-
-```ruby
-Rollbar.configure do |config|
-  config.disable_monkey_patch = true
   # other configuration settings
   # ...
 end
@@ -99,6 +84,40 @@ class MyApp < Sinatra::Base
   # other middleware/etc
   # ...
 end
+```
+
+
+### Rack
+
+Initialize Rollbar with your access token somewhere during startup:
+
+```ruby
+Rollbar.configure do |config|
+  config.access_token = 'POST_SERVER_ITEM_ACCESS_TOKEN'
+  # other configuration settings
+  # ...
+end
+```
+
+<!-- RemoveNextIfProject -->
+Be sure to replace ```POST_SERVER_ITEM_ACCESS_TOKEN``` with your project's ```post_server_item``` access token, which you can find in the Rollbar.com interface.
+
+The gem monkey patches `Rack::Builder` so Rollbar reports will be sent automatically without any other action. If you prefer to disable the monkey patch apply this change to your config:
+
+```ruby
+Rollbar.configure do |config|
+  config.disable_rack_monkey_patch = true
+  # other configuration settings
+  # ...
+end
+```
+
+If you disabled the `Rack::Builder` monkey patch or it doesn't work for the Rack framework you are using, then add our Rack middleware to your app:
+
+```ruby
+require 'rollbar/middleware/rack
+
+use Rollbar::Middleware::Rack
 ```
 
 ### Plain Ruby
@@ -370,6 +389,8 @@ class RollbarPersonData
 end
 
 # You can add the middleware to your application, for example:
+
+require 'rollbar/middleware/sinatra'
 
 class App < Sinatra::Base
   use Rollbar::Middleware::Sinatra

--- a/lib/rollbar/middleware/rack.rb
+++ b/lib/rollbar/middleware/rack.rb
@@ -1,0 +1,49 @@
+require 'rollbar'
+require 'rollbar/exception_reporter'
+require 'rollbar/request_data_extractor'
+
+module Rollbar
+  module Middleware
+    class Rack
+      include ::Rollbar::ExceptionReporter
+      include RequestDataExtractor
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Rollbar.reset_notifier!
+
+        Rollbar.scoped(fetch_scope(env)) do
+          begin
+            response = @app.call(env)
+            report_exception_to_rollbar(env, framework_error(env)) if framework_error(env)
+            response
+          rescue Exception => e
+            report_exception_to_rollbar(env, e)
+            raise
+          end
+        end
+      end
+
+      def fetch_scope(env)
+        {
+          :request => proc { extract_request_data_from_rack(env) },
+          :person => person_data_proc(env)
+        }
+      rescue Exception => e
+        report_exception_to_rollbar(env, e)
+        raise
+      end
+
+      def person_data_proc(env)
+        proc { extract_person_data_from_controller(env) }
+      end
+
+      def framework_error(env)
+        nil
+      end
+    end
+  end
+end

--- a/lib/rollbar/middleware/rack/builder.rb
+++ b/lib/rollbar/middleware/rack/builder.rb
@@ -3,7 +3,7 @@ require 'rollbar/request_data_extractor'
 
 module Rollbar
   module Middleware
-    module Rack
+    class Rack
       module Builder
         include ExceptionReporter
         include RequestDataExtractor

--- a/lib/rollbar/middleware/rack/test_session.rb
+++ b/lib/rollbar/middleware/rack/test_session.rb
@@ -1,6 +1,6 @@
 module Rollbar
   module Middleware
-    module Rack
+    class Rack
       module TestSession
         include ExceptionReporter
 

--- a/lib/rollbar/middleware/sinatra.rb
+++ b/lib/rollbar/middleware/sinatra.rb
@@ -1,46 +1,8 @@
-require 'rollbar'
-require 'rollbar/exception_reporter'
-require 'rollbar/request_data_extractor'
+require 'rollbar/middleware/rack'
 
 module Rollbar
   module Middleware
-    class Sinatra
-      include ::Rollbar::ExceptionReporter
-      include RequestDataExtractor
-
-      def initialize(app)
-        @app = app
-      end
-
-      def call(env)
-        Rollbar.reset_notifier!
-
-        Rollbar.scoped(fetch_scope(env)) do
-          begin
-            response = @app.call(env)
-            report_exception_to_rollbar(env, framework_error(env)) if framework_error(env)
-            response
-          rescue Exception => e
-            report_exception_to_rollbar(env, e)
-            raise
-          end
-        end
-      end
-
-      def fetch_scope(env)
-        {
-          :request => proc { extract_request_data_from_rack(env) },
-          :person => person_data_proc(env)
-        }
-      rescue Exception => e
-        report_exception_to_rollbar(env, e)
-        raise
-      end
-
-      def person_data_proc(env)
-        proc { extract_person_data_from_controller(env) }
-      end
-
+    class Sinatra < Rollbar::Middleware::Rack
       def framework_error(env)
         env['sinatra.error']
       end

--- a/lib/rollbar/plugins/rack.rb
+++ b/lib/rollbar/plugins/rack.rb
@@ -4,11 +4,13 @@ Rollbar.plugins.define('rack') do
 
   execute do
     if defined?(Rack::Builder)
+      require 'rollbar/middleware/rack'
       require 'rollbar/middleware/rack/builder'
       Rack::Builder.send(:include, Rollbar::Middleware::Rack::Builder)
     end
 
     if defined?(Rack::Test::Session)
+      require 'rollbar/middleware/rack'
       require 'rollbar/middleware/rack/test_session'
       Rack::Test::Session.send(:include, Rollbar::Middleware::Rack::TestSession)
     end

--- a/spec/rollbar/plugins/rack_spec.rb
+++ b/spec/rollbar/plugins/rack_spec.rb
@@ -16,11 +16,11 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
   let(:app) do
     action_proc = action
 
-    Rack::Builder.new { run action_proc }
+    ::Rack::Builder.new { run action_proc }
   end
 
   let(:request) do
-    Rack::MockRequest.new(app)
+    ::Rack::MockRequest.new(app)
   end
 
   let(:exception) { kind_of(RackMockError) }


### PR DESCRIPTION
Convert `Rollbar::Middleware::Rack` to be a class instead of a module,
so it can be added to the Rack middleware chain with `use
Rollbar::Middleware::Rack`.

Also, move the code from `Rollbar::Middleware::Sinatra` to
`Rollbar::Middleware::Rack` since Sinatra behavior is a subset of Rack
behavior.