### PR TITLE
Add Rollbar.configuration.logger_level

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,12 @@ end
 What logger to use for printing debugging and informational messages during
 operation.
 
+### logger_level
+
+**Default** `:info`
+
+Regardless of what Logger you're using, Rollbar will not proxy logs to it if its less than this particular level.
+
 ### disable_monkey_patch
 
 **Default** `false`

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -12,7 +12,7 @@ module Rollbar
     attr_accessor :custom_data_method
     attr_accessor :delayed_job_enabled
     attr_accessor :default_logger
-    attr_accessor :logger_level
+    attr_reader :logger_level
     attr_accessor :disable_monkey_patch
     attr_accessor :disable_rack_monkey_patch
     attr_accessor :disable_core_monkey_patch

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -12,6 +12,7 @@ module Rollbar
     attr_accessor :custom_data_method
     attr_accessor :delayed_job_enabled
     attr_accessor :default_logger
+    attr_accessor :logger_level
     attr_accessor :disable_monkey_patch
     attr_accessor :disable_rack_monkey_patch
     attr_accessor :disable_core_monkey_patch
@@ -73,6 +74,7 @@ module Rollbar
       @code_version = nil
       @custom_data_method = nil
       @default_logger = lambda { ::Logger.new(STDERR) }
+      @logger_level = :info
       @delayed_job_enabled = true
       @disable_monkey_patch = false
       @disable_core_monkey_patch = false
@@ -243,6 +245,10 @@ module Rollbar
     # allow params to be read like a hash
     def [](option)
       send(option)
+    end
+
+    def logger_level=(level)
+      @logger_level = level.to_sym
     end
 
     def logger

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -23,7 +23,7 @@ module Rollbar
     end
 
     def log(level, message)
-      return unless Rollbar.configuration.enabled || acceptable_levels.include?(level.to_sym)
+      return unless Rollbar.configuration.enabled && acceptable_levels.include?(level.to_sym)
 
       @object.send(level, message)
     rescue

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -23,8 +23,7 @@ module Rollbar
     end
 
     def log(level, message)
-      return unless Rollbar.configuration.enabled
-      return unless acceptable_levels.include? level.to_sym
+      return unless Rollbar.configuration.enabled || acceptable_levels.include?(level.to_sym)
 
       @object.send(level, message)
     rescue

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -24,11 +24,21 @@ module Rollbar
 
     def log(level, message)
       return unless Rollbar.configuration.enabled
+      return unless acceptable_levels.include? level.to_sym
 
       @object.send(level, message)
     rescue
       puts "[Rollbar] Error logging #{level}:"
       puts "[Rollbar] #{message}"
+    end
+
+    protected
+
+    def acceptable_levels
+      @acceptable_levels ||= begin
+        levels = %i[debug info warn error]
+        levels[levels.find_index(Rollbar.configuration.logger_level)..-1]
+      end
     end
   end
 end

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -35,7 +35,7 @@ module Rollbar
 
     def acceptable_levels
       @acceptable_levels ||= begin
-        levels = %i[debug info warn error]
+        levels = [:debug, :info, :warn, :error]
         levels[levels.find_index(Rollbar.configuration.logger_level)..-1]
       end
     end

--- a/spec/rollbar/logger_proxy_spec.rb
+++ b/spec/rollbar/logger_proxy_spec.rb
@@ -8,6 +8,7 @@ describe Rollbar::LoggerProxy do
 
   before do
     allow(Rollbar.configuration).to receive(:enabled).and_return(true)
+    allow(Rollbar.configuration).to receive(:logger_level).and_return(:debug)
   end
 
   shared_examples 'delegate to logger' do
@@ -44,6 +45,24 @@ describe Rollbar::LoggerProxy do
         allow(logger).to receive(:info).and_raise(StandardError.new)
 
         expect { subject.log('info', message) }.not_to raise_error
+      end
+    end
+
+    context 'if logger_level is :info' do
+      before do
+        allow(Rollbar.configuration).to receive(:logger_level).and_return(:info)
+      end
+
+      it 'doesnt call the logger (debug)' do
+        expect(logger).to_not receive(:debug)
+
+        subject.log('debug', 'foo')
+      end
+
+      it 'calls the logger (error)' do
+        expect(logger).to receive(:error)
+
+        subject.log('error', 'foo')
       end
     end
   end


### PR DESCRIPTION
This allows customization where Rollbar may be used inside a Rails project that has a production Rails.logger's log_level set to :info but does not want internal Rollbar entries all over the place.

Just because an app has its default logger set to a particular log level doesn't mean it wants Rollbar's own log level to mimic that.

### Realistic use case:

1. I use Rails
2. My `Rails.logger` goes to Logstash (`LogStashLogger`)
3. My log level is `:info` for valuable domain-specific investigation
4. I use Rollbar
6. By default Rollbar uses `Rails.logger`
6. Rollbar writes its internal logging to my logstash, reserved for domain-specific, terse info logs:

![screen shot 2018-05-16 at 1 03 16 pm](https://user-images.githubusercontent.com/740289/40151185-62e65a9a-594c-11e8-901e-215076366d4b.png)

7. Because of legacy reasons, there are a lot of workers or processes that generate Rollbar instances but don't want that polluting logstash