### PR TITLE
Add Configuration#use_exception_level_filters option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,12 @@ gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,12 @@ installed, uses `girl_friday`, otherwise defaults to `Thread`.
 When `true` indicates you wish to send data to Rollbar with `eventmachine`.
 Won't work unless `eventmachine` is installed.
 
+### use_exception_level_filters_default
+
+**Default** `false`
+
+When `true` the notifier will use the `exception_level_filters` when reporting. It can be overriden using `:use_exception_level_filters` option. see [Exception level filters](https://github.com/rollbar/rollbar-gem#exception-level-filters)
+
 ### web_base
 
 **Default** `'https://rollbar.com'`

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -15,7 +15,13 @@ gem 'rspec-rails', '>= 2.14.0'
 gem 'celluloid', '< 0.17.0' if RUBY_VERSION == '1.9.2'
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7'
+  if RUBY_VERSION < '2.2.2'
+    gem 'sidekiq', '>= 2.13.0', '< 5.0'
+  else
+    gem 'sidekiq', '>= 2.13.0'
+  end
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -43,7 +43,11 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'sidekiq', '< 2.13.0'
 else
   gem 'webmock', :require => false
-  gem 'sidekiq', '>= 2.13.0'
+  if RUBY_VERSION < '2.2.2'
+    gem 'sidekiq', '>= 2.13.0', '< 5.0'
+  else
+    gem 'sidekiq', '>= 2.13.0'
+  end
 end
 
 gem 'resque'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -15,7 +15,11 @@ gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 gem 'test-unit'
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -15,7 +15,11 @@ gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 gem 'test-unit'
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -13,7 +13,11 @@ gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -13,7 +13,11 @@ gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -19,7 +19,11 @@ gem 'rspec-mocks', '~> 3.5.0.beta3'
 gem 'rake'
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/ruby_1_8_and_1_9_2.gemfile
+++ b/gemfiles/ruby_1_8_and_1_9_2.gemfile
@@ -6,7 +6,6 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 
 gem 'appraisal', '= 1.0.2'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-gem 'celluloid', '< 0.17.0' if RUBY_VERSION == '1.9.2'
 gem 'hitimes', '< 1.2.2'
 gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '3.0.20'
@@ -15,7 +14,9 @@ gem 'rspec-rails', '>= 2.14.0'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 
 gem 'oj', '~> 2.12.14' unless is_jruby
-gem 'sidekiq', '>= 2.13.0' if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+end
 
 platforms :rbx do
   gem 'minitest'
@@ -25,6 +26,7 @@ platforms :rbx do
 end
 
 if RUBY_VERSION.start_with?('1.9')
+  gem 'celluloid', '< 0.17.0'
   gem 'sucker_punch', '~> 1.0'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -55,6 +55,7 @@ module Rollbar
     attr_accessor :web_base
     attr_accessor :write_to_file
     attr_reader :send_extra_frame_data
+    attr_accessor :use_exception_level_filters_default
 
     attr_reader :project_gem_paths
 
@@ -116,6 +117,7 @@ module Rollbar
       @write_to_file = false
       @send_extra_frame_data = :none
       @project_gem_paths = []
+      @use_exception_level_filters_default = false
     end
 
     def initialize_copy(orig)

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -123,7 +123,7 @@ module Rollbar
       return 'disabled' unless configuration.enabled
 
       message, exception, extra = extract_arguments(args)
-      use_exception_level_filters = extra && extra.delete(:use_exception_level_filters) == true
+      use_exception_level_filters = use_exception_level_filters?(extra)
 
       return 'ignored' if ignored?(exception, use_exception_level_filters)
 
@@ -290,6 +290,14 @@ module Rollbar
     end
 
     private
+
+    def use_exception_level_filters?(options)
+      option_value = options && options.delete(:use_exception_level_filters)
+
+      return option_value unless option_value.nil?
+
+      configuration.use_exception_level_filters_default
+    end
 
     def call_before_process(options)
       options = {

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -565,6 +565,16 @@ describe Rollbar do
 
           Rollbar.error(exception)
         end
+
+        it 'should not use the filters if overriden at log site' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'ignore' }
+          end
+
+          Rollbar.error(exception, :use_exception_level_filters => false)
+
+          expect(Rollbar.last_report[:level]).to be_eql('error')
+        end
       end
     end
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -536,6 +536,82 @@ describe Rollbar do
       Rollbar.error(exception).should == 'disabled'
     end
 
+    context 'using configuration.use_exception_level_filters_default' do
+      before do
+        Rollbar.configure do |config|
+          config.use_exception_level_filters_default = true
+        end
+      end
+
+      context 'without use_exception_level_filters argument' do
+        it 'sends the correct filtered level' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'warning' }
+          end
+
+          Rollbar.error(exception)
+
+          expect(Rollbar.last_report[:level]).to be_eql('warning')
+        end
+
+        it 'ignore ignored exception classes' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'ignore' }
+          end
+
+          logger_mock.should_not_receive(:info)
+          logger_mock.should_not_receive(:warn)
+          logger_mock.should_not_receive(:error)
+
+          Rollbar.error(exception)
+        end
+      end
+    end
+
+    context 'using :use_exception_level_filters option as true' do
+      it 'sends the correct filtered level' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'warning' }
+        end
+
+        Rollbar.error(exception, :use_exception_level_filters => true)
+        expect(Rollbar.last_report[:level]).to be_eql('warning')
+      end
+
+      it 'ignore ignored exception classes' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = { 'NameError' => 'ignore' }
+        end
+
+        logger_mock.should_not_receive(:info)
+        logger_mock.should_not_receive(:warn)
+        logger_mock.should_not_receive(:error)
+
+        Rollbar.error(exception, :use_exception_level_filters => true)
+      end
+
+      context 'using :use_exception_level_filters option as false' do
+        it 'sends the correct filtered level' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'warning' }
+          end
+
+          Rollbar.error(exception, :use_exception_level_filters => false)
+          expect(Rollbar.last_report[:level]).to be_eql('error')
+        end
+
+        it 'ignore ignored exception classes' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'ignore' }
+          end
+
+          Rollbar.error(exception, :use_exception_level_filters => false)
+
+          expect(Rollbar.last_report[:level]).to be_eql('error')
+        end
+      end
+    end
+
     context 'using :use_exception_level_filters option as true' do
       it 'sends the correct filtered level' do
         Rollbar.configure do |config|


### PR DESCRIPTION
Let the users to set a global `use_exception_level_filters` option

Usage:

```
Rollbar.configure do |config|
  config.use_exception_level_filters = true
end
```

By default the setting is `false` so we keep the current interface

Fix #587