### PR TITLE
Test Ruby 2.3 and Rails 5.2 in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ gemfile:
   - gemfiles/rails42.gemfile
   - gemfiles/rails50.gemfile
   - gemfiles/rails51.gemfile
+  - gemfiles/rails52.gemfile
 matrix:
   include:
     - rvm: 1.8.7
@@ -124,6 +125,8 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: 1.8.7
       gemfile: gemfiles/rails51.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails52.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/rails31.gemfile
     - rvm: 1.9.2
@@ -138,18 +141,26 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/rails51.gemfile
+    - rvm: 1.9.2
+      gemfile: gemfiles/rails52.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails50.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails51.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/rails52.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails52.gemfile
     - rvm: 2.1.0
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.1.0
       gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.1.0
+      gemfile: gemfiles/rails52.gemfile
     - rvm: 2.2.2
       gemfile: gemfiles/rails30.gemfile
     - rvm: 2.2.2
@@ -174,6 +185,8 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: jruby-18mode
       gemfile: gemfiles/rails51.gemfile
+    - rvm: jruby-18mode
+      gemfile: gemfiles/rails52.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails30.gemfile
     - rvm: jruby-19mode
@@ -190,6 +203,8 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails51.gemfile
+    - rvm: jruby-19mode
+      gemfile: gemfiles/rails52.gemfile
     - rvm: rbx
       gemfile: gemfiles/rails30.gemfile
     - rvm: rbx
@@ -206,3 +221,5 @@ matrix:
       gemfile: gemfiles/rails50.gemfile
     - rvm: rbx
       gemfile: gemfiles/rails51.gemfile
+    - rvm: rbx
+      gemfile: gemfiles/rails52.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.2
+  - 2.3.0
   - jruby-18mode
   - jruby-19mode
   - rbx
@@ -88,6 +89,12 @@ matrix:
       jdk: oraclejdk7
     - rvm: 2.2.2
       jdk: oraclejdk8
+    - rvm: 2.3.0
+      jdk: openjdk6
+    - rvm: 2.3.0
+      jdk: oraclejdk7
+    - rvm: 2.3.0
+      jdk: oraclejdk8
 
     - rvm: ruby-head
       jdk: openjdk6
@@ -146,6 +153,10 @@ matrix:
     - rvm: 2.2.2
       gemfile: gemfiles/rails30.gemfile
     - rvm: 2.2.2
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.3.0
       gemfile: gemfiles/rails31.gemfile
     - rvm: jruby-18mode
       gemfile: gemfiles/rails30.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,10 @@ matrix:
       gemfile: gemfiles/rails41.gemfile
     - rvm: jruby-18mode
       gemfile: gemfiles/rails42.gemfile
+    - rvm: jruby-18mode
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: jruby-18mode
+      gemfile: gemfiles/rails51.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails30.gemfile
     - rvm: jruby-19mode

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -1,0 +1,52 @@
+require 'rubygems/version'
+
+source 'https://rubygems.org'
+
+is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
+
+gem 'appraisal'
+gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
+gem 'jruby-openssl', :platform => :jruby
+gem 'rails', '~> 5.2.0'
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+
+gem 'rspec-core', '~> 3.8.0'
+gem 'rspec-rails', '~> 3.8.0'
+gem 'rspec-support', '~> 3.8.0'
+gem 'rspec-expectations', '~> 3.8.0'
+gem 'rspec-mocks', '~> 3.8.0'
+
+gem 'rake'
+
+gem 'oj', '~> 2.16.1' unless is_jruby
+
+gem 'sidekiq', '>= 2.13.0'
+
+platforms :rbx do
+  gem 'minitest'
+  gem 'racc'
+  gem 'rubinius-developer_tools'
+  gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
+end
+
+gem 'sucker_punch', '~> 2.0'
+
+# We need last sinatra that uses rack 2.x
+gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil
+gem 'database_cleaner', '~> 1.x'
+gem 'delayed_job', :require => false
+gem 'generator_spec'
+gem 'girl_friday', '>= 0.11.1'
+gem 'redis'
+gem 'resque'
+
+gem 'mime-types'
+
+gem 'webmock', :require => false
+
+gem 'aws-sdk-sqs'
+gem 'shoryuken'
+
+gemspec :path => '../'


### PR DESCRIPTION
The CI for this gem is behind on the latest Rubies and Rails.

There are three commits:

* Add Ruby 2.3.0.
* Skip JRuby 1.8 tests for Rails 5.
* Add a Rails 5.2 Gemfile and test Ruby 2.2.2 and 2.3.0 against it.

I'd like to add Ruby 2.4 and 2.5 as well, but these versions seem to have some issues with the current gemfiles. I'll look into those later if I have time.
