### PR TITLE
Ensure params filtering take precedence over hash/array objects

### DIFF
--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -53,13 +53,15 @@ module Rollbar
         return scrub_array(params, options) if params.is_a?(Array)
 
         params.to_hash.inject({}) do |result, (key, value)|
-          if value.is_a?(Hash)
+          if fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s
+            result[key] = Rollbar::Scrubbers.scrub_value(value)
+          elsif value.is_a?(Hash)
             result[key] = scrub(value, options)
           elsif value.is_a?(Array)
             result[key] = scrub_array(value, options)
           elsif skip_value?(value)
             result[key] = "Skipped value of class '#{value.class.name}'"
-          elsif fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s || scrub_all
+          elsif scrub_all
             result[key] = Rollbar::Scrubbers.scrub_value(value)
           else
             result[key] = rollbar_filtered_param_value(value)

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -53,7 +53,7 @@ module Rollbar
         return scrub_array(params, options) if params.is_a?(Array)
 
         params.to_hash.inject({}) do |result, (key, value)|
-          if fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s
+          if fields_regex === Rollbar::Encoding.encode(key).to_s
             result[key] = scrub_value(value)
           elsif value.is_a?(Hash)
             result[key] = scrub(value, options)

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -54,7 +54,7 @@ module Rollbar
 
         params.to_hash.inject({}) do |result, (key, value)|
           if fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s
-            result[key] = Rollbar::Scrubbers.scrub_value(value)
+            result[key] = scrub_value(value)
           elsif value.is_a?(Hash)
             result[key] = scrub(value, options)
           elsif value.is_a?(Array)
@@ -62,7 +62,7 @@ module Rollbar
           elsif skip_value?(value)
             result[key] = "Skipped value of class '#{value.class.name}'"
           elsif scrub_all
-            result[key] = Rollbar::Scrubbers.scrub_value(value)
+            result[key] = scrub_value(value)
           else
             result[key] = rollbar_filtered_param_value(value)
           end
@@ -75,6 +75,10 @@ module Rollbar
         array.map do |value|
           value.is_a?(Hash) ? scrub(value, options) : rollbar_filtered_param_value(value)
         end
+      end
+
+      def scrub_value(value)
+        Rollbar::Scrubbers.scrub_value(value)
       end
 
       def rollbar_filtered_param_value(value)

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -78,6 +78,10 @@ describe Rollbar::Scrubbers::Params do
       end
 
       context 'with nested Hash' do
+        let(:scrub_config) do
+          super().push(:other)
+        end
+
         let(:params) do
           {
             :foo => 'bar',
@@ -85,6 +89,9 @@ describe Rollbar::Scrubbers::Params do
               :secret => 'the-secret',
               :password => 'the-password',
               :password_confirmation => 'the-password'
+            },
+            :other => {
+              :param => 'filtered'
             }
           }
         end
@@ -95,7 +102,8 @@ describe Rollbar::Scrubbers::Params do
               :secret => /\*+/,
               :password => /\*+/,
               :password_confirmation => /\*+/
-            }
+            },
+            :other => /\*+/
           }
         end
 
@@ -105,6 +113,10 @@ describe Rollbar::Scrubbers::Params do
       end
 
       context 'with nested Array' do
+        let(:scrub_config) do
+          super().push(:other)
+        end
+
         let(:params) do
           {
             :foo => 'bar',
@@ -112,6 +124,9 @@ describe Rollbar::Scrubbers::Params do
               :secret => 'the-secret',
               :password => 'the-password',
               :password_confirmation => 'the-password'
+            }],
+            :other => [{
+              :param => 'filtered'
             }]
           }
         end
@@ -122,7 +137,8 @@ describe Rollbar::Scrubbers::Params do
               :secret => /\*+/,
               :password => /\*+/,
               :password_confirmation => /\*+/
-            }]
+            }],
+            :other => /\*+/
           }
         end
 


### PR DESCRIPTION
This matches the current Rails implementation of parameter filtering, where it is possible to set a filter that will hide an entire array or nested hash, instead of just the inner keys.

Consider the following params payload:

```ruby
    user: { username: "foo", password: "bar" }
```

Currently we can set a filter for both "username" and "password", but setting for the entire "user" params hash does not work, it's simply ignored, because we parse hashes separately looking at each individual key first - before checking the configured filter.

With this change, setting a filter for "user" would effectively hide it from the payload, scrubbing the field as expected, since we first check the filter before proceeding with other processing.

---

Unrelated: I'm getting this failure locally on both master and this branch:

```
  1) Rollbar project_gems should handle regex gem patterns
     Failure/Error: gem_paths.length.should > 1

       expected: > 1
            got:   1
     # ./spec/rollbar_spec.rb:1173:in `block (3 levels) in <top (required)>'
```

I haven't stopped to check it properly, but doesn't seem to be related to the changes here since it's also happening on master.

Let me know if I can help with anything!