### PR TITLE
Make whitelisting ignore filter_parameters

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -60,7 +60,8 @@ module Rollbar
     def scrub_url(url, sensitive_params)
       options = {
         :url => url,
-        :scrub_fields => Array(Rollbar.configuration.scrub_fields) + sensitive_params,
+        :scrub_fields => Array(Rollbar.configuration.scrub_fields),
+        :extra_fields => sensitive_params,
         :scrub_user => Rollbar.configuration.scrub_user,
         :scrub_password => Rollbar.configuration.scrub_password,
         :randomize_scrub_length => Rollbar.configuration.randomize_scrub_length,

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -21,7 +21,7 @@ module Rollbar
         return {} unless params
 
         config = options[:config]
-        extra_fields = options[:extra_fields]
+        extra_fields = options[:whitelist] ? [] : options[:extra_fields]
         whitelist = options[:whitelist] | false
 
         scrub(params, build_scrub_options(config, extra_fields, whitelist))

--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -15,7 +15,7 @@ module Rollbar
         return url unless Rollbar::LanguageSupport.can_scrub_url?
 
         filter(url,
-               build_regex(options[:scrub_fields]),
+               build_regex(options[:scrub_fields], options[:extra_fields], options[:whitelist]),
                options[:scrub_user],
                options[:scrub_password],
                options.fetch(:randomize_scrub_length, true),
@@ -39,7 +39,8 @@ module Rollbar
 
       # Builds a regex to match with any of the received fields.
       # The built regex will also match array params like 'user_ids[]'.
-      def build_regex(fields)
+      def build_regex(scrub_fields, extra_fields, whitelist)
+        fields = whitelist ? scrub_fields : scrub_fields + extra_fields
         fields_or = fields.map { |field| "#{field}(\\[\\])?" }.join('|')
 
         Regexp.new("^#{fields_or}$")

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -31,7 +31,8 @@ describe Rollbar::RequestDataExtractor do
     it 'calls the scrubber with the correct options' do
       expected_options = {
         :url => url,
-        :scrub_fields => [:password, :secret, :param1, :param2],
+        :scrub_fields => [:password, :secret],
+        :extra_fields => [:param1, :param2],
         :scrub_user => true,
         :scrub_password => true,
         :randomize_scrub_length => true,

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -15,10 +15,12 @@ describe Rollbar::Scrubbers::Params do
   end
 
   describe '#call' do
+    let(:extra_fields) { [:secret, :password] }
     let(:options) do
       options = {
-        :params => params,
-        :config => scrub_config
+        params: params,
+        config: scrub_config,
+        extra_fields: extra_fields
       }
       
       if defined? whitelist
@@ -308,9 +310,9 @@ describe Rollbar::Scrubbers::Params do
     
     context 'with :whitelist option' do
       let(:scrub_config) do
-        [:secret, :password]
+        [:foo]
       end
-      
+
       let(:whitelist) { true }
 
       context 'with Array object' do
@@ -327,10 +329,10 @@ describe Rollbar::Scrubbers::Params do
         let(:result) do
           [
             {
-              :foo => /\*+/,
-              :secret => 'the-secret',
-              :password => 'the-password',
-              :password_confirmation => 'the-password'
+              :foo => 'bar',
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
             }
           ]
         end
@@ -351,10 +353,10 @@ describe Rollbar::Scrubbers::Params do
         end
         let(:result) do
           {
-            :foo => /\*+/,
-            :secret => 'the-secret',
-            :password => 'the-password',
-            :password_confirmation => 'the-password'
+            :foo => 'bar',
+            :secret => /\*+/,
+            :password => /\*+/,
+            :password_confirmation => /\*+/
           }
         end
 
@@ -377,21 +379,21 @@ describe Rollbar::Scrubbers::Params do
               :password_confirmation => 'the-password'
             },
             :other => {
-              :param => 'filtered',
+              :param => 'unfiltered',
               :to_scrub => 'to_scrub'
             }
           }
         end
         let(:result) do
           {
-            :foo => /\*+/,
+            :foo => 'bar',
             :extra => {
-              :secret => 'the-secret',
-              :password => 'the-password',
-              :password_confirmation => 'the-password'
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
             },
             :other => {
-              :param => 'filtered',
+              :param => 'unfiltered',
               :to_scrub => /\*+/
             }
           }
@@ -416,21 +418,21 @@ describe Rollbar::Scrubbers::Params do
               :password_confirmation => 'the-password'
             }],
             :other => [{
-              :param => 'filtered',
+              :param => 'unfiltered',
               :to_scrub => 'to_scrub'
             }]
           }
         end
         let(:result) do
           {
-            :foo => /\*+/,
+            :foo => 'bar',
             :extra => [{
-              :secret => 'the-secret',
-              :password => 'the-password',
-              :password_confirmation => 'the-password'
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/
             }],
             :other => [{
-              :param => 'filtered',
+              :param => 'unfiltered',
               :to_scrub => /\*+/
             }]
           }
@@ -456,11 +458,11 @@ describe Rollbar::Scrubbers::Params do
         end
         let(:result) do
           {
-            :foo => /\*+/,
+            :foo => 'bar',
             :extra => [{
-              :secret => 'the-secret',
-              :password => 'the-password',
-              :password_confirmation => 'the-password',
+              :secret => /\*+/,
+              :password => /\*+/,
+              :password_confirmation => /\*+/,
               :skipped => "Skipped value of class 'Tempfile'"
             }]
           }

--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -9,7 +9,8 @@ describe Rollbar::Scrubbers::URL do
       :scrub_fields => [:password, :secret],
       :scrub_user => false,
       :scrub_password => false,
-      :randomize_scrub_length => true
+      :randomize_scrub_length => true,
+      :extra_fields => [:password, :api_key]
     }
       
     if defined? whitelist
@@ -55,7 +56,8 @@ describe Rollbar::Scrubbers::URL do
             :url => url,
             :scrub_fields => [],
             :scrub_password => true,
-            :scrub_user => true
+            :scrub_user => true,
+            :extra_fields => [:password, :api_key]
           }
         end
 
@@ -95,7 +97,8 @@ describe Rollbar::Scrubbers::URL do
             :scrub_fields => [:password, :secret],
             :scrub_user => false,
             :scrub_password => false,
-            :randomize_scrub_length => false
+            :randomize_scrub_length => false,
+            :extra_fields => []
           }
         end
         let(:password) { 'longpasswordishere' }
@@ -125,10 +128,11 @@ describe Rollbar::Scrubbers::URL do
         let(:options) do
           {
             :url => url,
-            :scrub_fields => [:passwd, :password, :password_confirmation, :secret, :confirm_password, :secret_token, :api_key, :access_token, :auth, :SAMLResponse, :password, :auth],
+            :scrub_fields => [:passwd, :password, :password_confirmation, :secret, :confirm_password, :secret_token, :auth, :SAMLResponse, :password, :auth],
             :scrub_user => true,
             :scrub_password => true,
-            :randomize_scrub_length => true
+            :randomize_scrub_length => true,
+            :extra_fields => [:password, :api_key, :access_token]
           }
         end
 
@@ -163,13 +167,14 @@ describe Rollbar::Scrubbers::URL do
               :scrub_fields => [],
               :scrub_password => true,
               :scrub_user => true,
-              :whitelist => whitelist
+              :whitelist => whitelist,
+              :extra_fields => [:user, :password]
             }
           end
   
           let(:url) { 'http://user:password@foo.com/some-interesting-path#fragment' }
   
-          it 'returns the URL without any change' do
+          it 'returns the URL with scrubbed user and password' do
             expected_url = /http:\/\/\*{3,8}:\*{3,8}@foo.com\/some-interesting\-path#fragment/
   
             expect(subject.call(options)).to match(expected_url)


### PR DESCRIPTION
After testing #792 I think it's not working properly. This fix is based on previous master that worked well except situation when `config.filter_parameters` was set for Rails app. 

Detailed explanation can be found in the issue #793.

It is based on current documentation so to use whitelisting following config should be used:

```ruby
config.scrub_whitelist = true
config.scrub_fields = [:username, :action, :id, :something_else]
```