### PR TITLE
Handle malformed JSON request bodies

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -176,7 +176,12 @@ module Rollbar
       return {} unless correct_method
       return {} unless json_request?(rack_req)
 
-      Rollbar::JSON.load(rack_req.body.read)
+      raw_body = rack_req.body.read
+      begin
+        Rollbar::JSON.load(raw_body)
+      rescue
+        raw_body
+      end
     rescue
       {}
     ensure


### PR DESCRIPTION
If someone makes a request with a body and a JSON content-type,
we attempt to parse it as part of the request data extraction process.
If the body is actually not well formed JSON, then currently we just
throw the whole thing away and return an empty object. This change
instead returns the raw body as a string.

Fixes #618