### PR TITLE
GitHub Issue #765: Session key should not be send to rollbar by default

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -107,7 +107,7 @@ module Rollbar
       @js_options = {}
       @scrub_fields = [:passwd, :password, :password_confirmation, :secret,
                        :confirm_password, :password_confirmation, :secret_token,
-                       :api_key, :access_token]
+                       :api_key, :access_token, :session_id]
       @scrub_user = true
       @scrub_password = true
       @randomize_scrub_length = true

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -433,6 +433,12 @@ describe HomeController do
 
       expect(session_data['some_value']).to be_eql('this-is-a-cool-value')
     end
+    
+    it 'scrubs session id by default from the request' do
+      expect { get '/use_session_data' }.to raise_exception(NoMethodError)
+      
+      expect(Rollbar.last_report[:request][:session]['session_id']).to match('\*{3,8}')
+    end
   end
 
   context 'with json ACCEPT header', :type => 'request' do


### PR DESCRIPTION
Add scrubbing `session_id` from payload by default. Requested in https://github.com/rollbar/rollbar-gem/issues/765