### PR TITLE
nil guards in request_data_extractor

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -112,8 +112,10 @@ module Rollbar
       forwarded_proto = env['HTTP_X_FORWARDED_PROTO'] || env['rack.url_scheme'] || ''
       scheme = forwarded_proto.split(',').first
 
-      forwarded_host = env['HTTP_X_FORWARDED_HOST'] || env['HTTP_HOST'] || env['SERVER_NAME']
-      host = forwarded_host && forwarded_host.split(',').first.strip
+      host = env['HTTP_X_FORWARDED_HOST'] || env['HTTP_HOST'] || env['SERVER_NAME'] || ''
+      if !host.empty?
+        host = host.split(',').first.strip
+      end
 
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
       unless path.nil? || path.empty?
@@ -121,8 +123,8 @@ module Rollbar
       end
 
       port = env['HTTP_X_FORWARDED_PORT']
-      if port && !(scheme.downcase == 'http' && port.to_i == 80) && \
-         !(scheme.downcase == 'https' && port.to_i == 443) && \
+      if port && !(!scheme.nil? && scheme.downcase == 'http' && port.to_i == 80) && \
+         !(!scheme.nil? && scheme.downcase == 'https' && port.to_i == 443) && \
          !(host.include? ':')
         host = host + ':' + port
       end

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -113,9 +113,7 @@ module Rollbar
       scheme = forwarded_proto.split(',').first
 
       host = env['HTTP_X_FORWARDED_HOST'] || env['HTTP_HOST'] || env['SERVER_NAME'] || ''
-      if !host.empty?
-        host = host.split(',').first.strip
-      end
+      host = host.split(',').first.strip unless host.empty?
 
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
       unless path.nil? || path.empty?


### PR DESCRIPTION
Fixes #633 

Empty strings cause a bug where a nil comes out of `split.first`:

```
" ".split(',').first == " "
"".split(',').first == nil

```