### PR TITLE
GitHub Issue #658: java.lang.Exception are reported as "Empty message" and no stack trace

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -339,6 +339,8 @@ module Rollbar
           message = arg
         elsif arg.is_a?(Exception)
           exception = arg
+        elsif RUBY_PLATFORM == 'java' && arg.is_a?(java.lang.Exception)
+          exception = arg
         elsif arg.is_a?(Hash)
           extra = arg
           

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -40,4 +40,17 @@ describe Rollbar::Notifier do
       expect(subject.scope_object).to be(subject.scope_object)
     end
   end
+  
+  if RUBY_PLATFORM == 'java'
+    describe "#extract_arguments" do
+      it "extracts Java exceptions" do
+        begin
+          raise java.lang.Exception.new("Hello")
+        rescue java.lang.Exception => e
+          message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
+          expect(exception).to eq(e)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
PR for issue https://github.com/rollbar/rollbar-gem/issues/658

Adds reporting of `java.lang.Exception` on `jruby`.