### PR TITLE
Issue #686: Enable current JRuby for Rails 5.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,36 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.0
-  - jruby-18mode
-  - jruby-19mode
   - rbx
+  - jruby-9.1.9.0
+  #
+  # # About legacy JRuby
+  #
+  # Legacy JRubies (jruby-18mode, jruby-19mode) have been disabled for some time by
+  # listing all possible targets in either the exclude or allow_failures sections.
+  # I have taken a look at getting them running, and have found that no valid
+  # combination of dependencies is possible for Rails 3.0 and higher. It appears
+  # Rails 2.2 is meant to work, though I haven't tried it.
+  #
+  # For Rails 3.0, it is possible to get a working bundle with all gem dependencies,
+  # but the JDBC adapter gem needs an earlier version of ActiveSupport, and it will
+  # fail at runtime.
+  #
+  # For Rails 3.1 and 3.2, Rack 1.3.x and higher require Ruby 2.x, while Rails 3.x will
+  # not accept any 1.2.x version of Rack. Even if this could be resolved, one would
+  # hit the above runtime issue amyway.
+  #
+  # # About current JRuby
+  #
+  # While current JRuby builds aim to be Ruby 2.5.x compatible, the JDBC adapter
+  # gem is constrained to only Rails 5.0, 5.1 and 5.2 at this time. (Old versions
+  # of the gem allow >= Rails 2.2, but in practice it will not work with Rails 3.0
+  # and higher because of the ActiveSupport issue described above.) For as long as
+  # the test suite relies on Rails and SqlLite, it is not possible to include
+  # earlier Rails for JRuby.
+
 jdk:
+  # These are the JDKs currently supported on Travis (Trusty - Ubuntu 14.04)
   - openjdk7
   - openjdk8
   - oraclejdk8
@@ -47,45 +73,15 @@ matrix:
     - rvm: 1.9.2
       gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
       jdk: openjdk7
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk8
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk8
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk8
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk8
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk9
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk9
+
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    # all JRuby builds have dependency issues that need to be fixed
-    - rvm: jruby-18mode
-    - rvm: jruby-19mode
-    # Ruby 2.4.5 has a known issue, under investigation
-    - rvm: 2.4.5
     # Ruby 2.6.x is still being eveluated and may have test failures
     - rvm: 2.6.0
+    # oraclejdk9 has a dependency issue that needs to be investigated
+    - jdk: oraclejdk9
 
-    # NOTE: Allowing this to fail because of some strange error in rspec-core `undefined method `example_group_finished'`.
-    # Seems to work with oraclejdk7.
-    - rvm: jruby-19mode
-      jdk: openjdk7
   exclude:
     # Don't run tests for non-jruby environments with the JDK.
     # NOTE: openjdk7 is missing from these exclusions so that Travis will run at least 1 build for the given rvm.
@@ -278,43 +274,19 @@ matrix:
       gemfile: gemfiles/rails40.gemfile
     - rvm: 2.6.0
       gemfile: gemfiles/rails41.gemfile
-    # All current JRubies are 1.8.x and 1.9.x, and use the ruby_1_8_and_1_9_2.gemfile
-    - rvm: jruby-18mode
+    # JRuby JDBC Adapter is only compatible with Rails >= 5.x
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails30.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails31.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails32.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails40.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails41.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails30.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails32.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails41.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails52.gemfile
     - rvm: rbx
       gemfile: gemfiles/rails30.gemfile
     - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'aws-sdk-sqs'
-gem 'database_cleaner', '~> 1.0.0'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -46,7 +46,7 @@ end
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -47,7 +47,7 @@ end
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -43,7 +43,7 @@ gem 'sucker_punch', '~> 2.0'
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -46,6 +46,17 @@ describe Rollbar do
     end
 
     it 'should not crash with circular extra_data' do
+      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
+      # The example says we should *not* crash with a circular hash, however the matcher
+      # is actually matching on the internal error we get when we *do* crash on a
+      # recursive stack overflow. On some platforms, this will crash deeper in the
+      # interpreter and we don't get the chance to handle the error at all.
+      #
+      # If the intent is to not crash, there are numerous parts of the reporting
+      # code that need to tbe made safe. If not, this spec should be removed because
+      # the behavior at stack overflow is platform dependent at best and undefined
+      # at worst.
+
       a = { :foo => 'bar' }
       b = { :a => a }
       c = { :b => b }

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -158,57 +158,57 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('error', 'exception description', exception, extra_data, nil)
         notifier.log('error', exception, extra_data, 'exception description')
       end
-      
+
       context 'with :on_error_response hook configured' do
         let!(:notifier) { Rollbar::Notifier.new }
         let(:configuration) do
           config = Rollbar::Configuration.new
           config.access_token = test_access_token
           config.enabled = true
-          
+
           config.hook :on_error_response do |response|
             return ":on_error_response executed"
           end
-          
+
           config
         end
         let(:message) { 'foo' }
         let(:level) { 'foo' }
-  
+
         before do
           notifier.configuration = configuration
           allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(:code => 500, :body => "Error"))
           @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
         end
-        
+
         it "calls the :on_error_response hook if response status is not 200" do
           expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil, nil).and_call_original
           expect(notifier.configuration.hook(:on_error_response)).to receive(:call)
-          
+
           notifier.log(level, message)
         end
       end
-      
+
       context 'with :on_report_internal_error hook configured' do
         let!(:notifier) { Rollbar::Notifier.new }
         let(:configuration) do
           config = Rollbar::Configuration.new
           config.access_token = test_access_token
           config.enabled = true
-          
+
           config.hook :on_report_internal_error do |response|
             return ":on_report_internal_error executed"
           end
-          
+
           config
         end
         let(:message) { 'foo' }
         let(:level) { 'foo' }
-  
+
         before do
           notifier.configuration = configuration
         end
-        
+
         it "calls the :on_report_internal_error hook if" do
           expect(notifier.configuration.hook(:on_report_internal_error)).to receive(:call)
           expect(notifier).to receive(:report) do
@@ -217,22 +217,22 @@ describe Rollbar do
           notifier.log(level, message)
         end
       end
-    
+
       context 'an item with a context' do
         let(:context) { { :controller => 'ExampleController' } }
-        
+
         context 'with a custom_data_method configured' do
           before do
             Rollbar.configure do |config|
-              config.custom_data_method = lambda do |message, exception, context| 
+              config.custom_data_method = lambda do |message, exception, context|
                 { :result => "MyApp#" + context[:controller] }
               end
             end
           end
-          
+
           it 'should have access to the context data through configuration.custom_data_method' do
             result = notifier.log('error', "Custom message", { :custom_data_method_context => context})
-            
+
             result[:body][:message][:extra].should_not be_nil
             result[:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
             result[:body][:message][:extra][:custom_data_method_context].should be_nil
@@ -977,6 +977,17 @@ describe Rollbar do
     # END Backwards
 
     it 'should not crash with circular extra_data' do
+      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
+      # The example says we should *not* crash with a circular hash, however the matcher
+      # is actually matching on the internal error we get when we *do* crash on a
+      # recursive stack overflow. On some platforms, this will crash deeper in the
+      # interpreter and we don't get the chance to handle the error at all.
+      #
+      # If the intent is to not crash, there are numerous parts of the reporting
+      # code that need to tbe made safe. If not, this spec should be removed because
+      # the behavior at stack overflow is platform dependent at best and undefined
+      # at worst.
+
       a = { :foo => "bar" }
       b = { :a => a }
       c = { :b => b }


### PR DESCRIPTION
## RSpec update:
The RSpec example "should not crash with circular extra_data" is now skipped, as it does the opposite of what it says. All platforms _do_ crash with a cycle in the hash. (We have no guards in place to prevent this.) And the matcher in the example tests for the message we get on a stack too deep error, not the message of the test exception. The biggest problem with this is that not all Rubies will catch this and return a controlled exception. JRuby segfaults, and it turns out this is the segfault we have been seeing in all MRI 2.4.x Ruby.

I didn't remove these examples completely because it's not clear whether we should want to put guards in, and allow circular references. Do the other rollbar language adapters allow this? Is there ever a valid reason for a report payload to have a hash with a cycle in it? If we do want to add this, it deserves its own PR.

## Legacy JRuby: (as commented in .travis.yml)
Legacy JRubies (jruby-18mode, jruby-19mode) have been disabled for some time by listing all possible targets in either the exclude or allow_failures sections. I have taken a look at getting them running, and have found that no valid combination of dependencies is possible for Rails 3.0 and higher. It appears Rails 2.2 is meant to work, though I haven't tried it.

For Rails 3.0, it is possible to get a working bundle with all gem dependencies, but the JDBC adapter gem needs an earlier version of ActiveSupport, and it will fail at runtime.

For Rails 3.1 and 3.2, Rack 1.3.x and higher require Ruby 2.x, while Rails 3.x will not accept any 1.2.x version of Rack. Even if this could be resolved, one would hit the above runtime issue anyway.

## Current JRuby
While current JRuby builds aim to be Ruby 2.5.x compatible, the JDBC adapter gem is constrained to only Rails 5.0, 5.1 and 5.2 at this time. (Old versions of the gem allow >= Rails 2.2, but in practice it will not work with Rails 3.0 and higher because of the ActiveSupport issue described above.) For as long as the test suite relies on Rails and SqlLite, it is not possible to include Rails < 5.x for JRuby.

## Oracle JDK 9
This JDK crashes in Bundler on Travis. Root cause is unknown yet, and oraclejdk9 builds are marked as allowed to fail.