### PR TITLE
GitHub Issue #237: custom_data_method controller context

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ If your `custom_data_method` crashes while reporting an error, Rollbar will repo
 `context` for your `custom_data_method` is the value passed in the `:custom_data_method_context` key of your `log` method's `extra_data` argument. Note that once the value is passed as `context` it is removed from your `extra_data` and will be not be included in your `extra` by default.
 
 ```ruby
-config.custom_data_method = lambda{ |message, exception, context|
+config.custom_data_method = lambda { |message, exception, context|
   {
     fully_qualified_controller_name: "MyApp::" + context[:controller_name]
   }

--- a/README.md
+++ b/README.md
@@ -504,6 +504,38 @@ This data will appear in the Occurrences tab and on the Occurrence Detail pages 
 
 If your `custom_data_method` crashes while reporting an error, Rollbar will report that new error and will attach its uuid URL to the parent error report.
 
+`context` for your `custom_data_method` is the value passed in the `:custom_data_method_context` key of your `log` method's `extra_data` argument. Note that once the value is passed as `context` it is removed from your `extra_data` and will be not be included in your `extra` by default.
+
+```ruby
+config.custom_data_method = lambda{ |message, exception, context|
+  {
+    fully_qualified_controller_name: "MyApp::" + context[:controller_name]
+  }
+}
+
+Rollbar.log(
+  "error", 
+  "Simple message", 
+  { 
+    extra_data_1: "some value",
+    custom_data_method_context: { 
+      controller_name: "ExampleController"
+    }
+  }
+)
+```
+
+The above example will result in the following `extra`:
+
+```ruby
+  { 
+    extra_data_1: "some value",
+    fully_qualified_controller_name: "MyApp::ExampleController"
+  }
+```
+
+As you can see, the `custom_data_method_context` will not be directly included in your `extra`.
+
 ## Exception level filters
 
 By default, all uncaught exceptions are reported at the "error" level, except for the following, which are reported at "warning" level:

--- a/README.md
+++ b/README.md
@@ -482,12 +482,20 @@ config.scrub_fields = :scrub_all
 
 ## Including additional runtime data
 
-You can provide a callable that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that takes no arguments and returns a hash.
+You can provide a callable that will be called for each exception or message report.  ```custom_data_method``` should be a lambda that either takes no arguments or takes three arguments (message, exception, context) and returns a hash.
 
 Add the following in ```config/initializers/rollbar.rb```:
 
 ```ruby
 config.custom_data_method = lambda {
+  { :some_key => :some_value, :complex_key => {:a => 1, :b => [2, 3, 4]} }
+}
+```
+
+Or
+
+```ruby
+config.custom_data_method = lambda{ |message, exception, context|
   { :some_key => :some_value, :complex_key => {:a => 1, :b => [2, 3, 4]} }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -536,6 +536,36 @@ The above example will result in the following `extra`:
 
 As you can see, the `custom_data_method_context` will not be directly included in your `extra`.
 
+Below is an example usage in a Rails application:
+
+```ruby
+# config/initializers/rollbar.rb
+Rollbar.configure do |config|
+  ...
+  
+  config.custom_data_method = lambda do |message, exception, context|
+    { controller_name: context[:controller].controller_name }
+  end
+end
+```
+
+```ruby
+# app/controller/welcome_controller.rb
+class WelcomeController < ApplicationController
+  def check_context
+    Rollbar.log(
+      'info', 
+      'This is a message from Welcome#check_context',
+      {
+        custom_data_method_context: {
+          controller: self
+        }
+      }
+    )
+  end
+end
+```
+
 ## Exception level filters
 
 By default, all uncaught exceptions are reported at the "error" level, except for the following, which are reported at "warning" level:

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -169,10 +169,10 @@ module Rollbar
 
     def custom_data
       
-      if configuration.custom_data_method.parameters.empty?
-        data = configuration.custom_data_method.call
-      else
+      if configuration.custom_data_method.arity == 3
         data = configuration.custom_data_method.call(message, exception, context)
+      else
+        data = configuration.custom_data_method.call
       end
       
       Rollbar::Util.deep_copy(data)

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -31,6 +31,8 @@ module Rollbar
     attr_reader :scope
     attr_reader :logger
     attr_reader :notifier
+    
+    attr_reader :context
 
     def_delegators :payload, :[]
 
@@ -52,6 +54,7 @@ module Rollbar
       @scope = options[:scope]
       @payload = nil
       @notifier = options[:notifier]
+      @context = options[:context]
     end
 
     def payload
@@ -165,7 +168,13 @@ module Rollbar
     end
 
     def custom_data
-      data = configuration.custom_data_method.call
+      
+      if configuration.custom_data_method.parameters.empty?
+        data = configuration.custom_data_method.call
+      else
+        data = configuration.custom_data_method.call(message, exception, context)
+      end
+      
       Rollbar::Util.deep_copy(data)
     rescue => e
       return {} if configuration.safely?

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -26,7 +26,7 @@ module Rollbar
     attr_reader :message
     attr_reader :exception
     attr_reader :extra
-
+    
     attr_reader :configuration
     attr_reader :scope
     attr_reader :logger
@@ -168,7 +168,6 @@ module Rollbar
     end
 
     def custom_data
-      
       if configuration.custom_data_method.arity == 3
         data = configuration.custom_data_method.call(message, exception, context)
       else

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -345,9 +345,7 @@ module Rollbar
           context = extra[:custom_data_method_context]
           extra.delete :custom_data_method_context
           
-          if extra.empty?
-            extra = nil
-          end
+          extra = nil if extra.empty?
         end
       end
 

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -409,7 +409,7 @@ module Rollbar
       log_error '[Rollbar] Reporting internal error encountered while sending data to Rollbar.'
 
       begin
-        item = build_item('error', nil, exception, :internal => true)
+        item = build_item('error', nil, exception, { :internal => true }, nil)
       rescue => e
         send_failsafe('build_item in exception_data', e)
         return

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -28,7 +28,7 @@ describe HomeController do
 
   context "rollbar base_data" do
     it 'should have the Rails environment' do
-      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil)
+      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil, nil)
       data['data'][:environment].should == ::Rails.env
     end
 
@@ -37,7 +37,7 @@ describe HomeController do
         config.environment = 'dev'
       end
 
-      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil)
+      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil, nil)
       data['data'][:environment].should == 'dev'
     end
 
@@ -45,7 +45,7 @@ describe HomeController do
       old_env, ::Rails.env = ::Rails.env, ''
       preconfigure_rails_notifier
 
-      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil)
+      data = Rollbar.notifier.send(:build_item, 'error', 'message', nil, nil, nil)
       data['data'][:environment].should == 'unspecified'
 
       ::Rails.env = old_env

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -128,7 +128,7 @@ describe Rollbar::Item do
     
       it 'should have access to the context in custom_data_method' do
         configuration.custom_data_method = lambda do |message, exception, context|
-          { result: "MyApp#" + context[:controller] }
+          { :result => "MyApp#" + context[:controller] }
         end
   
         payload['data'][:body][:message][:extra].should_not be_nil
@@ -143,7 +143,7 @@ describe Rollbar::Item do
       
       it 'should have access to the message in custom_data_method' do
         configuration.custom_data_method = lambda do |message, exception, context|
-          { result: "Transformed in custom_data_method: " + message }
+          { :result => "Transformed in custom_data_method: " + message }
         end
         
         payload['data'][:body][:message][:extra].should_not be_nil
@@ -155,7 +155,7 @@ describe Rollbar::Item do
         
         it 'should have access to the current exception in custom_data_method' do
           configuration.custom_data_method = lambda do |message, exception, context|
-            { result: "Transformed in custom_data_method: " + exception.message }
+            { :result => "Transformed in custom_data_method: " + exception.message }
           end
           
           payload['data'][:body][:trace][:extra].should_not be_nil

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -20,6 +20,7 @@ describe Rollbar::Item do
   let(:exception) {}
   let(:extra) {}
   let(:scope) {}
+  let(:context) {}
 
   let(:options) do
     {
@@ -30,7 +31,8 @@ describe Rollbar::Item do
       :configuration => configuration,
       :logger => logger,
       :scope => scope,
-      :notifier => notifier
+      :notifier => notifier,
+      :context => context
     }
   end
 
@@ -119,6 +121,47 @@ describe Rollbar::Item do
       payload['data'][:body][:message][:extra].should_not be_nil
       payload['data'][:body][:message][:extra][:a].should == 1
       payload['data'][:body][:message][:extra][:b][2].should == 4
+    end
+    
+    context do
+      let(:context) { { :controller => "ExampleController" } }
+    
+      it 'should have access to the context in custom_data_method' do
+        configuration.custom_data_method = lambda do |message, exception, context|
+          { result: "MyApp#" + context[:controller] }
+        end
+  
+        payload['data'][:body][:message][:extra].should_not be_nil
+        payload['data'][:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
+      end
+      
+      it 'should not include data passed in :context if there is no custom_data_method configured' do
+        configuration.custom_data_method = nil
+  
+        payload['data'][:body][:message][:extra].should be_nil
+      end
+      
+      it 'should have access to the message in custom_data_method' do
+        configuration.custom_data_method = lambda do |message, exception, context|
+          { result: "Transformed in custom_data_method: " + message }
+        end
+        
+        payload['data'][:body][:message][:extra].should_not be_nil
+        payload['data'][:body][:message][:extra][:result].should == "Transformed in custom_data_method: " + message
+      end
+      
+      context do
+        let(:exception) { Exception.new "Exception to test custom_data_method" }
+        
+        it 'should have access to the current exception in custom_data_method' do
+          configuration.custom_data_method = lambda do |message, exception, context|
+            { result: "Transformed in custom_data_method: " + exception.message }
+          end
+          
+          payload['data'][:body][:trace][:extra].should_not be_nil
+          payload['data'][:body][:trace][:extra][:result].should == "Transformed in custom_data_method: " + exception.message
+        end
+      end
     end
 
     context do

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -166,7 +166,7 @@ describe Rollbar do
           before do
             Rollbar.configure do |config|
               config.custom_data_method = lambda do |message, exception, context| 
-                { result: "MyApp#" + context[:controller] }
+                { :result => "MyApp#" + context[:controller] }
               end
             end
           end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -124,38 +124,38 @@ describe Rollbar do
       end
 
       it 'should report a simple message' do
-        expect(notifier).to receive(:report).with('error', 'test message', nil, nil)
+        expect(notifier).to receive(:report).with('error', 'test message', nil, nil, nil)
         notifier.log('error', 'test message')
       end
 
       it 'should report a simple message with extra data' do
         extra_data = {:key => 'value', :hash => {:inner_key => 'inner_value'}}
 
-        expect(notifier).to receive(:report).with('error', 'test message', nil, extra_data)
+        expect(notifier).to receive(:report).with('error', 'test message', nil, extra_data, nil)
         notifier.log('error', 'test message', extra_data)
       end
 
       it 'should report an exception' do
-        expect(notifier).to receive(:report).with('error', nil, exception, nil)
+        expect(notifier).to receive(:report).with('error', nil, exception, nil, nil)
         notifier.log('error', exception)
       end
 
       it 'should report an exception with extra data' do
         extra_data = {:key => 'value', :hash => {:inner_key => 'inner_value'}}
 
-        expect(notifier).to receive(:report).with('error', nil, exception, extra_data)
+        expect(notifier).to receive(:report).with('error', nil, exception, extra_data, nil)
         notifier.log('error', exception, extra_data)
       end
 
       it 'should report an exception with a description' do
-        expect(notifier).to receive(:report).with('error', 'exception description', exception, nil)
+        expect(notifier).to receive(:report).with('error', 'exception description', exception, nil, nil)
         notifier.log('error', exception, 'exception description')
       end
 
       it 'should report an exception with a description and extra data' do
         extra_data = {:key => 'value', :hash => {:inner_key => 'inner_value'}}
 
-        expect(notifier).to receive(:report).with('error', 'exception description', exception, extra_data)
+        expect(notifier).to receive(:report).with('error', 'exception description', exception, extra_data, nil)
         notifier.log('error', exception, extra_data, 'exception description')
       end
       
@@ -172,11 +172,11 @@ describe Rollbar do
           end
           
           it 'should have access to the context data through configuration.custom_data_method' do
-            
-            result = notifier.log('error', "Custom message", :context => context)
+            result = notifier.log('error', "Custom message", { :custom_data_method_context => context})
             
             result[:body][:message][:extra].should_not be_nil
             result[:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
+            result[:body][:message][:extra][:custom_data_method_context].should be_nil
           end
         end
       end
@@ -222,7 +222,7 @@ describe Rollbar do
           }
 
           expect(handler).to receive(:call).with(options)
-          expect(notifier).to receive(:report).with(level, message, exception, extra)
+          expect(notifier).to receive(:report).with(level, message, exception, extra, nil)
 
           notifier.log(level, message, exception, extra)
         end
@@ -320,57 +320,57 @@ describe Rollbar do
       let(:extra_data) { {:key => 'value', :hash => {:inner_key => 'inner_value'}} }
 
       it 'should report with a debug level' do
-        expect(notifier).to receive(:report).with('debug', nil, exception, nil)
+        expect(notifier).to receive(:report).with('debug', nil, exception, nil, nil)
         notifier.debug(exception)
 
-        expect(notifier).to receive(:report).with('debug', 'description', exception, nil)
+        expect(notifier).to receive(:report).with('debug', 'description', exception, nil, nil)
         notifier.debug(exception, 'description')
 
-        expect(notifier).to receive(:report).with('debug', 'description', exception, extra_data)
+        expect(notifier).to receive(:report).with('debug', 'description', exception, extra_data, nil)
         notifier.debug(exception, 'description', extra_data)
       end
 
       it 'should report with an info level' do
-        expect(notifier).to receive(:report).with('info', nil, exception, nil)
+        expect(notifier).to receive(:report).with('info', nil, exception, nil, nil)
         notifier.info(exception)
 
-        expect(notifier).to receive(:report).with('info', 'description', exception, nil)
+        expect(notifier).to receive(:report).with('info', 'description', exception, nil, nil)
         notifier.info(exception, 'description')
 
-        expect(notifier).to receive(:report).with('info', 'description', exception, extra_data)
+        expect(notifier).to receive(:report).with('info', 'description', exception, extra_data, nil)
         notifier.info(exception, 'description', extra_data)
       end
 
       it 'should report with a warning level' do
-        expect(notifier).to receive(:report).with('warning', nil, exception, nil)
+        expect(notifier).to receive(:report).with('warning', nil, exception, nil, nil)
         notifier.warning(exception)
 
-        expect(notifier).to receive(:report).with('warning', 'description', exception, nil)
+        expect(notifier).to receive(:report).with('warning', 'description', exception, nil, nil)
         notifier.warning(exception, 'description')
 
-        expect(notifier).to receive(:report).with('warning', 'description', exception, extra_data)
+        expect(notifier).to receive(:report).with('warning', 'description', exception, extra_data, nil)
         notifier.warning(exception, 'description', extra_data)
       end
 
       it 'should report with an error level' do
-        expect(notifier).to receive(:report).with('error', nil, exception, nil, {})
+        expect(notifier).to receive(:report).with('error', nil, exception, nil, nil)
         notifier.error(exception)
 
-        expect(notifier).to receive(:report).with('error', 'description', exception, nil, {})
+        expect(notifier).to receive(:report).with('error', 'description', exception, nil, nil)
         notifier.error(exception, 'description')
 
-        expect(notifier).to receive(:report).with('error', 'description', exception, extra_data, {})
+        expect(notifier).to receive(:report).with('error', 'description', exception, extra_data, nil)
         notifier.error(exception, 'description', extra_data)
       end
 
       it 'should report with a critical level' do
-        expect(notifier).to receive(:report).with('critical', nil, exception, nil, {})
+        expect(notifier).to receive(:report).with('critical', nil, exception, nil, nil)
         notifier.critical(exception)
 
-        expect(notifier).to receive(:report).with('critical', 'description', exception, nil, {})
+        expect(notifier).to receive(:report).with('critical', 'description', exception, nil, nil)
         notifier.critical(exception, 'description')
 
-        expect(notifier).to receive(:report).with('critical', 'description', exception, extra_data, {})
+        expect(notifier).to receive(:report).with('critical', 'description', exception, extra_data, nil)
         notifier.critical(exception, 'description', extra_data)
       end
     end
@@ -476,7 +476,7 @@ describe Rollbar do
         expect(logger_mock).to receive(:error).with('[Rollbar] Tried to send a report with no message, exception or extra data.')
         expect(notifier).not_to receive(:schedule_payload)
 
-        result = notifier.send(:report, 'info', nil, nil, nil)
+        result = notifier.send(:report, 'info', nil, nil, nil, nil)
         result.should == 'error'
       end
 
@@ -494,7 +494,7 @@ describe Rollbar do
 
         expect(notifier).not_to receive(:schedule_payload)
 
-        result = notifier.send(:report, 'info', 'message', nil, nil)
+        result = notifier.send(:report, 'info', 'message', nil, nil, nil)
         result.should == 'ignored'
       end
     end
@@ -1333,7 +1333,7 @@ describe Rollbar do
         gem_spec.gem_dir if gem_spec
       end.compact
 
-      data = notifier.send(:build_item, 'info', 'test', nil, {})['data']
+      data = notifier.send(:build_item, 'info', 'test', nil, {}, nil)['data']
       data[:project_package_paths].kind_of?(Array).should == true
       data[:project_package_paths].length.should == gem_paths.length
 
@@ -1369,7 +1369,7 @@ describe Rollbar do
         config.project_gems = gems
       end
 
-      data = notifier.send(:build_item, 'info', 'test', nil, {})['data']
+      data = notifier.send(:build_item, 'info', 'test', nil, {}, nil)['data']
       data[:project_package_paths].kind_of?(Array).should == true
       data[:project_package_paths].length.should == 1
     end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1356,7 +1356,7 @@ describe Rollbar do
       gem_paths.any?{|path| path.include? 'rollbar-gem'}.should == true
       gem_paths.any?{|path| path.include? 'rspec-rails'}.should == true
 
-      data = notifier.send(:build_item, 'info', 'test', nil, {})['data']
+      data = notifier.send(:build_item, 'info', 'test', nil, {}, nil)['data']
       data[:project_package_paths].kind_of?(Array).should == true
       data[:project_package_paths].length.should == gem_paths.length
       (data[:project_package_paths] - gem_paths).length.should == 0


### PR DESCRIPTION
This PR addresses feature request in https://github.com/rollbar/rollbar-gem/issues/237

It makes `message`, `exception` and `context` available in `custom_data_method`. The `message` and the `exception` are the current message or exception. The `context` is the value passed in `Notifier#log`'s `extra_data` hash under the `:custom_data_method_context` key.

From the `README.md` description:

```ruby
config.custom_data_method = lambda{ |message, exception, context|
  {
    fully_qualified_controller_name: "MyApp::" + context[:controller_name]
  }
}

Rollbar.log(
  "error", 
  "Simple message", 
  { 
    extra_data_1: "some value",
    custom_data_method_context: { 
      controller_name: "ExampleController"
    }
  }
)
```

The above example will result in the following `extra`:

```ruby
  { 
    extra_data_1: "some value",
    fully_qualified_controller_name: "MyApp::ExampleController"
  }
```

It's also backward compatible and supports no argument `custom_data_method`.