### PR TITLE
[Docs] Mention #default_logger is Rails.logger when using Rails project

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ end
 
 ### default_logger
 
-**Default** `Logger.new(STDERR)`
+**Default** `Logger.new(STDERR)` or `::Rails.logger` when using Rails
 
 What logger to use for printing debugging and informational messages during
 operation.


### PR DESCRIPTION
Per:

https://github.com/rollbar/rollbar-gem/blob/137aed9014772404dfb0c8a6dab18adc3983ded2/lib/rollbar/plugins/rails/railtie_mixin.rb#L13-L21

`Rollbar.default_logger` will return Rails' configured logger instance instead of `Logger.new(STDERR)`