### PR TITLE
GitHub Issue 544: warning: method redefined; discarding old use_eventmachine=

### DIFF
--- a/lib/rollbar/plugins/rails/railtie_mixin.rb
+++ b/lib/rollbar/plugins/rails/railtie_mixin.rb
@@ -1,5 +1,3 @@
-require 'rollbar'
-
 module Rollbar
   module RailtieMixin
     extend ActiveSupport::Concern


### PR DESCRIPTION
This PR removes a circular Rollbar dependency from `railtie_mixn.rb`

https://github.com/rollbar/rollbar-gem/issues/544