### PR TITLE
Update Rollbar gem to support secure_headers 6.x

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -157,8 +157,8 @@ module Rollbar
       def append_nonce?
         defined?(::SecureHeaders) && ::SecureHeaders.respond_to?(:content_security_policy_script_nonce) &&
           defined?(::SecureHeaders::Configuration) &&
-          !::SecureHeaders::Configuration.default.csp.opt_out? &&
-          !::SecureHeaders::Configuration.default.current_csp[:script_src].to_a.include?("'unsafe-inline'")
+          !::SecureHeaders::Configuration.dup.csp.opt_out? &&
+          !::SecureHeaders::Configuration.dup.csp[:script_src].to_a.include?("'unsafe-inline'")
       end
     end
   end


### PR DESCRIPTION
The secure_headers 6.x gem changed the interface for accessing the
configuration object. Trying to use `default` yields an exception now.
This is the new interface.

I know that this was _just_ changed for @marunbai's PR https://github.com/rollbar/rollbar-gem/pull/730. However, it looks like the latest version of secure headers has changed this yet again. This fixes it immediately.

A few additional thoughts:

1) Since there is no hard dependency on a specific version of SecureHeaders in the Gemfile, it makes these kinds of changes really hard to track—they just pop up on you and break things... would it make sense to introduce a hard dependency on SecureHeaders? Probably not as that is probably not something many people want.

2) ... so, would it make sense to pull some of this coupling between rollbar-gem and secure-headers into a separate integration gem, say, `rollbar-gem-secure-headers` so that dependencies could be more accurately tracked?

I'd love to get _this_ fix out asap, but it might be worth thinking about 2...