### PR TITLE
Remove invalid ** usages from dummyapp/.gitignore

### DIFF
--- a/spec/dummyapp/.gitignore
+++ b/spec/dummyapp/.gitignore
@@ -21,7 +21,7 @@ db/*.sqlite3
 /tmp/*
 
 # various artifacts
-**.war
+**/*.war
 *.rbc
 *.sassc
 .rspec
@@ -55,7 +55,7 @@ pickle-email-*.html
 # Here are some files you may want to ignore globally:
 
 # scm revert files
-**.orig
+**/*.orig
 
 # Mac finder artifacts
 .DS_Store
@@ -70,4 +70,4 @@ pickle-email-*.html
 /*.tmproj
 
 # vim artifacts
-**.swp
+**/*.swp


### PR DESCRIPTION
https://git-scm.com/docs/gitignore says that double asterisk patterns in gitignore are only valid when used with directory separators, i.e. `**/...`, `.../**`, and `.../**/...`.

I noticed this when using [ripgrep](https://github.com/BurntSushi/ripgrep). It seems that its interpretation of ignore patterns is stricter than Git's:

```
$ rg something
./vendor/bundle/ruby/2.4.0/gems/rollbar-2.18.0/spec/dummyapp/.gitignore: line 24: error parsing glob '**.war': invalid use of **; must be one path component
./vendor/bundle/ruby/2.4.0/gems/rollbar-2.18.0/spec/dummyapp/.gitignore: line 58: error parsing glob '**.orig': invalid use of **; must be one path component
./vendor/bundle/ruby/2.4.0/gems/rollbar-2.18.0/spec/dummyapp/.gitignore: line 73: error parsing glob '**.swp': invalid use of **; must be one path component
...
```