### PR TITLE
GitHub Issue 727: Allow IP collection to be easily turned on and off in config

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -43,6 +43,7 @@ module Rollbar
     attr_accessor :scrub_fields
     attr_accessor :scrub_user
     attr_accessor :scrub_password
+    attr_accessor :collect_user_ip
     attr_accessor :user_ip_obfuscator_secret
     attr_accessor :randomize_scrub_length
     attr_accessor :uncaught_exception_level
@@ -120,6 +121,7 @@ module Rollbar
       @project_gem_paths = []
       @use_exception_level_filters_default = false
       @proxy = nil
+      @collect_user_ip = true
     end
 
     def initialize_copy(orig)

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -131,6 +131,7 @@ module Rollbar
     end
 
     def rollbar_user_ip(env)
+      return nil unless Rollbar.configuration.collect_user_ip
       user_ip_string = (env['action_dispatch.remote_ip'] || env['HTTP_X_REAL_IP'] || x_forwarded_for_client(env['HTTP_X_FORWARDED_FOR']) || env['REMOTE_ADDR']).to_s
 
       Rollbar::Util::IPObfuscator.obfuscate_ip(user_ip_string)

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -138,6 +138,18 @@ describe Rollbar::RequestDataExtractor do
 
           expect(result[:user_ip]).to be_eql('2.2.2.2')
         end
+        
+        context 'with collect_user_ip configuration option disabled' do
+          before do
+            Rollbar.configuration.collect_user_ip = false
+          end
+          
+          it 'does not extract user\'s IP' do
+            result = subject.extract_request_data_from_rack(env)
+  
+            expect(result[:user_ip]).to be_nil
+          end
+        end
       end
 
       context 'with private first client IP' do


### PR DESCRIPTION
PR addressing https://github.com/rollbar/rollbar-gem/issues/727

Adds `collect_user_ip` config option defaulting to `true` which determines if the user's IP address should be collected.