### PR TITLE
Bug undefined blank for string in Rollbar::Logger

### DIFF
--- a/lib/rollbar/logger.rb
+++ b/lib/rollbar/logger.rb
@@ -28,7 +28,7 @@ module Rollbar
 
       message ||= block_given? ? yield : progname
 
-      return true if message.blank?
+      return true if blank?(message)
 
       rollbar.log(rollbar_level(severity), message)
     end
@@ -64,6 +64,11 @@ module Rollbar
     end
 
     private
+
+    def blank?(message)
+      return message.blank? if message.respond_to?(:blank?)
+      message.respond_to?(:empty?) ? !!message.empty? : !message
+    end
 
     # Find correct Rollbar level to use using the indexes in Logger::Severity
     # DEBUG = 0

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -60,7 +60,7 @@ describe Rollbar::Logger do
     end
 
     context 'without active_support/core_ext/object/blank' do
-      let(:message) { 'foo'.tap{ |message| message.instance_eval('undef :blank?') } }
+      let(:message) { 'foo'.tap { |message| message.instance_eval('undef :blank?') } }
 
       it 'calls Rollbar to send the message' do
         expect_any_instance_of(Rollbar::Notifier).to receive(:log).with(:error, message)

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -58,6 +58,16 @@ describe Rollbar::Logger do
         subject.add(10, message)
       end
     end
+
+    context 'without active_support/core_ext/object/blank' do
+      let(:message) { 'foo'.tap{ |message| message.instance_eval('undef :blank?') } }
+
+      it 'calls Rollbar to send the message' do
+        expect_any_instance_of(Rollbar::Notifier).to receive(:log).with(:error, message)
+
+        subject.add(Logger::ERROR, message)
+      end
+    end
   end
 
   describe '#<<' do


### PR DESCRIPTION
Possible solution to close #674 - feel free to use it or not to :)

Implements a local blank for usage without core_ext
Check if message responds to :blank?, if it does not
use a local implementation of it.

local implementation taken from
https://github.com/rails/rails/blob/v5.1.4/activesupport/lib/active_support/core_ext/object/blank.rb#L17