### PR TITLE
Set revision at rollback

### DIFF
--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -31,6 +31,15 @@ namespace :rollbar do
 end
 
 namespace :deploy do
+  task :get_current_revision do
+    on primary fetch(:rollbar_role) do
+      within release_path do
+        set(:current_revision, capture(:cat, 'REVISIONS'))
+      end
+    end
+  end
+
+  after 'deploy:finishing_rollback', 'deploy:get_current_revision'
   after 'deploy:finished', 'rollbar:deploy'
 end
 


### PR DESCRIPTION
When Capistrano does not set the current revision at the time of
rollback, an item that there is no revision is notified to the rollbar.