### PR TITLE
GitHub Issue #728: Anonymize IP address config option

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -44,6 +44,7 @@ module Rollbar
     attr_accessor :scrub_user
     attr_accessor :scrub_password
     attr_accessor :collect_user_ip
+    attr_accessor :anonymize_user_ip
     attr_accessor :user_ip_obfuscator_secret
     attr_accessor :randomize_scrub_length
     attr_accessor :uncaught_exception_level
@@ -122,6 +123,7 @@ module Rollbar
       @use_exception_level_filters_default = false
       @proxy = nil
       @collect_user_ip = true
+      @anonymize_user_ip = false
     end
 
     def initialize_copy(orig)

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -5,6 +5,7 @@ require 'rollbar/scrubbers'
 require 'rollbar/scrubbers/url'
 require 'rollbar/scrubbers/params'
 require 'rollbar/util/ip_obfuscator'
+require 'rollbar/util/ip_anonymizer'
 require 'rollbar/json'
 
 module Rollbar
@@ -133,6 +134,8 @@ module Rollbar
     def rollbar_user_ip(env)
       return nil unless Rollbar.configuration.collect_user_ip
       user_ip_string = (env['action_dispatch.remote_ip'] || env['HTTP_X_REAL_IP'] || x_forwarded_for_client(env['HTTP_X_FORWARDED_FOR']) || env['REMOTE_ADDR']).to_s
+
+      user_ip_string = Rollbar::Util::IPAnonymizer.anonymize_ip(user_ip_string)
 
       Rollbar::Util::IPObfuscator.obfuscate_ip(user_ip_string)
     rescue

--- a/lib/rollbar/util/ip_anonymizer.rb
+++ b/lib/rollbar/util/ip_anonymizer.rb
@@ -1,0 +1,40 @@
+module Rollbar
+  module Util
+    module IPAnonymizer
+      require 'ipaddr'
+
+      def self.anonymize_ip(ip_string)
+        return ip_string unless Rollbar.configuration.anonymize_user_ip
+        
+        ip = IPAddr.new(ip_string)
+          
+        if ip.ipv6?
+          return anonymize_ipv6 ip
+        end
+        
+        if ip.ipv4?
+          return anonymize_ipv4 ip
+        end
+        
+      rescue
+        nil
+      end
+      
+      def self.anonymize_ipv4(ip)
+        ip_parts = ip.to_s.split '.'
+        
+        ip_parts[ip_parts.count-1] = "0"
+        
+        IPAddr.new(ip_parts.join('.')).to_s
+      end
+      
+      def self.anonymize_ipv6(ip)
+        ip_parts = ip.to_s.split ':'
+        
+        ip_string = ip_parts[0..2].join(':') + ':0000:0000:0000:0000:0000'
+        
+        IPAddr.new(ip_string).to_s
+      end
+    end
+  end
+end

--- a/lib/rollbar/util/ip_anonymizer.rb
+++ b/lib/rollbar/util/ip_anonymizer.rb
@@ -5,17 +5,9 @@ module Rollbar
 
       def self.anonymize_ip(ip_string)
         return ip_string unless Rollbar.configuration.anonymize_user_ip
-        
         ip = IPAddr.new(ip_string)
-          
-        if ip.ipv6?
-          return anonymize_ipv6 ip
-        end
-        
-        if ip.ipv4?
-          return anonymize_ipv4 ip
-        end
-        
+        return anonymize_ipv6 ip if ip.ipv6?
+        return anonymize_ipv4 ip if ip.ipv4?
       rescue
         nil
       end
@@ -23,7 +15,7 @@ module Rollbar
       def self.anonymize_ipv4(ip)
         ip_parts = ip.to_s.split '.'
         
-        ip_parts[ip_parts.count-1] = "0"
+        ip_parts[ip_parts.count - 1] = '0'
         
         IPAddr.new(ip_parts.join('.')).to_s
       end

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -150,6 +150,18 @@ describe Rollbar::RequestDataExtractor do
             expect(result[:user_ip]).to be_nil
           end
         end
+        
+        context 'with anonymize_user_ip configuration option enabled' do
+          before do
+            Rollbar.configuration.anonymize_user_ip = true
+          end
+          
+          it 'it anonymizes the IPv4 address' do
+            result = subject.extract_request_data_from_rack(env)
+  
+            expect(result[:user_ip]).to be_eql('2.2.2.0')
+          end
+        end
       end
 
       context 'with private first client IP' do

--- a/spec/rollbar/util/ip_anonymizer_spec.rb
+++ b/spec/rollbar/util/ip_anonymizer_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'rollbar/util/ip_anonymizer'
+
+describe Rollbar::Util::IPAnonymizer do
+  
+  before do
+    Rollbar.configuration.anonymize_user_ip = true
+  end
+  
+  context 'with IPv4 address' do
+    let(:ip) { '127.0.0.1' }
+    
+    it 'anonymizes the IP by replacing the last octet with 0' do
+      anonymized_ip = described_class.anonymize_ip(ip)
+  
+      expect(anonymized_ip).to be_eql(IPAddr.new('127.0.0.0').to_s)
+    end
+  end
+  
+  context 'with IPv6 address' do
+    let(:ip) { '2001:0db8:85a3:0000:0000:8a2e:0370:7334' }
+    
+    it 'anonymizes the IP by replacing the last 80 bits with 0' do
+      
+      anonymized_ip = described_class.anonymize_ip(ip)
+  
+      expect(anonymized_ip).to be_eql(IPAddr.new('2001:db8:85a3::').to_s)
+    end
+  end
+end


### PR DESCRIPTION
PR addressing https://github.com/rollbar/rollbar-gem/issues/728

Adds config option `anonymize_user_ip` that defaults to `false`. It anonymizes the IP address recorded in Rollbar following the Google Analytics algorithm: https://support.google.com/analytics/answer/2763052

This is different than `user_ip_obfuscator_secret` which encodes the user IP address using a secret string creating a unique derivative of the IP address.