### PR TITLE
GitHub Issue #741: Recursive Rollbar submission condition can crash the process

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -156,7 +156,7 @@ module Rollbar
     end
 
     def build_extra
-      if custom_data_method?
+      if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
         Util.deep_merge(custom_data, extra || {})
       else
         extra

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -26,12 +26,12 @@ module Rollbar
     attr_reader :message
     attr_reader :exception
     attr_reader :extra
-    
+
     attr_reader :configuration
     attr_reader :scope
     attr_reader :logger
     attr_reader :notifier
-    
+
     attr_reader :context
 
     def_delegators :payload, :[]
@@ -173,7 +173,7 @@ module Rollbar
       else
         data = configuration.custom_data_method.call
       end
-      
+
       Rollbar::Util.deep_copy(data)
     rescue => e
       return {} if configuration.safely?

--- a/lib/rollbar/plugins/rails/controller_methods.rb
+++ b/lib/rollbar/plugins/rails/controller_methods.rb
@@ -1,4 +1,5 @@
 require 'rollbar/request_data_extractor'
+require 'rollbar/util'
 
 module Rollbar
   module Rails
@@ -6,7 +7,7 @@ module Rollbar
       include RequestDataExtractor
 
       def rollbar_person_data
-        user = send(Rollbar.configuration.person_method)
+        (user = send(Rollbar.configuration.person_method)) unless Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
         # include id, username, email if non-empty
         if user
           {

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -97,5 +97,17 @@ module Rollbar
 
       Util.iterate_and_update(payload, normalizer)
     end
+    
+    def self.count_method_in_stack(method_symbol, file_path = '')
+      caller.grep(/#{file_path}.*#{method_symbol.to_s}/).count
+    end
+    
+    def self.method_in_stack(method_symbol, file_path = '')
+      count_method_in_stack(method_symbol, file_path) > 0
+    end
+    
+    def self.method_in_stack_twice(method_symbol, file_path = '')
+      count_method_in_stack(method_symbol, file_path) > 1
+    end
   end
 end

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -97,7 +97,7 @@ module Rollbar
 
       Util.iterate_and_update(payload, normalizer)
     end
-    
+
     def self.count_method_in_stack(method_symbol, file_path = '')
       caller.grep(/#{file_path}.*#{method_symbol.to_s}/).count
     end

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -101,7 +101,7 @@ module Rollbar
     def self.count_method_in_stack(method_symbol, file_path = '')
       caller.grep(/#{file_path}.*#{method_symbol.to_s}/).count
     end
-    
+
     def self.method_in_stack(method_symbol, file_path = '')
       count_method_in_stack(method_symbol, file_path) > 0
     end

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -105,7 +105,7 @@ module Rollbar
     def self.method_in_stack(method_symbol, file_path = '')
       count_method_in_stack(method_symbol, file_path) > 0
     end
-    
+
     def self.method_in_stack_twice(method_symbol, file_path = '')
       count_method_in_stack(method_symbol, file_path) > 1
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -326,7 +326,7 @@ describe HomeController do
 
         get '/cause_exception'
       end
-      
+
       it 'should detect and stop recursion in the person method' do
         Rollbar.configure do |config|
           config.person_method = 'recursive_current_user'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -326,6 +326,14 @@ describe HomeController do
 
         get '/cause_exception'
       end
+      
+      it 'should detect and stop recursion in the person method' do
+        Rollbar.configure do |config|
+          config.person_method = 'recursive_current_user'
+        end
+
+        get '/cause_exception'
+      end
 
       context 'with logged user' do
         let(:user) do

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -57,4 +57,8 @@ class HomeController < ApplicationController
     user.email = 'email@test.com'
     user
   end
+  
+  def recursive_current_user
+    Rollbar.error('Recurisve call to rollbar')
+  end
 end

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -57,7 +57,7 @@ class HomeController < ApplicationController
     user.email = 'email@test.com'
     user
   end
-  
+
   def recursive_current_user
     Rollbar.error('Recurisve call to rollbar')
   end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -239,6 +239,21 @@ describe Rollbar do
           end
         end
       end
+      
+      context 'with a recurisve custom_data_method call' do
+        before do
+          Rollbar.configure do |config|
+            config.custom_data_method = lambda do
+              notifier.error('Recurisve call to rollbar')
+            end
+          end
+        end
+        
+        it 'should detect recursion and stop the infinite loop' do
+          expect(notifier).to receive(:report).twice.and_call_original
+          notifier.log('error', 'Call to Rollbar with custom_data_method')
+        end
+      end
     end
 
     context 'with before_process handlers in configuration' do


### PR DESCRIPTION
Detect recursive calls to Rollbar in `custom_data_method` and `person_method`.

In https://github.com/rollbar/rollbar-gem/issues/741 @bnekolny reported that attempt to report an item in `person_method` causes an infinite loop, as SDK keeps trying to use the same method to add person data. This PR stops propagation of data in recursive `person_method` and `custom_data_method` by checking the stack trace.