### PR TITLE
Adds 'aws-sdk-sqs' to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque'
 gem 'shoryuken'
+gem 'aws-sdk-sqs'
 gem 'sinatra'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'
 end
 
+gem 'aws-sdk-sqs'
 gem 'database_cleaner', '~> 1.0.0'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
@@ -40,7 +41,6 @@ gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque'
 gem 'shoryuken'
-gem 'aws-sdk-sqs'
 gem 'sinatra'
 
 gemspec


### PR DESCRIPTION
as it's a dependency of shoryuken. See
error message that occurred while running tests below:

```shell
Failure/Error: require 'shoryuken'

RuntimeError:
  AWS SDK 3 requires aws-sdk-sqs to be installed separately. Please add
  gem 'aws-sdk-sqs' to your Gemfile
```