### PR TITLE
Make scrub_all work correctly (including with whitelist)

### DIFF
--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -6,6 +6,8 @@ require 'rollbar/language_support'
 module Rollbar
   module Scrubbers
     class URL
+      SCRUB_ALL = :scrub_all
+
       def self.call(*args)
         new.call(*args)
       end
@@ -15,10 +17,12 @@ module Rollbar
         return url unless Rollbar::LanguageSupport.can_scrub_url?
 
         filter(url,
-               build_regex(options[:scrub_fields], options[:whitelist] || []),
+               build_regex(options[:scrub_fields]),
                options[:scrub_user],
                options[:scrub_password],
-               options.fetch(:randomize_scrub_length, true))
+               options.fetch(:randomize_scrub_length, true),
+               options[:scrub_fields].include?(SCRUB_ALL),
+               build_whitelist_regex(options[:whitelist] || []))
       rescue => e
         Rollbar.logger.error("[Rollbar] There was an error scrubbing the url: #{e}, options: #{options.inspect}")
         url
@@ -26,20 +30,26 @@ module Rollbar
 
       private
 
-      def filter(url, regex, scrub_user, scrub_password, randomize_scrub_length)
+      def build_whitelist_regex(whitelist)
+        fields = whitelist.find_all { |f| f.is_a?(String) || f.is_a?(Symbol) }
+        return unless fields.any?
+        Regexp.new(fields.map { |val| /\A#{Regexp.escape(val.to_s)}\z/ }.join('|'))
+      end
+
+      def filter(url, regex, scrub_user, scrub_password, randomize_scrub_length, scrub_all, whitelist)
         uri = URI.parse(url)
 
         uri.user = filter_user(uri.user, scrub_user, randomize_scrub_length)
         uri.password = filter_password(uri.password, scrub_password, randomize_scrub_length)
-        uri.query = filter_query(uri.query, regex, randomize_scrub_length)
+        uri.query = filter_query(uri.query, regex, randomize_scrub_length, scrub_all, whitelist)
 
         uri.to_s
       end
 
       # Builds a regex to match with any of the received fields.
       # The built regex will also match array params like 'user_ids[]'.
-      def build_regex(fields, whitelist)
-        fields_or = fields.reject { |f| whitelist.include? f }.map { |field| "#{field}(\\[\\])?" }.join('|')
+      def build_regex(fields)
+        fields_or = fields.map { |field| "#{field}(\\[\\])?" }.join('|')
 
         Regexp.new("^#{fields_or}$")
       end
@@ -52,12 +62,12 @@ module Rollbar
         scrub_password && password ? filtered_value(password, randomize_scrub_length) : password
       end
 
-      def filter_query(query, regex, randomize_scrub_length)
+      def filter_query(query, regex, randomize_scrub_length, scrub_all, whitelist)
         return query unless query
 
         params = decode_www_form(query)
 
-        encoded_query = encode_www_form(filter_query_params(params, regex, randomize_scrub_length))
+        encoded_query = encode_www_form(filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist))
 
         # We want this to rebuild array params like foo[]=1&foo[]=2
         URI.escape(CGI.unescape(encoded_query))
@@ -71,14 +81,14 @@ module Rollbar
         URI.encode_www_form(params)
       end
 
-      def filter_query_params(params, regex, randomize_scrub_length)
+      def filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist)
         params.map do |key, value|
-          [key, filter_key?(key, regex) ? filtered_value(value, randomize_scrub_length) : value]
+          [key, filter_key?(key, regex, scrub_all, whitelist) ? filtered_value(value, randomize_scrub_length) : value]
         end
       end
 
-      def filter_key?(key, regex)
-        !!(key =~ regex)
+      def filter_key?(key, regex, scrub_all, whitelist)
+        !(whitelist === key) && (scrub_all || regex === key)
       end
 
       def filtered_value(value, randomize_scrub_length)


### PR DESCRIPTION
`:scrub_all` as a key in the `scrub_fields` configuration means to scrub everything. This kinda sorta worked before, but there were some corner cases that were broken. This fixes those.

Also, `scrub_whitelist` is intended to be a list of things you do not want to scrub regardless of why you were going to scrub them in the first place. This was broken with `scrub_all` before, this fixes that.

Furthermore, the `scrub_whitelist` does an exact match, so if you for example have `:password` in `scrub_fields`, because we do substring matching for scrubbing, this would imply `password` and `password_confirmation` would get scrubbed. If you decide to add `password` to `scrub_whitelist`, you will see that `password` will not be scrubbed but `password_confirmation` will still be scrubbed. This is because the substring matching for scrubbing is still matching `password_confirmation` but the whitelist requires an explicit match which does not happen with only `password` in the whitelist. This seems to be the right behaviour as a closed default is what one wants when it comes to sensitive data.