### PR TITLE
Better logging for capistrano sourcemap uploading

### DIFF
--- a/lib/rollbar/tasks/rollbar.cap
+++ b/lib/rollbar/tasks/rollbar.cap
@@ -32,7 +32,7 @@ namespace :rollbar do
   desc 'Upload sourcemaps to Rollbar.'
   task :sourcemap do
     on primary fetch(:rollbar_role) do
-      info "Uploading source maps from #{fetch(:rollbar_sourcemaps_target_dir)}"
+      info "Uploading source maps"
       warn("You need to upgrade capistrano to '>= 3.1' version in order to correctly upload sourcemaps to Rollbar. (On 3.0, the reported revision will be incorrect.)") if Capistrano::VERSION =~ /^3\.0/
       url_base = fetch(:rollbar_sourcemaps_minified_url_base)
       unless url_base
@@ -46,7 +46,17 @@ namespace :rollbar do
           source_maps = source_maps.map { |file| file.gsub(/^\.\//, '') }
           source_maps.each do |source_map|
             minified_url = File.join(url_base, source_map)
-            execute(:curl, *%W(https://api.rollbar.com/api/1/sourcemap -F access_token=#{fetch(:rollbar_token)} -F version=#{fetch(:rollbar_revision)} -F minified_url=#{minified_url} -F source_map=@./#{source_map}))
+            args = *%W(--silent https://api.rollbar.com/api/1/sourcemap -F access_token=#{fetch(:rollbar_token)} -F version=#{fetch(:rollbar_revision)} -F minified_url=#{minified_url} -F source_map=@./#{source_map})
+            info "curl #{args.join(' ')}" # log the command, since capture doesn't output anything
+            api_response_body = capture(:curl, args)
+            begin
+              api_response_json = JSON.parse(api_response_body)
+              if api_response_json["err"] != 0
+                warn "Error uploading sourcemaps: #{api_response_json["message"] || 'Unknown Error'}"
+              end
+            rescue JSON::ParserError => e
+              warn "Error parsing response: #{e.message}. Response body: #{api_response_body}"
+            end
           end
         end
       end


### PR DESCRIPTION
Original code produced very verbose output from curl. 
In this pull request I pass "silent" to curl and also handle possible errors from rollbar api.