### PR TITLE
Add the option to stop sending non-project frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,15 @@ Rollbar.silenced {
   foo = bar  # will not be reported
 }
 ```
+## Non-project frames
+
+By default all backtrace frames are sent whether they are in-project frames or non-project frames. Since the backtrace can be very long and non-project frames are mostly irrelevant, you can configure Rollbar to only send the in-project frames by setting `send_non_project_frames` to either `true` or `false`. Example:
+
+```ruby
+Rollbar.configure do |config|
+   config.send_non_project_frames = true
+end
+```
 
 ## Sending backtrace without rescued exceptions
 

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -55,6 +55,7 @@ module Rollbar
     attr_accessor :web_base
     attr_accessor :write_to_file
     attr_reader :send_extra_frame_data
+    attr_accessor :send_non_project_frames
     attr_accessor :use_exception_level_filters_default
 
     attr_reader :project_gem_paths
@@ -116,6 +117,7 @@ module Rollbar
       @web_base = DEFAULT_WEB_BASE
       @write_to_file = false
       @send_extra_frame_data = :none
+      @send_non_project_frames = true
       @project_gem_paths = []
       @use_exception_level_filters_default = false
     end

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -77,7 +77,7 @@ module Rollbar
         exception_backtrace(current_exception).reverse.map do |frame|
           Rollbar::Item::Frame.new(self, frame,
                                    :configuration => configuration).to_h
-        end
+        end.compact
       end
 
       # Returns the backtrace to be sent to our API. There are 3 options:

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -21,7 +21,6 @@ module Rollbar
         # parse the line
         match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
         return unknown_frame unless match
-        
         return nil if !configuration.send_non_project_frames && outside_project?(match[1])
 
         filename = match[1]
@@ -83,7 +82,7 @@ module Rollbar
         # let's check it's in any of the Gem.path paths
         Gem.path.any? { |path| filename.start_with?(path) }
       end
-      
+ 
       def code_data(file_lines, lineno)
         file_lines[lineno - 1]
       end

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -21,6 +21,7 @@ module Rollbar
         # parse the line
         match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
         return unknown_frame unless match
+
         return nil if !configuration.send_non_project_frames && outside_project?(match[1])
 
         filename = match[1]

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -20,11 +20,9 @@ module Rollbar
       def to_h
         # parse the line
         match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
-
         return unknown_frame unless match
-
-        config = configuration.send_non_project_frames
-        return nil if !config && outside_project?(match[1])
+        
+        return nil if !configuration.send_non_project_frames && outside_project?(match[1])
 
         filename = match[1]
         lineno = match[2].to_i

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -23,6 +23,9 @@ module Rollbar
 
         return unknown_frame unless match
 
+        config = configuration.send_non_project_frames
+        return nil if !config && outside_project?(match[1])
+
         filename = match[1]
         lineno = match[2].to_i
         frame_data = {
@@ -82,7 +85,7 @@ module Rollbar
         # let's check it's in any of the Gem.path paths
         Gem.path.any? { |path| filename.start_with?(path) }
       end
-
+      
       def code_data(file_lines, lineno)
         file_lines[lineno - 1]
       end

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -82,7 +82,7 @@ module Rollbar
         # let's check it's in any of the Gem.path paths
         Gem.path.any? { |path| filename.start_with?(path) }
       end
- 
+
       def code_data(file_lines, lineno)
         file_lines[lineno - 1]
       end

--- a/spec/rollbar/item/frame_spec.rb
+++ b/spec/rollbar/item/frame_spec.rb
@@ -61,6 +61,7 @@ foo13
         let(:configuration) do
           double('configuration',
                  :send_extra_frame_data => :none,
+                 :send_non_project_frames => true,
                  :root => '/var/www')
         end
 
@@ -79,6 +80,7 @@ foo13
         let(:configuration) do
           double('configuration',
                  :send_extra_frame_data => :all,
+                 :send_non_project_frames => true,                 
                  :root => '/var/www')
         end
 
@@ -134,6 +136,7 @@ foo13
           let(:configuration) do
             double('configuration',
                    :send_extra_frame_data => :app,
+                   :send_non_project_frames => true,                   
                    :root => '/outside/project',
                    :project_gem_paths => [])
           end
@@ -153,6 +156,7 @@ foo13
           let(:configuration) do
             double('configuration',
                    :send_extra_frame_data => :app,
+                   :send_non_project_frames => true,                   
                    :root => '/var/outside/',
                    :project_gem_paths => ['/var/www/'])
           end
@@ -177,6 +181,7 @@ foo13
           let(:configuration) do
             double('configuration',
                    :send_extra_frame_data => :app,
+                   :send_non_project_frames => true,                   
                    :root => '/var/www',
                    :project_gem_paths => [])
           end
@@ -200,6 +205,7 @@ foo13
             let(:configuration) do
               double('configuration',
                      :send_extra_frame_data => :app,
+                     :send_non_project_frames => true,                     
                      :root => '/var/www/',
                      :project_gem_paths => [])
             end
@@ -259,6 +265,125 @@ foo13
 
               expect(subject.to_h).to be_eql(expected_result)
             end
+          end
+        end
+      end
+
+      context 'with send_non_project_frames = false' do
+        context 'with frame outside the root' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => false,
+                   :send_extra_frame_data => :none,
+                   :root => '/outside/project',
+                   :project_gem_paths => [])
+          end
+
+          it 'just returns nil' do
+            expected_result = nil
+
+            expect(subject.to_h).to be_eql(expected_result)
+          end
+        end
+
+        context 'with frame inside project_gem_paths' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => false,
+                   :send_extra_frame_data => :none,                   
+                   :root => '/var/outside/',
+                   :project_gem_paths => ['/var/www/'])
+          end
+
+          it 'returns a normal frame with basic data' do
+            expected_result = {
+              :filename => filepath,
+              :lineno => 7,
+              :method => 'send_action'
+            }
+
+            expect(subject.to_h).to be_eql(expected_result)
+          end
+        end
+
+        context 'and frame inside app root' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => false,
+                   :send_extra_frame_data => :none,                   
+                   :root => '/var/www',
+                   :project_gem_paths => [])
+          end
+
+          it 'returns also normal frame with basic data' do
+            expected_result = {
+              :filename => filepath,
+              :lineno => 7,
+              :method => 'send_action'
+            }
+
+            expect(subject.to_h).to be_eql(expected_result)
+          end
+        end
+      end
+
+      context 'with send_non_project_frames = true' do
+        context 'with frame outside the root' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => true,
+                   :send_extra_frame_data => :none,                   
+                   :root => '/outside/project',
+                   :project_gem_paths => [])
+          end
+
+          it 'returns a normal frame with basic data' do
+            expected_result = {
+              :filename => filepath,
+              :lineno => 7,
+              :method => 'send_action'
+            }
+            expect(subject.to_h).to be_eql(expected_result)
+          end
+        end
+
+        context 'with frame inside project_gem_paths' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => true,
+                   :send_extra_frame_data => :none,                   
+                   :root => '/var/outside/',
+                   :project_gem_paths => ['/var/www/'])
+          end
+
+          it 'returns also normal frame with basic data' do
+            expected_result = {
+              :filename => filepath,
+              :lineno => 7,
+              :method => 'send_action'
+            }
+
+            expect(subject.to_h).to be_eql(expected_result)
+          end
+        end
+
+        context 'and frame inside app root' do
+          let(:configuration) do
+            double('configuration',
+                   :send_non_project_frames => true,
+                   :send_extra_frame_data => :none,                   
+                   :root => '/var/www',
+                   :project_gem_paths => [])
+          end
+
+          it 'returns also normal frame with basic data' do
+            expected_result = {
+              :filename => filepath,
+              :lineno => 7,
+              :method => 'send_action'
+            }
+
+            expect(subject.to_h).to be_eql(expected_result)
           end
         end
       end


### PR DESCRIPTION
I ran into a problem in my current company while integrating Rollbar with JIRA; the backtrace frames are sent too large which make the automatically generated bugs on JIRA unreadable because all the backtrace frames are sent, whether they are non-project or in-project frames. I thought it would be a nice feature if the sending of non-project frames can be controlled by the user.

User can decide to either send non-project exception frames, which is the default, or not to send them so it can be easier to pinpoint the code that is causing the exception precisely. 

This feature is configurable using config.send_extra_frame_data which can be `true` or `false` based on the user's preference. Example:

```ruby
Rollbar.configure do |config|
  config.send_non_project_frames = false
end