### PR TITLE
add a whitelist option for the fields to scrub

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -41,6 +41,7 @@ module Rollbar
     attr_accessor :js_enabled
     attr_accessor :safely
     attr_accessor :scrub_fields
+    attr_accessor :scrub_fields_whitelist
     attr_accessor :scrub_user
     attr_accessor :scrub_password
     attr_accessor :user_ip_obfuscator_secret
@@ -101,8 +102,9 @@ module Rollbar
       @js_enabled = false
       @js_options = {}
       @scrub_fields = [:passwd, :password, :password_confirmation, :secret,
-                       :confirm_password, :password_confirmation, :secret_token,
+                       :confirm_password, :secret_token,
                        :api_key, :access_token]
+      @scrub_fields_whitelist = []
       @scrub_user = true
       @scrub_password = true
       @randomize_scrub_length = true

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -60,6 +60,7 @@ module Rollbar
       options = {
         :url => url,
         :scrub_fields => Array(Rollbar.configuration.scrub_fields) + sensitive_params,
+        :scrub_fields_whitelist => Rollbar.configuration.scrub_fields_whitelist,
         :scrub_user => Rollbar.configuration.scrub_user,
         :scrub_password => Rollbar.configuration.scrub_password,
         :randomize_scrub_length => Rollbar.configuration.randomize_scrub_length
@@ -72,6 +73,7 @@ module Rollbar
       options = {
         :params => params,
         :config => Rollbar.configuration.scrub_fields,
+        :whitelist => Rollbar.configuration.scrub_fields_whitelist,
         :extra_fields => sensitive_params
       }
       Rollbar::Scrubbers::Params.call(options)

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -30,6 +30,7 @@ describe Rollbar::RequestDataExtractor do
       expected_options = {
         :url => url,
         :scrub_fields => [:password, :secret, :param1, :param2],
+        :scrub_fields_whitelist => [],
         :scrub_user => true,
         :scrub_password => true,
         :randomize_scrub_length => true
@@ -50,6 +51,7 @@ describe Rollbar::RequestDataExtractor do
     end
     let(:sensitive_params) { [:param1, :param2] }
     let(:scrub_fields) { [:password, :secret] }
+    let(:whitelist) { [] }
 
     before do
       allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_fields)
@@ -59,6 +61,7 @@ describe Rollbar::RequestDataExtractor do
       expected_options = {
         :params => params,
         :config => scrub_fields,
+        :whitelist => whitelist,
         :extra_fields => sensitive_params
       }
 

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -18,8 +18,12 @@ describe Rollbar::Scrubbers::Params do
     let(:options) do
       {
         :params => params,
-        :config => scrub_config
+        :config => scrub_config,
+        :whitelist => whitelist
       }
+    end
+    let(:whitelist) do
+      []
     end
 
     context 'with scrub fields configured' do
@@ -33,16 +37,21 @@ describe Rollbar::Scrubbers::Params do
             {
               :foo => 'bar',
               :secret => 'the-secret',
+              :secret_thing => 'the-secret-thing',
               :password => 'the-password',
               :password_confirmation => 'the-password'
             }
           ]
+        end
+        let(:whitelist) do
+          [:secret_thing]
         end
         let(:result) do
           [
             {
               :foo => 'bar',
               :secret => /\*+/,
+              :secret_thing => 'the-secret-thing',
               :password => /\*+/,
               :password_confirmation => /\*+/
             }
@@ -59,14 +68,19 @@ describe Rollbar::Scrubbers::Params do
           {
             :foo => 'bar',
             :secret => 'the-secret',
+            :secret_thing => 'the-secret-thing',
             :password => 'the-password',
             :password_confirmation => 'the-password'
           }
+        end
+        let(:whitelist) do
+          []
         end
         let(:result) do
           {
             :foo => 'bar',
             :secret => /\*+/,
+            :secret_thing => /\*+/,
             :password => /\*+/,
             :password_confirmation => /\*+/
           }
@@ -95,13 +109,16 @@ describe Rollbar::Scrubbers::Params do
             }
           }
         end
+        let(:whitelist) do
+          [:password_confirmation]
+        end
         let(:result) do
           {
             :foo => 'bar',
             :extra => {
               :secret => /\*+/,
               :password => /\*+/,
-              :password_confirmation => /\*+/
+              :password_confirmation => 'the-password'
             },
             :other => /\*+/
           }
@@ -129,6 +146,9 @@ describe Rollbar::Scrubbers::Params do
               :param => 'filtered'
             }]
           }
+        end
+        let(:whitelist) do
+          []
         end
         let(:result) do
           {

--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -7,6 +7,7 @@ describe Rollbar::Scrubbers::URL do
     {
       :url => url,
       :scrub_fields => [:password, :secret],
+      :scrub_fields_whitelist => [],
       :scrub_user => false,
       :scrub_password => false,
       :randomize_scrub_length => true
@@ -48,6 +49,7 @@ describe Rollbar::Scrubbers::URL do
           {
             :url => url,
             :scrub_fields => [],
+            :scrub_fields_whitelist => [],
             :scrub_password => true,
             :scrub_user => true
           }
@@ -80,6 +82,26 @@ describe Rollbar::Scrubbers::URL do
             expect(subject.call(options)).to match(expected_url)
           end
         end
+
+        context 'with some whitelisted' do
+          let(:options) do
+            {
+              :url => url,
+              :scrub_fields => [:password, :secret],
+              :scrub_fields_whitelist => [:secret],
+              :scrub_user => false,
+              :scrub_password => false,
+              :randomize_scrub_length => true
+            }
+          end
+          let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue#fragment' }
+
+          it 'returns the URL with some params filtered' do
+            expected_url = /http:\/\/foo.com\/some-interesting-path\?foo=bar&password=\*{3,8}&secret=somevalue#fragment/
+
+            expect(subject.call(options)).to match(expected_url)
+          end
+        end
       end
 
       context 'with no-random scrub length' do
@@ -87,6 +109,7 @@ describe Rollbar::Scrubbers::URL do
           {
             :url => url,
             :scrub_fields => [:password, :secret],
+            :scrub_fields_whitelist => [],
             :scrub_user => false,
             :scrub_password => false,
             :randomize_scrub_length => false
@@ -120,6 +143,7 @@ describe Rollbar::Scrubbers::URL do
           {
             :url => url,
             :scrub_fields => [:passwd, :password, :password_confirmation, :secret, :confirm_password, :secret_token, :api_key, :access_token, :auth, :SAMLResponse, :password, :auth],
+            :scrub_fields_whitelist => [],
             :scrub_user => true,
             :scrub_password => true,
             :randomize_scrub_length => true


### PR DESCRIPTION
Fixes #614 

Still needs an update to the README but code is working

We already do exact string matching for url parameters but not for params. Not sure why that is, but it means we don't need a whitelist for url parameters technically.