### PR TITLE
Use :local_user variable

### DIFF
--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -36,7 +36,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :rollbar_user,      Proc.new { ENV['USER'] || ENV['USERNAME'] }
+    set :rollbar_user,      Proc.new { fetch :local_user, ENV['USER'] || ENV['USERNAME'] }
     set :rollbar_env,       Proc.new { fetch :rails_env, 'production' }
     set :rollbar_token,     Proc.new { abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'" }
     set :rollbar_role,      Proc.new { :app }


### PR DESCRIPTION
Capistrano 3.3.3 introduced `:local_user` and I think `:rollbar_user` should refer to this value.
In addition, this change allow users to change `:rollbar_user` by changing `:local_user`.