### PR TITLE
Ignore empty ROLLBAR_ENV

### DIFF
--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -62,5 +62,5 @@ Rollbar.configure do |config|
   # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
   # setup for Heroku. See:
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
-  config.environment = ENV['ROLLBAR_ENV'] || Rails.env
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
 end


### PR DESCRIPTION
If ENV variables are not set, they appear as `nil` in ruby when accessed. If they are empty, they appear as en empty string `""` to ruby. An empty strings is true when used with `||` operator in ruby. As we want to have an environment set for Rollbar, we should use .presence to ignore empty ROLLBAR_ENV variables and use the Rails.env instead.

```bash
$ ENV_FOO=test ENV_BAR= be rails c
Loading development environment (Rails 5.0.3)
2.3.3 :001 > ENV['ENV_FOO']
 => "test" 
2.3.3 :002 > ENV['ENV_BAR']
 => "" 
2.3.3 :003 > ENV['ENV_BAZ']
 => nil 
```