### PR TITLE
Fix shoryuken handler undefined method call

### DIFF
--- a/lib/rollbar/delay/shoryuken.rb
+++ b/lib/rollbar/delay/shoryuken.rb
@@ -8,6 +8,10 @@ module Rollbar
     class Shoryuken
       include ::Shoryuken::Worker
 
+      def self.call(payload)
+        new.call(payload)
+      end
+
       def self.queue_name
         "rollbar_#{Rollbar.configuration.environment}"
       end

--- a/spec/rollbar/delay/shoryuken_spec.rb
+++ b/spec/rollbar/delay/shoryuken_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'rollbar/delay/shoryuken'
+
+describe Rollbar::Delay::Shoryuken do
+  describe '.call' do
+    let(:payload) do
+      { :key => 'value' }
+    end
+
+    let(:loaded_hash) do
+      Rollbar::JSON.load(Rollbar::JSON.dump(payload))
+    end
+
+    it 'process the payload' do
+      Shoryuken.worker_executor = Shoryuken::Worker::InlineExecutor
+      expect(Rollbar).to receive(:process_from_async_handler).with(loaded_hash)
+      described_class.call(payload)
+      Shoryuken.worker_executor = Shoryuken::Worker::DefaultExecutor
+    end
+  end
+end


### PR DESCRIPTION
[`process_async_item(item)`](https://github.com/rollbar/rollbar-gem/blob/master/lib/rollbar/notifier.rb#L668) tries to call `configuration.async_handler.call(item.payload)` for `Rollbar::Delay::Shoryuken` class even though there's no `self.call` defined which results in
```ruby
#<NoMethodError: undefined method `call' for Rollbar::Delay::Shoryuken:Class>
```

