### PR TITLE
Remove warning on @root_notifier cause not initialized

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -190,6 +190,8 @@ module Rollbar
       end
     end
   end
+
+  self.root_notifier = nil
 end
 
 Rollbar.plugins.require_all


### PR DESCRIPTION
Related to #544 