### PR TITLE
GitHub Issue #664: Middleware only renders Rollbar snippet on pages with 200 status code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == '
 # if RUBY_VERSION >= '1.9.3'
 #   gem 'delayed_job', :require => false
 # else
-  gem 'delayed_job', '4.1.3', :require => false
+#  gem 'delayed_job', '4.1.3', :require => false
 # end
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -35,10 +35,10 @@ end
 
 gem 'database_cleaner', '~> 1.0.0'
 
-if RUBY_VERSION < '1.9.3'
-  gem 'delayed_job', '4.1.3', :require => false
-else
+if RUBY_VERSION >= '1.9.3'
   gem 'delayed_job', :require => false
+else
+  gem 'delayed_job', '4.1.3', :require => false
 end
 
 gem 'generator_spec'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ source 'https://rubygems.org'
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
+# if RUBY_VERSION >= '1.9.3'
+#   gem 'delayed_job', :require => false
+# else
+  gem 'delayed_job', '4.1.3', :require => false
+# end
+
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
 gem 'jruby-openssl', :platform => :jruby
@@ -34,12 +40,6 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'database_cleaner', '~> 1.0.0'
-
-# if RUBY_VERSION >= '1.9.3'
-#   gem 'delayed_job', :require => false
-# else
-  gem 'delayed_job', '4.1.3', :require => false
-# end
 
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,11 @@ end
 
 gem 'database_cleaner', '~> 1.0.0'
 
-if RUBY_VERSION >= '1.9.3'
-  gem 'delayed_job', :require => false
-else
+# if RUBY_VERSION >= '1.9.3'
+#   gem 'delayed_job', :require => false
+# else
   gem 'delayed_job', '4.1.3', :require => false
-end
+# end
 
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,13 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'database_cleaner', '~> 1.0.0'
-gem 'delayed_job', :require => false
+
+if RUBY_VERSION < '1.9.3'
+  gem 'delayed_job', '4.1.3', :require => false
+else
+  gem 'delayed_job', :require => false
+end
+
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -41,7 +41,7 @@ module Rollbar
       end
 
       def add_js?(env, status, headers)
-        enabled? && status == 200 && !env[JS_IS_INJECTED_KEY] &&
+        enabled? && !env[JS_IS_INJECTED_KEY] &&
           html?(headers) && !attachment?(headers) && !streaming?(env)
       end
 

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -25,7 +25,7 @@ module Rollbar
         app_result = app.call(env)
 
         begin
-          return app_result unless add_js?(env, app_result[0], app_result[1])
+          return app_result unless add_js?(env, app_result[1])
 
           response_string = add_js(env, app_result[2])
           build_response(env, app_result, response_string)
@@ -40,7 +40,7 @@ module Rollbar
         !!config[:enabled]
       end
 
-      def add_js?(env, status, headers)
+      def add_js?(env, headers)
         enabled? && !env[JS_IS_INJECTED_KEY] &&
           html?(headers) && !attachment?(headers) && !streaming?(env)
       end


### PR DESCRIPTION
Rollbar.js snippet should be rendered in any HTML response bodies, regardless of the status code of the response. Previously it was only rendered on 200 response codes.

This PR addresses https://github.com/rollbar/rollbar-gem/issues/664