### PR TITLE
get session from env instead of request

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -31,7 +31,7 @@ module Rollbar
       post_params = scrub_params(rollbar_post_params(rack_req), sensitive_params)
       raw_body_params = scrub_params(mergeable_raw_body_params(rack_req), sensitive_params)
       cookies = scrub_params(rollbar_request_cookies(rack_req), sensitive_params)
-      session = scrub_params(rollbar_request_session(rack_req), sensitive_params)
+      session = scrub_params(rollbar_request_session(env), sensitive_params)
       route_params = scrub_params(rollbar_route_params(env), sensitive_params)
 
       url = scrub_url(rollbar_url(env), sensitive_params)
@@ -201,8 +201,8 @@ module Rollbar
       end
     end
 
-    def rollbar_request_session(rack_req)
-      session = rack_req.session
+    def rollbar_request_session(env)
+      session = env.fetch('rack.session', {})
 
       session.to_hash
     rescue


### PR DESCRIPTION
`Rack::Session` and `ActionDispatch::Session` populate `env['rack.session']` with an empty hash unless another value has already been set (e.g., a session object). If any errors are rescued or reported in middleware between Rollbar's middleware and the default Rails session initialization middleware, this value would have been set, and will create issues when trying to prepare the session later on. I.e., calling Rollbar too early nukes the request by mutating the env.

Issue found on Rack 1.5.5, Rails 4.1.16. Newer versions of Rack also set this default value (but in a slightly different way), so it should apply there as well.