### PR TITLE
Scrub keys from hash arguments

### DIFF
--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -52,14 +52,18 @@ module Rollbar
 
         return scrub_array(params, options) if params.is_a?(Array)
 
+        should_scrub = ->(key) { scrub_all || fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s }
+
         params.to_hash.inject({}) do |result, (key, value)|
-          if value.is_a?(Hash)
+          if should_scrub.call(key)
+            result[key] = Rollbar::Scrubbers.scrub_value(value)
+          elsif value.is_a?(Hash)
             result[key] = scrub(value, options)
           elsif value.is_a?(Array)
             result[key] = scrub_array(value, options)
           elsif skip_value?(value)
             result[key] = "Skipped value of class '#{value.class.name}'"
-          elsif fields_regex && fields_regex =~ Rollbar::Encoding.encode(key).to_s || scrub_all
+          elsif should_scrub.call(key)
             result[key] = Rollbar::Scrubbers.scrub_value(value)
           else
             result[key] = rollbar_filtered_param_value(value)

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -271,10 +271,7 @@ describe Rollbar::Scrubbers::Params do
           :foo => /\*+/,
           :password => /\*+/,
           :bar => /\*+/,
-          :extra => {
-            :foo => /\*+/,
-            :bar => /\*+/
-          }
+          :extra => /\*+/
         }
       end
 
@@ -296,3 +293,4 @@ describe Rollbar::Scrubbers::Params::SKIPPED_CLASSES do
     expect(described_class).to be_eql([Tempfile])
   end
 end
+


### PR DESCRIPTION
This is an attempt to filter out large elements from a body of a POST message, that rollbar is attempting to post in the content of an error.

The environment is a rack app (running in puma). A post request with a structure similar to below causes an error - 

```
 {
   "foo": 1,
   "blob": "very large data"
 }
 
```

The rollbar configuration has:
 
config.scrub_fields = [:blob]

but despite that, blob is included in the payload (and posting the error fails due to size).


This PR ensures that the hash keys included in the scrub_fields are excluded from the payload.

Does this ring right?

