### PR TITLE
Update gemspec to not include test files to reduce gem byte size

### DIFF
--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://rollbar.com'
   gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.test_files    = gem.files.grep(%r{^(spec)/})
+  gem.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
   gem.name          = 'rollbar'
   gem.require_paths = ['lib']
   gem.version       = Rollbar::VERSION

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -11,10 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Reports exceptions to Rollbar}
   gem.homepage      = 'https://rollbar.com'
   gem.license       = 'MIT'
-
-  gem.files         = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   gem.name          = 'rollbar'
   gem.require_paths = ['lib']
   gem.version       = Rollbar::VERSION

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://rollbar.com'
   gem.license       = 'MIT'
 
-  gem.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  gem.files         = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   gem.name          = 'rollbar'


### PR DESCRIPTION
The rollbar .gem file is [currently 264kb](https://rubygems.org/gems/rollbar/versions). The majority of this is from unnecessarily including the 800kb (uncompressed) spec/ files in the gem, which is unnecessary. For the `files` directive, I've replicated the current syntax from the current `bundle gem foo` generator. I have also removed the `test_files` directive, which doesn't seem useful, nor is it in [the current gemspec reference](https://guides.rubygems.org/specification-reference/).

I've manually confirmed that `gem build rollbar.gemspec` succeeds with the changes.

Pros: Less network bandwidth, less disk consumed, slightly faster builds. Cons: None.