### PR TITLE
Rework gem regex spec to avoid deprecation warning.

### DIFF
--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1420,7 +1420,10 @@ describe Rollbar do
         config.project_gems = gems
       end
 
-      gem_paths = gems.map{|gem| Gem::Specification.find_all_by_name(gem).map(&:gem_dir) }.flatten.compact.uniq
+      gem_paths = gems.map do |name|
+        Gem::Specification.each.select { |spec| name === spec.name }
+      end.flatten.uniq.map(&:gem_dir)
+
       gem_paths.length.should > 1
 
       gem_paths.any?{|path| path.include? 'rollbar-gem'}.should == true


### PR DESCRIPTION
Currently the specs are outputting this warning:

```
NOTE: Dependency.new w/ a regexp is deprecated.
Dependency.new called from .../lib/ruby/2.2.0/rubygems/specification.rb:910
```

In #120, the warning was fixed in the main code but not the specs. This PR fixes the specs using the same lookup.

This will also help future-proof the specs, as calling `Gem::Specification.find_all_by_name` with a regex in Ruby 2.4+ will raise an exception:

```
NoMethodError: undefined method `upcase' for /rspec/:Regexp
```
