### PR TITLE
any extra that we are passed we should dup

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -337,7 +337,7 @@ module Rollbar
         end
       end
 
-      [message, exception, extra]
+      [message, exception, Rollbar::Util.deep_dup(extra)]
     end
 
     def lookup_exception_level(orig_level, exception, use_exception_level_filters)

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -62,6 +62,21 @@ module Rollbar
       end
     end
 
+    def self.deep_dup(obj)
+      if obj.is_a?(::Hash)
+        result = obj.dup
+        obj.each { |k, v| result[k] = deep_dup(v)}
+        result
+      elsif obj.is_a?(Array)
+        result = obj.dup
+        result.clear
+        obj.each { |v| result << deep_dup(v)}
+        result
+      else
+        obj.dup
+      end
+    end
+
     def self.deep_merge(hash1, hash2)
       hash1 ||= {}
       hash2 ||= {}


### PR DESCRIPTION
Fixes #628 

We modify the extra data that is passed in for utf-8 encoding, but that is a problem if there are frozen objects passed in. So to fix that we can dup the extra object that is passed in which will unfreeze it. We can't use our `deep_copy` because that uses clone which maintains the frozen status. So I added a `deep_dup` which is the same as `deep_copy` but calls dup instead.