### PR TITLE
GitHub Issue 703: Feature request: reporting error hooks

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -128,6 +128,10 @@ module Rollbar
       @proxy = nil
       @collect_user_ip = true
       @anonymize_user_ip = false
+      @hooks = {
+        :on_error_response => nil, # params: response
+        :on_report_internal_error => nil, #params: exception
+      }
     end
 
     def initialize_copy(orig)
@@ -258,6 +262,22 @@ module Rollbar
 
     def logger
       @logger ||= default_logger.call
+    end
+    
+    def hook(symbol, &block)
+      if @hooks.has_key?(symbol)
+        if block_given?
+          @hooks[symbol] = block
+        else
+          @hooks[symbol]
+        end
+      else
+        raise StandardError.new "Hook :" + symbol.to_s + " is not supported by Rollbar SDK."
+      end
+    end
+    
+    def execute_hook(symbol, *args)
+      hook(symbol).call(*args) if hook(symbol).is_a?(Proc)
     end
   end
 end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -407,6 +407,8 @@ module Rollbar
     # If that fails, we'll fall back to a more static failsafe response.
     def report_internal_error(exception)
       log_error '[Rollbar] Reporting internal error encountered while sending data to Rollbar.'
+      
+      configuration.execute_hook(:on_report_internal_error, exception)
 
       begin
         item = build_item('error', nil, exception, { :internal => true }, nil)
@@ -575,6 +577,7 @@ module Rollbar
       else
         log_warning "[Rollbar] Got unexpected status code from Rollbar api: #{response.code}"
         log_info "[Rollbar] Response: #{response.body}"
+        configuration.execute_hook(:on_error_response, response)
       end
     end
 

--- a/spec/rollbar/configuration_spec.rb
+++ b/spec/rollbar/configuration_spec.rb
@@ -43,4 +43,32 @@ describe Rollbar::Configuration do
       expect(new_config.environment).to be_eql('bar')
     end
   end
+  
+  describe '#hook' do
+    it "assigns and returns the appropriate hook" do
+      subject.hook :on_error_response do
+        puts "foo hook"
+      end
+      
+      expect(subject.hook(:on_error_response).is_a?(Proc)).to be_eql(true)
+    end
+    
+    it "raises a StandardError if requested hook is not supported" do
+      expect{ subject.hook(:foo) }.to raise_error(StandardError)
+    end
+  end
+  
+  describe '#execute_hook' do
+    it "executes the approriate hook" do
+      bar = "test value"
+      
+      subject.hook :on_error_response do
+        bar = "changed value"
+      end
+      
+      subject.execute_hook :on_error_response
+      
+      expect(bar).to be_eql("changed value")
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses feature request #703 

Adds configuration hooks which allow for executing arbitrary logic in selected points of the SDK:
* `:on_error_response`: when Rollbar API responded with a status code different than 200
* `:on_report_internal_error`: when an exception was thrown in the SDK internally while reporting the error to Rollbar API

**Usage**
```ruby
Rollbar.configure do |config|
  config.hook :on_error_response do |response|
    ...
  end
end
```