### PR TITLE
Add option to only send report on failure

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -16,6 +16,7 @@ module Rollbar
     attr_accessor :disable_rack_monkey_patch
     attr_accessor :disable_core_monkey_patch
     attr_accessor :dj_threshold
+    attr_accessor :dj_only_report_failures
     attr_accessor :enabled
     attr_accessor :endpoint
     attr_accessor :environment
@@ -76,6 +77,7 @@ module Rollbar
       @disable_core_monkey_patch = false
       @disable_rack_monkey_patch = false
       @dj_threshold = 0
+      @dj_only_report_failures = false
       @enabled = nil # set to true when configure is called
       @endpoint = DEFAULT_ENDPOINT
       @environment = nil

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -53,7 +53,10 @@ module Rollbar
     end
 
     def self.skip_report?(job)
-      job.attempts < ::Rollbar.configuration.dj_threshold
+      job.attempts < ::Rollbar.configuration.dj_threshold && (
+        !::Rollbar.configuration.dj_only_report_failures ||
+          !job.failed_at
+      )
     end
 
     def self.build_job_data(job)

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -105,8 +105,8 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
         expect(described_class.skip_report?(job)).to be(false)
       end
 
-      context "with configuration.only_report_failures = true" do
-        context "and the job is failed" do
+      context 'with configuration.only_report_failures = true' do
+        context 'and the job is failed' do
           let(:failed_at) { Time.now }
 
           it 'returns false' do


### PR DESCRIPTION
I had a desire to silence exceptions from my jobs that inevitably self-corrected.

This PR adds a configuration option to only send the report to Rollbar when the job gets marked as failed.

Another possible enhancement would be to add an optional callback to the job which accept the exception and make a skip decision itself. This pattern is used in DJ so each one can have its own max_attempts, or custom back-off function: https://github.com/collectiveidea/delayed_job/#custom-jobs