### PR TITLE
Support URI reserved characters in proxy server passwords.

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -530,14 +530,15 @@ module Rollbar
     end
 
     def proxy_from_config
-      proxy = configuration.proxy
-      return nil unless proxy
+      proxy_settings = configuration.proxy
+      return nil unless proxy_settings
 
-      px = URI.parse(proxy[:host])
-      px.port = proxy[:port]
-      px.user = proxy[:user]
-      px.password = proxy[:password]
-      px
+      proxy = null_proxy
+      proxy.host = URI.parse(proxy_settings[:host]).host
+      proxy.port = proxy_settings[:port]
+      proxy.user = proxy_settings[:user]
+      proxy.password = proxy_settings[:password]
+      proxy
     end
 
     def proxy_from_env(uri)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1043,18 +1043,20 @@ describe Rollbar do
     end
 
     context 'via environment variables' do
+      before do
+        @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
+      end
+
       it 'honors proxy settings in the environment' do
         ENV['http_proxy']  = 'http://user:pass@example.com:80'
         ENV['https_proxy'] = 'http://user:pass@example.com:80'
 
-        uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
-        expect(Net::HTTP).to receive(:new).with(uri.host, uri.port, 'example.com', 80, 'user', 'pass').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'example.com', 80, 'user', 'pass').and_call_original
         Rollbar.info("proxy this")
       end
 
       it 'does not use a proxy if no proxy settings in environemnt' do
-        uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
-        expect(Net::HTTP).to receive(:new).with(uri.host, uri.port, nil, nil, nil, nil).and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil, nil).and_call_original
         Rollbar.info("proxy this")
       end
     end
@@ -1069,11 +1071,12 @@ describe Rollbar do
             :password => 'bar'
           }
         end
+
+        @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
       end
 
       it 'honors proxy settings in the config file' do
-        uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
-        expect(Net::HTTP).to receive(:new).with(uri.host, uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
         Rollbar.info("proxy this")
       end
 
@@ -1081,8 +1084,16 @@ describe Rollbar do
         ENV['http_proxy']  = 'http://user:pass@example.com:80'
         ENV['https_proxy'] = 'http://user:pass@example.com:80'
 
-        uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
-        expect(Net::HTTP).to receive(:new).with(uri.host, uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
+        Rollbar.info("proxy this")
+      end
+
+      it 'allows @-signs in passwords' do
+        Rollbar.configure do |config|
+          config.proxy[:password] = "manh@tan"
+	end
+
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'manh@tan').and_call_original
         Rollbar.info("proxy this")
       end
     end


### PR DESCRIPTION
I was the guy who submitted the original PR for proxy server support in Rollbar. Unfortunately, that code will fail in the proxy requires authentication, the credentials include URI-reserved characters, such as '@' or '?', and the credentials are provided as part of the Rollbar configuration.

This PR addresses that by holding the proxy configuration information in a Struct instead of a URI object. This PR includes tests, but the fix has also been tested in a runtime environment.