### PR TITLE
Tune up RSpec and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: ruby
 before_install:
   - gem update --system 2.5.1
   - gem --version
-  - gem install bundler
+  - gem install bundler -v 1.6.1
   - bundle --version
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,29 @@ services:
 language: ruby
 # Broken bundler on travis CI - https://github.com/bundler/bundler/issues/2784
 before_install:
-  - gem update --system 2.5.1
+  - gem update --system 2.7.7
   - gem --version
   - gem install bundler -v 1.6.1
   - bundle --version
+
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.2
   - 2.3.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - jruby-18mode
   - jruby-19mode
   - rbx
 jdk:
-  - openjdk6
   - openjdk7
-  - oraclejdk7
+  - openjdk8
   - oraclejdk8
+  - oraclejdk9
 env:
   - ROLLBAR_SSL_CERT_FILE=/home/travis/build/rollbar/rollbar-gem/spec/cacert.pem
 gemfile:
@@ -38,14 +43,44 @@ matrix:
   include:
     - rvm: 1.8.7
       gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk6
+      jdk: openjdk7
     - rvm: 1.9.2
       gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk6
+      jdk: openjdk7
+    - rvm: jruby-18mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk7
+    - rvm: jruby-19mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk7
+    - rvm: jruby-18mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk8
+    - rvm: jruby-19mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: openjdk8
+    - rvm: jruby-18mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: oraclejdk8
+    - rvm: jruby-19mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: oraclejdk8
+    - rvm: jruby-18mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: oraclejdk9
+    - rvm: jruby-19mode
+      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
+      jdk: oraclejdk9
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-18mode
     - rvm: jruby-head
+    # all JRuby builds have dependency issues that need to be fixed
+    - rvm: jruby-18mode
+    - rvm: jruby-19mode
+    # Ruby 2.4.5 has a known issue, under investigation
+    - rvm: 2.4.5
+    # Ruby 2.6.x is still being eveluated and may have test failures
+    - rvm: 2.6.0
 
     # NOTE: Allowing this to fail because of some strange error in rspec-core `undefined method `example_group_finished'`.
     # Seems to work with oraclejdk7.
@@ -55,62 +90,87 @@ matrix:
     # Don't run tests for non-jruby environments with the JDK.
     # NOTE: openjdk7 is missing from these exclusions so that Travis will run at least 1 build for the given rvm.
     - rvm: 1.8.7
-      jdk: openjdk6
-    - rvm: 1.8.7
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: 1.8.7
       jdk: oraclejdk8
+    - rvm: 1.8.7
+      jdk: oraclejdk9
     - rvm: 1.9.2
-      jdk: openjdk6
+      jdk: openjdk8
     - rvm: 1.9.2
-      jdk: oraclejdk7
+      jdk: oraclejdk8
     - rvm: 1.9.2
+      jdk: oraclejdk9
+    - rvm: 1.9.3
+      jdk: openjdk8
+    - rvm: 1.9.3
       jdk: oraclejdk8
     - rvm: 1.9.3
-      jdk: openjdk6
-    - rvm: 1.9.3
-      jdk: oraclejdk7
-    - rvm: 1.9.3
-      jdk: oraclejdk8
+      jdk: oraclejdk9
     - rvm: 2.0.0
-      jdk: openjdk6
-    - rvm: 2.0.0
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: 2.0.0
       jdk: oraclejdk8
+    - rvm: 2.0.0
+      jdk: oraclejdk9
     - rvm: 2.1.0
-      jdk: openjdk6
-    - rvm: 2.1.0
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: 2.1.0
       jdk: oraclejdk8
+    - rvm: 2.1.0
+      jdk: oraclejdk9
     - rvm: 2.2.2
-      jdk: openjdk6
-    - rvm: 2.2.2
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: 2.2.2
       jdk: oraclejdk8
+    - rvm: 2.2.2
+      jdk: oraclejdk9
     - rvm: 2.3.0
-      jdk: openjdk6
-    - rvm: 2.3.0
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: 2.3.0
       jdk: oraclejdk8
+    - rvm: 2.3.0
+      jdk: oraclejdk9
+    - rvm: 2.3.8
+      jdk: openjdk8
+    - rvm: 2.3.8
+      jdk: oraclejdk8
+    - rvm: 2.3.8
+      jdk: oraclejdk9
+    - rvm: 2.4.5
+      jdk: openjdk8
+    - rvm: 2.4.5
+      jdk: oraclejdk8
+    - rvm: 2.4.5
+      jdk: oraclejdk9
+    - rvm: 2.5.3
+      jdk: openjdk8
+    - rvm: 2.5.3
+      jdk: oraclejdk8
+    - rvm: 2.5.3
+      jdk: oraclejdk9
+    - rvm: 2.6.0
+      jdk: openjdk8
+    - rvm: 2.6.0
+      jdk: oraclejdk8
+    - rvm: 2.6.0
+      jdk: oraclejdk9
 
     - rvm: ruby-head
-      jdk: openjdk6
-    - rvm: ruby-head
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: ruby-head
       jdk: oraclejdk8
+    - rvm: ruby-head
+      jdk: oraclejdk9
     - rvm: rbx
-      jdk: openjdk6
-    - rvm: rbx
-      jdk: oraclejdk7
+      jdk: openjdk8
     - rvm: rbx
       jdk: oraclejdk8
+    - rvm: rbx
+      jdk: oraclejdk9
 
-    # TODO: comment as to why these are excluded
+    # MRI 1.8.x - 1.9.2 have a separate gemfile and cannot use the
+    # gemfiles for 1.9.3 and higher.
     - rvm: 1.8.7
       gemfile: gemfiles/rails31.gemfile
     - rvm: 1.8.7
@@ -143,32 +203,82 @@ matrix:
       gemfile: gemfiles/rails51.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/rails52.gemfile
+    # Rails 5.x requires Ruby 2.2.2 or higher
     - rvm: 1.9.3
       gemfile: gemfiles/rails50.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails51.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails52.gemfile
+    # Rails 5.x requires Ruby 2.2.2 or higher
     - rvm: 2.0.0
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails51.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails52.gemfile
+    # Rails 5.x requires Ruby 2.2.2 or higher
     - rvm: 2.1.0
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.1.0
       gemfile: gemfiles/rails51.gemfile
     - rvm: 2.1.0
       gemfile: gemfiles/rails52.gemfile
+    # MRI 2.2.2 supports Rails 3.2.x and higher
     - rvm: 2.2.2
       gemfile: gemfiles/rails30.gemfile
     - rvm: 2.2.2
       gemfile: gemfiles/rails31.gemfile
+    # MRI 2.3.x supports Rails 4.0.x and higher
     - rvm: 2.3.0
       gemfile: gemfiles/rails30.gemfile
     - rvm: 2.3.0
       gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails41.gemfile
+    # MRI 2.4.x and higher (e.g. 2.5.x, 2.6.x, etc) supports Rails 4.2.8 and higher
+    # Rails lower than 4.2.8 is incompatible with Ruby 2.4 Integer class
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.4.5
+      gemfile: gemfiles/rails41.gemfile
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails41.gemfile
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.6.0
+      gemfile: gemfiles/rails41.gemfile
+    # All current JRubies are 1.8.x and 1.9.x, and use the ruby_1_8_and_1_9_2.gemfile
     - rvm: jruby-18mode
       gemfile: gemfiles/rails30.gemfile
     - rvm: jruby-18mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 language: ruby
 # Broken bundler on travis CI - https://github.com/bundler/bundler/issues/2784
 before_install:
-  - gem update --system 2.1.11
+  - gem update --system 2.5.1
   - gem --version
   - gem install bundler
   - bundle --version

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -14,13 +14,18 @@ gem 'rake', '< 11'
 gem 'rspec-rails', '>= 2.14.0'
 gem 'celluloid', '< 0.17.0' if RUBY_VERSION == '1.9.2'
 
-gem 'oj', '~> 2.12.14' unless is_jruby
-if RUBY_VERSION > '1.8.7'
-  if RUBY_VERSION < '2.2.2'
-    gem 'sidekiq', '>= 2.13.0', '< 5.0'
+unless is_jruby
+  if RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
   else
-    gem 'sidekiq', '>= 2.13.0'
+    gem 'oj', '~> 2.12.14'
   end
+end
+
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '~> 2.13.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
 end
 
 platforms :rbx do
@@ -33,8 +38,10 @@ end
 
 if RUBY_VERSION.start_with?('1.9')
   gem 'sucker_punch', '~> 1.0'
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'
+  gem 'shoryuken'
 end
 
 gem 'sinatra'
@@ -54,8 +61,6 @@ else
 end
 
 gem 'resque'
-
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -12,7 +12,19 @@ gem 'rails', '3.1.12'
 gem 'rspec-rails', '~> 3.4'
 gem 'rake'
 
-gem 'oj', '~> 2.12.14' unless is_jruby
+unless is_jruby
+  if RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
+
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '~> 2.13.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
 
 platforms :rbx do
   gem 'minitest'
@@ -24,8 +36,10 @@ end
 
 if RUBY_VERSION.start_with?('1.9')
   gem 'sucker_punch'
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch'
+  gem 'shoryuken'
 end
 
 gem 'sinatra'
@@ -40,19 +54,11 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'
   gem 'public_suffix', '< 1.5'
   gem 'webmock', '< 2.3.0', :require => false
-  gem 'sidekiq', '< 2.13.0'
 else
   gem 'webmock', :require => false
-  if RUBY_VERSION < '2.2.2'
-    gem 'sidekiq', '>= 2.13.0', '< 5.0'
-  else
-    gem 'sidekiq', '>= 2.13.0'
-  end
 end
 
 gem 'resque'
-
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -14,9 +14,16 @@ gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 # Please see https://github.com/rspec/rspec-rails/issues/1273
 gem 'test-unit'
 
-gem 'oj', '~> 2.12.14' unless is_jruby
+unless is_jruby
+  if RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
+
 if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+  gem 'sidekiq', '~> 2.13.0'
 else
   gem 'sidekiq', '>= 2.13.0'
 end
@@ -31,8 +38,10 @@ end
 
 if RUBY_VERSION.start_with?('1.9')
   gem 'sucker_punch', '~> 1.0'
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'
+  gem 'shoryuken'
 end
 
 gem 'delayed_job', :require => false
@@ -53,8 +62,6 @@ else
 end
 
 gem 'resque'
-
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -14,9 +14,16 @@ gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 # Please see https://github.com/rspec/rspec-rails/issues/1273
 gem 'test-unit'
 
-gem 'oj', '~> 2.12.14' unless is_jruby
+unless is_jruby
+  if RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
+
 if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+  gem 'sidekiq', '~> 2.13.0'
 else
   gem 'sidekiq', '>= 2.13.0'
 end
@@ -32,9 +39,11 @@ end
 if RUBY_VERSION.start_with?('1.9')
   gem 'sucker_punch', '~> 1.0'
   gem 'json', '~> 1.8'
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'
   gem 'json', '~> 2.0'
+  gem 'shoryuken'
 end
 
 gem 'delayed_job', :require => false
@@ -55,6 +64,5 @@ else
 end
 
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -12,9 +12,16 @@ gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
 
-gem 'oj', '~> 2.12.14' unless is_jruby
+unless is_jruby
+  if RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
+
 if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
+  gem 'sidekiq', '~> 2.13.0'
 else
   gem 'sidekiq', '>= 2.13.0'
 end
@@ -28,8 +35,10 @@ end
 
 if RUBY_VERSION.start_with?('1.9')
   gem 'sucker_punch', '~> 1.0'
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
 elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0'
+  gem 'shoryuken'
 end
 
 gem 'delayed_job', :require => false
@@ -50,8 +59,6 @@ else
 end
 
 gem 'resque'
-
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -8,16 +8,10 @@ is_not_jruby = !is_jruby
 gem 'appraisal'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '4.2.7.1'
+gem 'rails', '4.2.8'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
-
-if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
-else
-  gem 'sidekiq', '>= 2.13.0'
-end
 
 platforms :rbx do
   gem 'minitest'
@@ -26,10 +20,26 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION.start_with?('2.4') && is_not_jruby
-  gem 'oj', '~> 2.16.0'
-elsif is_not_jruby
-  gem 'oj', '~> 2.12.14'
+unless is_jruby
+  if RUBY_VERSION >= '2.5'
+    gem 'oj'
+  elsif RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
+
+if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
+  gem 'sidekiq', '~> 2.13.0'
+else
+  gem 'sidekiq', '>= 2.13.0'
+end
+
+if RUBY_VERSION.start_with?('1.9')
+  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
+elsif RUBY_VERSION.start_with?('2')
+  gem 'shoryuken'
 end
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
@@ -54,6 +64,5 @@ else
 end
 
 gem 'aws-sdk-sqs'
-gem 'shoryuken'
 
 gemspec :path => '../'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -18,11 +18,16 @@ gem 'rspec-mocks', '~> 3.5.0.beta3'
 
 gem 'rake'
 
-gem 'oj', '~> 2.12.14' unless is_jruby
-if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
-else
-  gem 'sidekiq', '>= 2.13.0'
+gem 'sidekiq', '>= 2.13.0'
+
+unless is_jruby
+  if RUBY_VERSION >= '2.5'
+    gem 'oj'
+  elsif RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
 end
 
 platforms :rbx do

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -18,11 +18,16 @@ gem 'rspec-mocks', '~> 3.5.0.beta3'
 
 gem 'rake'
 
-gem 'oj', '~> 2.16.1' unless is_jruby
-if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'
-  gem 'sidekiq', '>= 2.13.0', '< 5.0'
-else
-  gem 'sidekiq', '>= 2.13.0'
+gem 'sidekiq', '>= 2.13.0'
+
+unless is_jruby
+  if RUBY_VERSION >= '2.5'
+    gem 'oj'
+  elsif RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
 end
 
 platforms :rbx do

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -18,7 +18,15 @@ gem 'rspec-mocks', '~> 3.8.0'
 
 gem 'rake'
 
-gem 'oj', '~> 2.16.1' unless is_jruby
+unless is_jruby
+  if RUBY_VERSION >= '2.5'
+    gem 'oj'
+  elsif RUBY_VERSION >= '2.4.0'
+    gem 'oj', '~> 2.16.1'
+  else
+    gem 'oj', '~> 2.12.14'
+  end
+end
 
 gem 'sidekiq', '>= 2.13.0'
 

--- a/lib/rollbar/delay/sidekiq.rb
+++ b/lib/rollbar/delay/sidekiq.rb
@@ -10,7 +10,7 @@ module Rollbar
       end
 
       def call(payload)
-        if (::Sidekiq::Client.push @options.merge('args' => [payload]) == nil)
+        if ::Sidekiq::Client.push(@options.merge('args' => [payload])) == nil
           raise StandardError.new "Unable to push the job to Sidekiq"
         end
       end

--- a/spec/delay/sidekiq_spec.rb
+++ b/spec/delay/sidekiq_spec.rb
@@ -35,8 +35,8 @@ describe Rollbar::Delay::Sidekiq, :if => RUBY_VERSION != '1.8.7' do
 
     context "with default options" do
       it "enqueues to default queue" do
-        options = Rollbar::Delay::Sidekiq::OPTIONS.merge('args' => payload)
-        ::Sidekiq::Client.should_receive(:push).with options
+        options = Rollbar::Delay::Sidekiq::OPTIONS.merge('args' => [payload])
+        ::Sidekiq::Client.should_receive(:push).with(options){ true }
 
         subject.call payload
       end
@@ -49,8 +49,8 @@ describe Rollbar::Delay::Sidekiq, :if => RUBY_VERSION != '1.8.7' do
       subject { Rollbar::Delay::Sidekiq.new custom_config }
 
       it "enqueues to custom queue" do
-        options = Rollbar::Delay::Sidekiq::OPTIONS.merge(custom_config.merge('args' => payload))
-        ::Sidekiq::Client.should_receive(:push).with options
+        options = Rollbar::Delay::Sidekiq::OPTIONS.merge(custom_config.merge('args' => [payload]))
+        ::Sidekiq::Client.should_receive(:push).with(options){ true }
 
         subject.call payload
       end


### PR DESCRIPTION
- [x] Get all the current environments green
- [x] Enable Ruby 2.4.x, 2.5.x, 2.6.x
- [x] See what else comes up

This PR brings RSpec and Travis status up to:
* All MRI are green except 4.2.x. This includes: 1.8.7, 1.9.2, 1.9.3, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.8 (last 2.3.x), 2.5.3 (last 2.5.x), and 6.0.0. These all work for me locally under rvm as well.
* Travis JRubies 18mode and 19mode are enabled, but have dependency errors. I could not find a prior build where these worked. Same with Rubinius.
* Travis has, apparently very recently, removed openjdk6 and oraclejdk7 from the Trusty distribution. (Other distros have even less stuff. Trusty is the default.) The config has been updated to use openjdk7, openjdk8, oraclejdk8, and oraclejdk9. While Jruby still has issues on these builds, each of the JDK environments installs correctly.

There is a matrix outlining the status of each of the Ruby and Rails combinations, with a description of known issues. As soon as any of the JRubies are working they will be added. This matrix may move, and if so I’ll update this comment.
https://docs.google.com/spreadsheets/d/1keJNwA2vHvyCZHKilvcB2JnPRzlvoiZBUHy9lK2ppkk/edit#gid=0

Managing the different environments is made significantly more complex because Travis appears to only allow a single global matrix for configuration. It would be much more manageable if multiple matrices could be defined, each with its own environment. (Anyone that knows more about how to do this, or if it’s possible, please reach out.)

The rubygems version must be set at the max version required by all rubies. Similarly, the bundler version must be set at a version compatible with all rubies. The current settings in .travis.yml are working. But Jruby and Rubinius builds aren’t enabled yet, and the current blocking issue is related to versions and dependencies. Having to rely on a single global version for these dependencies seems very brittle.

There is a tricky cutoff at Ruby 2.4.x and Rails 4.2.x where Ruby aliases Fixnum and Bignum to a single class, Integer. Versions of Rails that do not handle this correctly can (and do) stack overflow, giving either a system segfault or a more polite Stack Too Deep error. This is easily reproducible both locally and in Travis, and is noted in the linked matrix.
