### PR TITLE
GitHub Issue #726: Only collect person.id by default for person tracking

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -31,6 +31,7 @@ module Rollbar
     attr_accessor :person_id_method
     attr_accessor :person_username_method
     attr_accessor :person_email_method
+    attr_accessor :person_collect_email_username
     attr_accessor :populate_empty_backtraces
     attr_accessor :report_dj_data
     attr_accessor :open_timeout
@@ -92,6 +93,7 @@ module Rollbar
       @person_id_method = 'id'
       @person_username_method = 'username'
       @person_email_method = 'email'
+      @person_collect_email_username = false
       @project_gems = []
       @populate_empty_backtraces = false
       @report_dj_data = true

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -92,7 +92,13 @@ module Rollbar
       data[:uuid] = SecureRandom.uuid if defined?(SecureRandom) && SecureRandom.respond_to?(:uuid)
 
       Util.deep_merge(data, configuration.payload_options)
+      
       Util.deep_merge(data, scope)
+      
+      if !configuration.person_collect_email_username && data[:person].is_a?(Hash)
+        data[:person].delete(:username)
+        data[:person].delete(:email)
+      end
 
       # Our API doesn't allow null context values, so just delete
       # the key if value is nil.

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -21,6 +21,7 @@ module Rollbar
     @file_semaphore = Mutex.new
 
     def initialize(parent_notifier = nil, payload_options = nil, scope = nil)
+      
       if parent_notifier
         self.configuration = parent_notifier.configuration.clone
         self.scope_object = parent_notifier.scope_object.clone
@@ -126,6 +127,7 @@ module Rollbar
     #   Rollbar.log(e, 'This is a description of the exception')
     #
     def log(level, *args)
+      
       return 'disabled' unless configuration.enabled
 
       message, exception, extra, context = extract_arguments(args)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -334,15 +334,31 @@ describe HomeController do
         end
 
         before { cookies[:session_id] = user.id }
-
+        
         it 'sends the current user data' do
           put '/report_exception', *wrap_process_args({ 'foo' => 'bar' })
 
           person_data = Rollbar.last_report[:person]
 
           expect(person_data[:id]).to be_eql(user.id)
-          expect(person_data[:email]).to be_eql(user.email)
-          expect(person_data[:username]).to be_eql(user.username)
+        end
+
+        context 'with person_collect_email_username enable' do
+          before do
+            Rollbar.configure do |config|
+              config.person_collect_email_username = true
+            end
+          end
+          
+          it 'sends the current user data' do
+            put '/report_exception', *wrap_process_args({ 'foo' => 'bar' })
+  
+            person_data = Rollbar.last_report[:person]
+  
+            expect(person_data[:id]).to be_eql(user.id)
+            expect(person_data[:email]).to be_eql(user.email)
+            expect(person_data[:username]).to be_eql(user.username)
+          end
         end
       end
     end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -664,6 +664,52 @@ describe Rollbar::Item do
         expect(subject).to be_ignored
       end
     end
+    
+    context 'with person data' do
+      let(:ignored_ids) { [1,2,4] }
+      let(:person_data) do
+        { :person => {
+            :id => 2,
+            :username => 'foo',
+            :email => 'foo@bar.com'
+          }
+        }
+      end
+      let(:scope) { Rollbar::LazyStore.new(person_data) }
+      
+      it 'scrubs the person identifiable information' do
+        result = subject.build
+
+        expect(result['data'][:person]).to_not have_key(:username)
+        expect(result['data'][:person]).to_not have_key(:email)
+      end
+      
+      context 'with person_collect_email_username enabled' do
+        before do
+          configuration.person_collect_email_username = true
+        end
+        
+        it 'does not scrub the person identifiable information' do
+          result = subject.build
+  
+          expect(result['data'][:person]).to have_key(:username)
+          expect(result['data'][:person]).to have_key(:email)
+        end
+      end
+      
+      context 'with person_collect_email_username disabled' do
+        before do
+          configuration.person_collect_email_username = false
+        end
+        
+        it 'scrubs the person identifiable information' do
+          result = subject.build
+  
+          expect(result['data'][:person]).to_not have_key(:username)
+          expect(result['data'][:person]).to_not have_key(:email)
+        end
+      end
+    end
 
   end # end #build
 

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -117,7 +117,7 @@ describe Rollbar do
       Rollbar.report_message_with_request('Test message', 'info', request_data, person_data, extra_data)
 
       Rollbar.last_report[:request].should == request_data
-      Rollbar.last_report[:person].should == person_data
+      Rollbar.last_report[:person].should == {id: person_data[:id]}
       Rollbar.last_report[:body][:message][:extra][:extra_foo].should == 'extra_bar'
     end
   end

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -117,7 +117,7 @@ describe Rollbar do
       Rollbar.report_message_with_request('Test message', 'info', request_data, person_data, extra_data)
 
       Rollbar.last_report[:request].should == request_data
-      Rollbar.last_report[:person].should == {id: person_data[:id]}
+      Rollbar.last_report[:person].should == {:id => person_data[:id]}
       Rollbar.last_report[:body][:message][:extra][:extra_foo].should == 'extra_bar'
     end
   end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -973,7 +973,7 @@ describe Rollbar do
       Rollbar.info("Test message", extra_data)
 
       Rollbar.last_report[:request].should == request_data
-      Rollbar.last_report[:person].should == {id: person_data[:id]}
+      Rollbar.last_report[:person].should == {:id => person_data[:id]}
       Rollbar.last_report[:body][:message][:extra][:extra_foo].should == 'extra_bar'
     end
   end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -973,7 +973,7 @@ describe Rollbar do
       Rollbar.info("Test message", extra_data)
 
       Rollbar.last_report[:request].should == request_data
-      Rollbar.last_report[:person].should == person_data
+      Rollbar.last_report[:person].should == {id: person_data[:id]}
       Rollbar.last_report[:body][:message][:extra][:extra_foo].should == 'extra_bar'
     end
   end


### PR DESCRIPTION
PR addressing https://github.com/rollbar/rollbar-gem/issues/726

By default, we don't send any Person Data to Rollbar. However, this can be turned on with config option `person_collect_email_username` which will start collecting the current user's email and username.