### PR TITLE
update `append_nounce?` method for SecureHeaders

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -157,8 +157,8 @@ module Rollbar
       def append_nonce?
         defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce) &&
           defined?(::SecureHeaders::Configuration) &&
-          !::SecureHeaders::Configuration.get.csp.opt_out? &&
-          !::SecureHeaders::Configuration.get.current_csp[:script_src].to_a.include?("'unsafe-inline'")
+          !::SecureHeaders::Configuration.default.csp.opt_out? &&
+          !::SecureHeaders::Configuration.default.current_csp[:script_src].to_a.include?("'unsafe-inline'")
       end
     end
   end

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -177,7 +177,7 @@ END
           Object.const_set('SecureHeaders', Module.new)
           SecureHeaders.const_set('VERSION', '3.0.0')
           SecureHeaders.const_set('Configuration', Module.new {
-            def self.get
+            def self.default
             end
           })
           allow(SecureHeaders).to receive(:content_security_policy_script_nonce) { 'lorem-ipsum-nonce' }
@@ -189,7 +189,7 @@ END
 
         it 'renders the snippet and config in the response with nonce in script tag when SecureHeaders installed' do
           secure_headers_config = double(:configuration, :current_csp => {}, :csp => double(:opt_out? => false))
-          allow(SecureHeaders::Configuration).to receive(:get).and_return(secure_headers_config)
+          allow(SecureHeaders::Configuration).to receive(:default).and_return(secure_headers_config)
           res_status, res_headers, response = subject.call(env)
 
           new_body = response.body.join
@@ -205,7 +205,7 @@ END
                                            :script_src => %w('unsafe-inline')
                                          },
                                          :csp => double(:opt_out? => false))
-          allow(SecureHeaders::Configuration).to receive(:get).and_return(secure_headers_config)
+          allow(SecureHeaders::Configuration).to receive(:default).and_return(secure_headers_config)
 
           res_status, res_headers, response = subject.call(env)
           new_body = response.body.join
@@ -219,7 +219,7 @@ END
 
         it 'renders the snippet in the response without nonce if SecureHeaders CSP is OptOut' do
           secure_headers_config = double(:configuration, :csp => double(:opt_out? => true))
-          allow(SecureHeaders::Configuration).to receive(:get).and_return(secure_headers_config)
+          allow(SecureHeaders::Configuration).to receive(:default).and_return(secure_headers_config)
 
           res_status, res_headers, response = subject.call(env)
           new_body = response.body.join


### PR DESCRIPTION
This pr try to solve this issue: #695

According to http://www.rubydoc.info/gems/secure_headers/SecureHeaders/Configuration#default-class_method, the get method is returning default config without any arg so we could just use default instead of get