### PR TITLE
Make `logger` a public method.

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -295,6 +295,10 @@ module Rollbar
       end
     end
 
+    def logger
+      @logger ||= LoggerProxy.new(configuration.logger)
+    end
+
     private
 
     def use_exception_level_filters?(options)
@@ -705,10 +709,6 @@ module Rollbar
 
       uuid_url = Util.uuid_rollbar_url(data, configuration)
       log_info "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
-    end
-
-    def logger
-      @logger ||= LoggerProxy.new(configuration.logger)
     end
   end
 end


### PR DESCRIPTION
In Ruby 2.4+, Rollbar will emit a warning:

`forwarding to private method Rollbar::Notifier#logger`

The delegators of the Ruby Forwardable module expect that all the methods be public. Rollbar has them defined as `PUBLIC_NOTIFIER_METHODS` [here](https://github.com/boone/rollbar-gem/blob/master/lib/rollbar.rb#L25-L33), but the `logger` method is currently private.

This PR just moves the logger method to the public section of the `Rollbar::Notifier` class.
