### PR TITLE
WIP: Enable Rails 5 content_security_policy for js snippet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,36 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.0
-  - jruby-18mode
-  - jruby-19mode
   - rbx
+  - jruby-9.1.9.0
+  #
+  # # About legacy JRuby
+  #
+  # Legacy JRubies (jruby-18mode, jruby-19mode) have been disabled for some time by
+  # listing all possible targets in either the exclude or allow_failures sections.
+  # I have taken a look at getting them running, and have found that no valid
+  # combination of dependencies is possible for Rails 3.0 and higher. It appears
+  # Rails 2.2 is meant to work, though I haven't tried it.
+  #
+  # For Rails 3.0, it is possible to get a working bundle with all gem dependencies,
+  # but the JDBC adapter gem needs an earlier version of ActiveSupport, and it will
+  # fail at runtime.
+  #
+  # For Rails 3.1 and 3.2, Rack 1.3.x and higher require Ruby 2.x, while Rails 3.x will
+  # not accept any 1.2.x version of Rack. Even if this could be resolved, one would
+  # hit the above runtime issue amyway.
+  #
+  # # About current JRuby
+  #
+  # While current JRuby builds aim to be Ruby 2.5.x compatible, the JDBC adapter
+  # gem is constrained to only Rails 5.0, 5.1 and 5.2 at this time. (Old versions
+  # of the gem allow >= Rails 2.2, but in practice it will not work with Rails 3.0
+  # and higher because of the ActiveSupport issue described above.) For as long as
+  # the test suite relies on Rails and SqlLite, it is not possible to include
+  # earlier Rails for JRuby.
+
 jdk:
+  # These are the JDKs currently supported on Travis (Trusty - Ubuntu 14.04)
   - openjdk7
   - openjdk8
   - oraclejdk8
@@ -47,45 +73,15 @@ matrix:
     - rvm: 1.9.2
       gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
       jdk: openjdk7
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk8
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk8
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk8
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk8
-    - rvm: jruby-18mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk9
-    - rvm: jruby-19mode
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: oraclejdk9
+
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    # all JRuby builds have dependency issues that need to be fixed
-    - rvm: jruby-18mode
-    - rvm: jruby-19mode
-    # Ruby 2.4.5 has a known issue, under investigation
-    - rvm: 2.4.5
     # Ruby 2.6.x is still being eveluated and may have test failures
     - rvm: 2.6.0
+    # oraclejdk9 has a dependency issue that needs to be investigated
+    - jdk: oraclejdk9
 
-    # NOTE: Allowing this to fail because of some strange error in rspec-core `undefined method `example_group_finished'`.
-    # Seems to work with oraclejdk7.
-    - rvm: jruby-19mode
-      jdk: openjdk7
   exclude:
     # Don't run tests for non-jruby environments with the JDK.
     # NOTE: openjdk7 is missing from these exclusions so that Travis will run at least 1 build for the given rvm.
@@ -278,43 +274,19 @@ matrix:
       gemfile: gemfiles/rails40.gemfile
     - rvm: 2.6.0
       gemfile: gemfiles/rails41.gemfile
-    # All current JRubies are 1.8.x and 1.9.x, and use the ruby_1_8_and_1_9_2.gemfile
-    - rvm: jruby-18mode
+    # JRuby JDBC Adapter is only compatible with Rails >= 5.x
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails30.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails31.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails32.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails40.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails41.gemfile
-    - rvm: jruby-18mode
+    - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails30.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails32.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails41.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails52.gemfile
     - rvm: rbx
       gemfile: gemfiles/rails30.gemfile
     - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'aws-sdk-sqs'
-gem 'database_cleaner', '~> 1.0.0'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -46,7 +46,7 @@ end
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -47,7 +47,7 @@ end
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -43,7 +43,7 @@ gem 'sucker_punch', '~> 2.0'
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
-gem 'database_cleaner', '~> 1.x'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -141,7 +141,9 @@ module Rollbar
       end
 
       def script_tag(content, env)
-        if append_nonce?
+        if nonce = rails5_nonce(env)
+          script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
+        elsif secure_headers_nonce?
           nonce = ::SecureHeaders.content_security_policy_script_nonce(::Rack::Request.new(env))
           script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
         else
@@ -156,7 +158,23 @@ module Rollbar
         string
       end
 
-      def append_nonce?
+      # Rails 5.2 Secure Content Policy
+      def rails5_nonce(env)
+        # The nonce is the preferred method, however 'unsafe-inline' is also possible.
+        # The app gets to decide, so we handle both. If the script_src key is missing,
+        # Rails will not add the nonce to the headers, so we should not add it either.
+        # If the 'unsafe-inline' value is present, the app should not add a nonce and
+        # we should ignore it if they do.
+        req = ::ActionDispatch::Request.new env
+        req.respond_to?(:content_security_policy) &&
+        req.content_security_policy &&
+        req.content_security_policy.directives['script-src'] &&
+        !req.content_security_policy.directives['script-src'].include?("'unsafe-inline'") &&
+        req.content_security_policy_nonce
+      end
+
+      # Secure Headers gem
+      def secure_headers_nonce?
         secure_headers.append_nonce?
       end
 

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe ApplicationController, :type => 'request' do
+  shared_examples 'adds the snippet' do
+    it 'renders the snippet and config in the response', :type => 'request' do
+      get '/test_rollbar_js'
+
+      snippet_from_submodule = File.read(File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
+
+      expect(response.body).to include("var _rollbarConfig = #{Rollbar::configuration.js_options.to_json};")
+      expect(response.body).to include(snippet_from_submodule)
+    end
+  end
+
   before do
     Rollbar.configure do |config|
       config.js_options = { :foo => :bar }
@@ -8,12 +19,92 @@ describe ApplicationController, :type => 'request' do
     end
   end
 
-  it 'renders the snippet and config in the response', :type => 'request' do
-    get '/test_rollbar_js'
+  context 'using no security policy' do
+    include_examples 'adds the snippet'
+  end
 
-    snippet_from_submodule = File.read(File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
+  context 'using rails5 content_security_policy',
+    :if => (Gem::Version.new(Rails.version) >= Gem::Version.new('5.2.0')) do
 
-    expect(response.body).to include("var _rollbarConfig = #{Rollbar::configuration.js_options.to_json};")
-    expect(response.body).to include(snippet_from_submodule)
+    def reset_rails_config
+      # Load a new Rails config between examples
+      #
+      # Rails will not read an updated config after app boot, and rspec provides
+      # no way to restart the app. Here, we reset the memoized value so the app
+      # will read in the new config on the next request.
+      Rails.application.instance_variable_set(:@app_env_config, nil)
+    end
+
+    def configure_csp(mode)
+      Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+      if mode == :nonce_present
+        # Rails will add the nonce to script_src automatically, when script_src is present.
+        Rails.application.config.content_security_policy do |policy|
+          policy.script_src  :self, :https
+        end
+      elsif mode == :script_src_not_present
+        # This is a valid policy, but Rails will not apply the nonce to script_src.
+        Rails.application.config.content_security_policy do |policy|
+          policy.default_src  :self, :https
+          policy.script_src  nil
+        end
+      elsif mode == :unsafe_inline
+        # Browser behavior is undefined when unsafe_inline and the nonce are both present.
+        # The app should never set both, but if they do, our best behavior is to not use the nonce.
+        Rails.application.config.content_security_policy do |policy|
+          policy.script_src  :self, :unsafe_inline
+        end
+      else
+        raise 'Unknown CSP mode'
+      end
+    end
+
+    def nonce(response)
+      response.request.content_security_policy_nonce
+    end
+
+    before do
+      reset_rails_config
+      configure_csp(nonce_mode)
+    end
+
+    context 'when script_src is not present' do
+      let(:nonce_mode) { :script_src_not_present }
+
+      it 'renders the snippet and config in the response without nonce in script tag' do
+        get '/test_rollbar_js'
+
+        expect(response.body).to_not include %Q(<script type="text/javascript" nonce="#{nonce(response)}">)
+        expect(response.body).to include %Q(<script type="text/javascript">)
+      end
+
+      include_examples 'adds the snippet'
+    end
+
+    context 'when unsafe_inline is present' do
+      let(:nonce_mode) { :unsafe_inline }
+
+      it 'renders the snippet and config in the response with nonce in script tag' do
+        get '/test_rollbar_js'
+
+        expect(response.body).to_not include %Q(<script type="text/javascript" nonce="#{nonce(response)}">)
+        expect(response.body).to include %Q(<script type="text/javascript">)
+      end
+
+      include_examples 'adds the snippet'
+    end
+
+    context 'when scp nonce is present' do
+      let(:nonce_mode) { :nonce_present }
+
+      it 'renders the snippet and config in the response with nonce in script tag' do
+        get '/test_rollbar_js'
+
+        expect(response.body).to include %Q(<script type="text/javascript" nonce="#{nonce(response)}">)
+        expect(response.body).to_not include %Q(<script type="text/javascript">)
+      end
+
+      include_examples 'adds the snippet'
+    end
   end
 end

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -46,6 +46,17 @@ describe Rollbar do
     end
 
     it 'should not crash with circular extra_data' do
+      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
+      # The example says we should *not* crash with a circular hash, however the matcher
+      # is actually matching on the internal error we get when we *do* crash on a
+      # recursive stack overflow. On some platforms, this will crash deeper in the
+      # interpreter and we don't get the chance to handle the error at all.
+      #
+      # If the intent is to not crash, there are numerous parts of the reporting
+      # code that need to tbe made safe. If not, this spec should be removed because
+      # the behavior at stack overflow is platform dependent at best and undefined
+      # at worst.
+
       a = { :foo => 'bar' }
       b = { :a => a }
       c = { :b => b }

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -158,57 +158,57 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('error', 'exception description', exception, extra_data, nil)
         notifier.log('error', exception, extra_data, 'exception description')
       end
-      
+
       context 'with :on_error_response hook configured' do
         let!(:notifier) { Rollbar::Notifier.new }
         let(:configuration) do
           config = Rollbar::Configuration.new
           config.access_token = test_access_token
           config.enabled = true
-          
+
           config.hook :on_error_response do |response|
             return ":on_error_response executed"
           end
-          
+
           config
         end
         let(:message) { 'foo' }
         let(:level) { 'foo' }
-  
+
         before do
           notifier.configuration = configuration
           allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(:code => 500, :body => "Error"))
           @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
         end
-        
+
         it "calls the :on_error_response hook if response status is not 200" do
           expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil, nil).and_call_original
           expect(notifier.configuration.hook(:on_error_response)).to receive(:call)
-          
+
           notifier.log(level, message)
         end
       end
-      
+
       context 'with :on_report_internal_error hook configured' do
         let!(:notifier) { Rollbar::Notifier.new }
         let(:configuration) do
           config = Rollbar::Configuration.new
           config.access_token = test_access_token
           config.enabled = true
-          
+
           config.hook :on_report_internal_error do |response|
             return ":on_report_internal_error executed"
           end
-          
+
           config
         end
         let(:message) { 'foo' }
         let(:level) { 'foo' }
-  
+
         before do
           notifier.configuration = configuration
         end
-        
+
         it "calls the :on_report_internal_error hook if" do
           expect(notifier.configuration.hook(:on_report_internal_error)).to receive(:call)
           expect(notifier).to receive(:report) do
@@ -217,22 +217,22 @@ describe Rollbar do
           notifier.log(level, message)
         end
       end
-    
+
       context 'an item with a context' do
         let(:context) { { :controller => 'ExampleController' } }
-        
+
         context 'with a custom_data_method configured' do
           before do
             Rollbar.configure do |config|
-              config.custom_data_method = lambda do |message, exception, context| 
+              config.custom_data_method = lambda do |message, exception, context|
                 { :result => "MyApp#" + context[:controller] }
               end
             end
           end
-          
+
           it 'should have access to the context data through configuration.custom_data_method' do
             result = notifier.log('error', "Custom message", { :custom_data_method_context => context})
-            
+
             result[:body][:message][:extra].should_not be_nil
             result[:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
             result[:body][:message][:extra][:custom_data_method_context].should be_nil
@@ -977,6 +977,17 @@ describe Rollbar do
     # END Backwards
 
     it 'should not crash with circular extra_data' do
+      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
+      # The example says we should *not* crash with a circular hash, however the matcher
+      # is actually matching on the internal error we get when we *do* crash on a
+      # recursive stack overflow. On some platforms, this will crash deeper in the
+      # interpreter and we don't get the chance to handle the error at all.
+      #
+      # If the intent is to not crash, there are numerous parts of the reporting
+      # code that need to tbe made safe. If not, this spec should be removed because
+      # the behavior at stack overflow is platform dependent at best and undefined
+      # at worst.
+
       a = { :foo => "bar" }
       b = { :a => a }
       c = { :b => b }


### PR DESCRIPTION
Issue https://github.com/rollbar/rollbar-gem/issues/698

Rails 5.2 has built in support for CSP: https://edgeguides.rubyonrails.org/security.html#content-security-policy

Apps that want to enable CSP have two choices for inline JS, like the rollbar js snippet:
1. Set the `'unsafe-inline'` policy, which is global and removes security for inline JS, or
2. Use a nonce, which Rails CSP supports, but requires the snippet to use the nonce.

This PR supports both options by only including the nonce when expected.
