### PR TITLE
Don't send person's personally identifiable information as a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ If the methods to extract the ```id```, ```username```, and ```email``` from the
 ```ruby
 Rollbar.configure do |config|
   config.person_id_method = "user_id"  # default is "id"
-  config.person_username_method = "user_name"  # default is "username"
+  config.person_username_method = "user_name"  # default is `nil`
   config.person_email_method = "email_address"  # default is `nil`
 end
 ```

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ If the methods to extract the ```id```, ```username```, and ```email``` from the
 Rollbar.configure do |config|
   config.person_id_method = "user_id"  # default is "id"
   config.person_username_method = "user_name"  # default is "username"
-  config.person_email_method = "email_address"  # default is "email"
+  config.person_email_method = "email_address"  # default is `nil`
 end
 ```
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -25,6 +25,7 @@ Huge thanks to the following contributors (by github username). For the most up-
 - [jeremyvdw](https://github.com/jeremyvdw)
 - [jjb](https://github.com/jjb)
 - [johnknott](https://github.com/johnknott)
+- [johnsyweb](https://github.com/johnsyweb)
 - [jonah-williams](https://github.com/jonah-williams)
 - [jondeandres](https://github.com/jondeandres)
 - [JoshuaOSHickman](https://github.com/JoshuaOSHickman)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,8 @@ if `person_method` not present.
 
 ### person_username_method
 
+**Default** `nil`
+
 A string or symbol giving the name of the method on the user instance that
 returns the person's username. Gets called on the result of `person_method`.
 Ignored if `person_method` not present.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,6 +180,8 @@ Ignored if `person_method` not present.
 
 ### person_email_method
 
+**Default** `nil`
+
 A string or symbol giving the name of the method on the user instance that
 returns the person's email. Gets called on the result of `person_method`.
 Ignored if `person_method` not present.

--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -19,12 +19,14 @@ Rollbar.configure do |config|
 <%- end -%>
 
   # By default, Rollbar will try to call the `current_user` controller method
-  # to fetch the logged-in user object, and then call that object's `id`,
-  # `username`, and `email` methods to fetch those properties. To customize:
+  # to fetch the logged-in user object, and then call that object's `id` and
+  # `username` methods to fetch those properties. To customize:
   # config.person_method = "my_current_user"
   # config.person_id_method = "my_id"
   # config.person_username_method = "my_username"
-  # config.person_email_method = "my_email"
+
+  # Additionally, if you're happy to send Rollbar personally identifiable information...
+  # config.person_email_method = "email"
 
   # If you want to attach custom data to all exception and message reports,
   # provide a lambda like the following. It should return a hash.

--- a/lib/generators/rollbar/templates/initializer.rb
+++ b/lib/generators/rollbar/templates/initializer.rb
@@ -19,13 +19,13 @@ Rollbar.configure do |config|
 <%- end -%>
 
   # By default, Rollbar will try to call the `current_user` controller method
-  # to fetch the logged-in user object, and then call that object's `id` and
-  # `username` methods to fetch those properties. To customize:
+  # to fetch the logged-in user object, and then call that object's `id`
+  # method to fetch this property. To customize:
   # config.person_method = "my_current_user"
   # config.person_id_method = "my_id"
-  # config.person_username_method = "my_username"
 
-  # Additionally, if you're happy to send Rollbar personally identifiable information...
+  # Additionally, you may specify the following:
+  # config.person_username_method = "username"
   # config.person_email_method = "email"
 
   # If you want to attach custom data to all exception and message reports,

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -91,7 +91,7 @@ module Rollbar
       @person_method = 'current_user'
       @person_id_method = 'id'
       @person_username_method = 'username'
-      @person_email_method = 'email'
+      @person_email_method = nil
       @project_gems = []
       @populate_empty_backtraces = false
       @report_dj_data = true

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -90,7 +90,7 @@ module Rollbar
       @payload_options = {}
       @person_method = 'current_user'
       @person_id_method = 'id'
-      @person_username_method = 'username'
+      @person_username_method = nil
       @person_email_method = nil
       @project_gems = []
       @populate_empty_backtraces = false

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -342,24 +342,32 @@ describe HomeController do
         end
 
         context 'default' do
-          it 'sends the current user data excluding email address' do
-            expect(person_data[:id]).to be_eql(user.id)
-            expect(person_data[:email]).to be_nil
-            expect(person_data[:username]).to be_eql(user.username)
+          it 'sends the current user data excluding personally identifiable information' do
+            expect(person_data).to eq(:id => user.id,
+                                      :email => nil,
+                                      :username => nil)
           end
         end
 
-        context 'configured to send email addresses (no EU GDPR worries)' do
-          before do
-            Rollbar.configure do |config|
-              config.person_email_method = 'email'
-            end
-          end
+        context 'without EU GDPR subjects' do
+          context 'configured to send email addresses' do
+            before { Rollbar.configure { |config| config.person_email_method = 'email' } }
 
-          it 'sends the current user data including email address' do
-            expect(person_data[:id]).to be_eql(user.id)
-            expect(person_data[:email]).to eq('foo@bar.com')
-            expect(person_data[:username]).to be_eql(user.username)
+            it 'sends the current user data including email address' do
+              expect(person_data).to eq(:id => user.id,
+                                        :email => 'foo@bar.com',
+                                        :username => nil)
+            end
+
+            context 'configured to send email addresses and username' do
+              before { Rollbar.configure { |config| config.person_username_method = 'username' } }
+
+              it 'sends the current user data including email address and username' do
+                  expect(person_data).to eq(:id => user.id,
+                                            :email => 'foo@bar.com',
+                                            :username => 'the_username')
+              end
+            end
           end
         end
       end

--- a/spec/dummyapp/config/initializers/rollbar.rb
+++ b/spec/dummyapp/config/initializers/rollbar.rb
@@ -7,12 +7,14 @@ Rollbar.configure do |config|
     :foo => :bar
   }
   # By default, Rollbar will try to call the `current_user` controller method
-  # to fetch the logged-in user object, and then call that object's `id`,
-  # `username`, and `email` methods to fetch those properties. To customize:
+  # to fetch the logged-in user object, and then call that object's `id` and
+  # `username` methods to fetch those properties. To customize:
   # config.person_method = "my_current_user"
   # config.person_id_method = "my_id"
   # config.person_username_method = "my_username"
-  # config.person_email_method = "my_email"
+
+  # Additionally, if you're happy to send Rollbar personally identifiable information...
+  # config.person_email_method = "email"
 
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception

--- a/spec/dummyapp/config/initializers/rollbar.rb
+++ b/spec/dummyapp/config/initializers/rollbar.rb
@@ -7,13 +7,13 @@ Rollbar.configure do |config|
     :foo => :bar
   }
   # By default, Rollbar will try to call the `current_user` controller method
-  # to fetch the logged-in user object, and then call that object's `id` and
-  # `username` methods to fetch those properties. To customize:
+  # to fetch the logged-in user object, and then call that object's `id`
+  # method to fetch this property. To customize:
   # config.person_method = "my_current_user"
   # config.person_id_method = "my_id"
-  # config.person_username_method = "my_username"
 
-  # Additionally, if you're happy to send Rollbar personally identifiable information...
+  # Additionally, you may specify the following:
+  # config.person_username_method = "username"
   # config.person_email_method = "email"
 
   # Add exception class names to the exception_level_filters hash to


### PR DESCRIPTION
#### Context

Sending a user's email address to a third-party is not desirable under The EU General Data Protection Regulation ([GDPR](https://www.eugdpr.org/)) and sending it to Rollbar is not a sensible default.

#### Change

The default is *not* to send the email address but how to do so remains a documented option.