### PR TITLE
Propagate configuration data to js safely

### DIFF
--- a/lib/rollbar/delay/shoryuken.rb
+++ b/lib/rollbar/delay/shoryuken.rb
@@ -8,12 +8,12 @@ module Rollbar
     class Shoryuken
       include ::Shoryuken::Worker
 
-      # not allowing bulk, to not double-report rollbars if one of them failed in bunch.
-      shoryuken_options :queue => queue_name, :auto_delete => true, :body_parser => :json, :retry_intervals => [60, 180, 360, 120_0, 360_0, 186_00]
-
       def self.queue_name
         "rollbar_#{Rollbar.configuration.environment}"
       end
+
+      # not allowing bulk, to not double-report rollbars if one of them failed in bunch.
+      shoryuken_options :queue => queue_name, :auto_delete => true, :body_parser => :json, :retry_intervals => [60, 180, 360, 120_0, 360_0, 186_00]
 
       ## responsible for performing job. - payload is a json parsed body of the message.
       def perform(_sqs_message, payload)

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -2,6 +2,7 @@ require 'rack'
 require 'rack/response'
 
 require 'rollbar/request_data_extractor'
+require 'rollbar/util'
 
 module Rollbar
   module Middleware
@@ -107,7 +108,7 @@ module Rollbar
       end
 
       def config_js_tag(env)
-        js_config = config[:options].dup
+        js_config = Rollbar::Util.deep_copy(config[:options])
 
         add_person_data(js_config, env)
 

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -253,6 +253,12 @@ END
         let(:headers) do
           { 'Content-Type' => content_type }
         end
+        let(:config) do
+          {
+            :enabled => true,
+            :options => { :foo => :bar, :payload => { :a => 42 } }
+          }
+        end
         let(:env) do
           {
             'rollbar.person_data' => {
@@ -266,6 +272,7 @@ END
           {
             :foo => :bar,
             :payload => {
+              :a => 42,
               :person => {
                 :id => 100,
                 :username => 'foo',
@@ -290,6 +297,20 @@ END
           end
 
           it 'works correctly and doesnt add anything about person data' do
+            _, _, response = subject.call(env)
+            new_body = response.body.join
+
+            expect(new_body).not_to include('person')
+          end
+
+          it 'doesnt include old data when called a second time' do
+            _, _, _ = subject.call({
+                'rollbar.person_data' => {
+                  :id => 100,
+                  :username => 'foo',
+                  :email => 'foo@bar.com'
+                }
+            })
             _, _, response = subject.call(env)
             new_body = response.body.join
 


### PR DESCRIPTION
Problem:

1. `js_config  = config[:options].dup` causes `js_config` to be a new hash, but the values in this object are just references to the elements in `config[:options]`, i.e. `dup` is shallow.
2. `add_person_data(js_config, env)` modifies `js_config` by adding data about the current user to `js_config[:payload][:person]` (and due to references also to `config[:options][:payload][:person]`.
3. On a subsequent request, if `extract_person_data_from_controller(env)` returns an empty hash, we do not set `js_config[:payload][:person]`, but due to 1. it is set to whatever was set in `config[:options]`, and due to 2. that is an old person.

Solution:

Instead of using `dup`, use our `deep_copy` to separate `config[:options]` from the `js_config` that we modify.

The unit test added fails with `dup` due to the above, and passes with `deep_copy`. Another approach would be to always set `js_config[:payload][:person]` to something even it is just `{}` if there is no data in the environment. That works, but we still shouldn't be modifying the configuration options so I think the `deep_copy` is the more principled solution.