### PR TITLE
Add host configuration option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,12 @@ tracked by [rollbar-agent](https://github.com/rollbar/rollbar-agent).
 Indicates which framework you're using. Common options include 'Rails',
 'Sinatra', and 'Rack' to name a few.
 
+### host
+
+**Default** `nil`
+
+The hostname (reported to Rollbar as `server.host`). When nil, the value of `Socket.gethostname` will be used.
+
 ### ignored_person_ids
 
 **Default** `[]`

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,6 +3,7 @@ require 'rubygems/version'
 source "https://rubygems.org"
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
+is_not_jruby = !is_jruby
 
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "jruby-openssl", :platform => :jruby
@@ -18,16 +19,10 @@ gem 'rake'
 
 gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'sucker_punch', '~> 1.0'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'sucker_punch', '~> 2.0'
-end
-
-if RUBY_VERSION.start_with?('2.4')
-  gem 'oj', '~> 2.16.0' unless is_jruby
-else
-  gem 'oj', '~> 2.12.14' unless is_jruby
+if RUBY_VERSION.start_with?('2.4') && is_not_jruby
+  gem 'oj', '~> 2.16.0'
+elsif is_not_jruby
+  gem 'oj', '~> 2.12.14'
 end
 
 gem 'sinatra'
@@ -39,12 +34,16 @@ gem 'girl_friday', '>= 0.11.1'
 gem 'generator_spec'
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
 
+gem 'nokogiri', '~> 1.6.0' if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0')
+
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
   gem 'public_suffix', '< 1.5'
   gem 'webmock', '< 2.3.0', :require => false
+  gem 'sucker_punch', '~> 1.0'
 else
   gem 'webmock', :require => false
+  gem 'sucker_punch', '~> 2.0'
 end
 
 

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -24,6 +24,7 @@ module Rollbar
     attr_accessor :filepath
     attr_accessor :framework
     attr_accessor :ignored_person_ids
+    attr_accessor :host
     attr_writer :logger
     attr_accessor :payload_options
     attr_accessor :person_method

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -194,7 +194,7 @@ module Rollbar
 
     def server_data
       data = {
-        :host => Socket.gethostname
+        :host => configuration.host || Socket.gethostname
       }
       data[:root] = configuration.root.to_s if configuration.root
       data[:branch] = configuration.branch if configuration.branch

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -585,6 +585,18 @@ describe Rollbar::Item do
         payload['data'][:server][:root].should == '/path/to/root'
         payload['data'][:server][:branch].should == 'master'
       end
+
+      context 'with custom hostname' do
+        before do
+          configuration.host = host
+        end
+
+        let(:host) { 'my-custom-hostname' }
+
+        it 'sends the custom hostname' do
+          expect(payload['data'][:server][:host]).to be_eql(host)
+        end
+      end
     end
 
     context 'with ignored person ids' do


### PR DESCRIPTION
Allows using a custom value for the host name. Usage:

```ruby
Rollbar.configure do |config|
  config.host = 'my-custom-host'
end
```
Close #540 