### PR TITLE
Fixes: https://github.com/rollbar/rollbar-gem/issues/472

### DIFF
--- a/lib/rollbar/plugins/delayed_job/job_data.rb
+++ b/lib/rollbar/plugins/delayed_job/job_data.rb
@@ -32,6 +32,8 @@ module Rollbar
         return payload_object unless payload_object.respond_to?(:object)
 
         object_data(payload_object.object)
+      rescue
+        payload_object = job
       end
 
       def object_data(object)

--- a/lib/rollbar/plugins/delayed_job/job_data.rb
+++ b/lib/rollbar/plugins/delayed_job/job_data.rb
@@ -33,7 +33,7 @@ module Rollbar
 
         object_data(payload_object.object)
       rescue
-        payload_object = job
+        {}
       end
 
       def object_data(object)

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -10,7 +10,7 @@ module Rollbar
     class RollbarPlugin < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job, &Delayed::invoke_job_callback)
-        lifecycle.after(:failure) do |worker, job, *args, &block|
+        lifecycle.after(:failure) do |_, job, _, _|
           Delayed.report(job.last_error, job)
         end
       end

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -10,6 +10,9 @@ module Rollbar
     class RollbarPlugin < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job, &Delayed::invoke_job_callback)
+        lifecycle.after(:failure) do |worker, job, *args, &block|
+          Delayed.report(job.last_error, job)
+        end
       end
     end
 

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -35,10 +35,14 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
   end
 
   context 'with failed deserialization' do
+    let(:expected_args) do
+      [/Delayed::DeserializationError/, {:use_exception_level_filters=>true}]
+    end
+
     it 'sends the exception' do
       expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
       allow_any_instance_of(Delayed::Backend::Base).to receive(:payload_object).and_raise(Delayed::DeserializationError)
-      expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*expected_args)
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
     end

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -34,6 +34,15 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
     end
   end
 
+  context 'with failed deserialization' do
+    it 'sends the exception' do
+      expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
+      allow_any_instance_of(Delayed::Backend::Base).to receive(:payload_object).and_raise(Delayed::DeserializationError)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+
+      FailingJob.new.delay.do_job_please!(:foo, :bar)
+    end
+  end
 
   describe '.build_job_data' do
     let(:job) { double(:payload_object => {}) }


### PR DESCRIPTION
If there is every an error within the payload object itself, within delayed jobs, rollbar does not propagate that error, since delayed job fails to call the :invoke_job lifecycle hook and instead calls the :failure lifecycle hook.