### PR TITLE
Fix "Empty message" report for java.lang.Error & children

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -339,7 +339,7 @@ module Rollbar
           message = arg
         elsif arg.is_a?(Exception)
           exception = arg
-        elsif RUBY_PLATFORM == 'java' && arg.is_a?(java.lang.Exception)
+        elsif RUBY_PLATFORM == 'java' && arg.is_a?(java.lang.Throwable)
           exception = arg
         elsif arg.is_a?(Hash)
           extra = arg

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -43,6 +43,8 @@ describe Rollbar::Notifier do
   
   if RUBY_PLATFORM == 'java'
     describe '#extract_arguments' do
+      # See https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html
+      # for more background
       it 'extracts java.lang.Exception' do
         begin
           raise java.lang.Exception.new('Hello')

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -51,6 +51,14 @@ describe Rollbar::Notifier do
           expect(exception).to eq(e)
         end
       end
+      
+      it "extracts java.lang.Error" do
+        # NOTE: not raising because otherwise you'd get
+        # "Unable to infer file and line number from backtrace"
+        e = java.lang.OutOfMemoryError.new
+        message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
+        expect(exception).to eq(e)
+      end
     end
   end
 end

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -42,17 +42,17 @@ describe Rollbar::Notifier do
   end
   
   if RUBY_PLATFORM == 'java'
-    describe "#extract_arguments" do
-      it "extracts java.lang.Exception" do
+    describe '#extract_arguments' do
+      it 'extracts java.lang.Exception' do
         begin
-          raise java.lang.Exception.new("Hello")
+          raise java.lang.Exception.new('Hello')
         rescue java.lang.Exception => e
           message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
           expect(exception).to eq(e)
         end
       end
       
-      it "extracts java.lang.Error" do
+      it 'extracts java.lang.Error' do
         # NOTE: not raising because otherwise you'd get
         # "Unable to infer file and line number from backtrace"
         e = java.lang.OutOfMemoryError.new

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -55,11 +55,12 @@ describe Rollbar::Notifier do
       end
       
       it 'extracts java.lang.Error' do
-        # NOTE: not raising because otherwise you'd get
-        # "Unable to infer file and line number from backtrace"
-        e = java.lang.OutOfMemoryError.new
-        message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
-        expect(exception).to eq(e)
+        begin
+          raise java.lang.AssertionError.new('Hello')
+        rescue java.lang.Error => e
+          message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
+          expect(exception).to eq(e)
+        end
       end
     end
   end

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -48,7 +48,7 @@ describe Rollbar::Notifier do
       it 'extracts java.lang.Exception' do
         begin
           raise java.lang.Exception.new('Hello')
-        rescue java.lang.Exception => e
+        rescue => e
           message, exception, extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
           expect(exception).to eq(e)
         end

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -43,7 +43,7 @@ describe Rollbar::Notifier do
   
   if RUBY_PLATFORM == 'java'
     describe "#extract_arguments" do
-      it "extracts Java exceptions" do
+      it "extracts java.lang.Exception" do
         begin
           raise java.lang.Exception.new("Hello")
         rescue java.lang.Exception => e


### PR DESCRIPTION
Exceptions like `java.lang.OutOfMemoryError` are not inheriting from `java.lang.Exception` but from `java.lang.Error` (as seen here https://docs.oracle.com/javase/8/docs/api/java/lang/OutOfMemoryError.html).

In this PR we intercept `java.lang.Throwable` (instead of `java.lang.Exception`), the common ancestor to `java.lang.Error` and `java.lang.Exception` (https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html), to make sure errors like `java.lang.OutOfMemoryError` are fully reported.