### PR TITLE
Support multiple secure_headers versions

### DIFF
--- a/spec/support/secure_headers_mocks.rb
+++ b/spec/support/secure_headers_mocks.rb
@@ -1,0 +1,83 @@
+module SecureHeadersMocks
+  NONCE = 'lorem-ipsum-nonce'
+
+  module CSP
+    class << self
+      attr_accessor :config
+
+      def opt_out?
+        config[:opt_out?]
+      end
+
+      def [](key)
+        config[key]
+      end
+    end
+  end
+
+  module SecureHeaders20
+  end
+
+  module SecureHeaders30
+    OPT_OUT = :opt_out
+    class << self
+      def content_security_policy_script_nonce(req)
+        NONCE
+      end
+    end
+
+    module Configuration
+      module CSPProxy
+        def self.csp
+          return OPT_OUT if CSP.opt_out?
+
+          CSP.config
+        end
+      end
+
+      def self.get
+        CSPProxy
+      end
+    end
+  end
+
+  module SecureHeaders35
+    class << self
+      def content_security_policy_script_nonce(req)
+        NONCE
+      end
+    end
+
+    module Configuration
+      module CSPProxy
+        def self.csp
+          CSP
+        end
+      end
+
+      def self.get
+        CSPProxy
+      end
+    end
+  end
+
+  module SecureHeaders60
+    class << self
+      def content_security_policy_script_nonce(req)
+        NONCE
+      end
+    end
+
+    module Configuration
+      module CSPProxy
+        def self.csp
+          CSP
+        end
+      end
+
+      def self.dup
+        CSPProxy
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR tries to fix https://github.com/rollbar/rollbar-gem/issues/712 and make the gem work with different secure_headers versions.

https://github.com/twitter/secure_headers doesn't define a `VERSION` constant and makes tricky to detect which interface to use. Depending on few checks we return a class that will take care of the interface to use.

I've tested manually the implementation using secure_headers versions from 2.x to 6.x passing by different versions 3.x (which is the major version with more minor versions). Things seem to work fine and now looks a bit easier extending the behavior if secure_headers changes the interface...

Some mocks are used in the tests to simulate the different secure_headers versions. Tests have been refactored a bit so we have few shared examples that can be used from secure_headers > 3.x.

It seems trying to be compatible with secure_headers 2.x is not easy cause the way they define the `nonce` so that version will be still unsupported. 