### PR TITLE
Issue #545: Handle recursion of payloads with cycles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ Style/SymbolArray:
 Metrics/LineLength:
   Max: 1000
 
+Metrics/MethodLength:
+  Max: 15 # Relax slightly from the default of 10
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -347,10 +347,10 @@ module Rollbar
           exception = arg
         elsif arg.is_a?(Hash)
           extra = arg
-          
+
           context = extra[:custom_data_method_context]
           extra.delete :custom_data_method_context
-          
+
           extra = nil if extra.empty?
         end
       end
@@ -411,7 +411,7 @@ module Rollbar
     # If that fails, we'll fall back to a more static failsafe response.
     def report_internal_error(exception)
       log_error '[Rollbar] Reporting internal error encountered while sending data to Rollbar.'
-      
+
       configuration.execute_hook(:on_report_internal_error, exception)
 
       begin

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -2,14 +2,17 @@ require 'rollbar/util/hash'
 
 module Rollbar
   module Util
-    def self.iterate_and_update(obj, block)
+    def self.iterate_and_update(obj, block, seen = {})
       return if obj.frozen?
+      return if seen[obj.object_id]
+      seen[obj.object_id] = true
+
       if obj.is_a?(Array)
         for i in 0 ... obj.size
           value = obj[i]
 
           if value.is_a?(::Hash) || value.is_a?(Array)
-            self.iterate_and_update(value, block)
+            self.iterate_and_update(value, block, seen)
           else
             obj[i] = block.call(value)
           end
@@ -21,7 +24,7 @@ module Rollbar
           new_key = nil
 
           if v.is_a?(::Hash) || v.is_a?(Array)
-            self.iterate_and_update(v, block)
+            self.iterate_and_update(v, block, seen)
             new_key = block.call(k)
           else
             new_key = block.call(k)

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -86,7 +86,7 @@ module Rollbar
       hash1
     end
 
-    def self.perform_deep_merge(hash1, hash2, merged)
+    def self.perform_deep_merge(hash1, hash2, merged) # rubocop:disable Metrics/AbcSize
       hash2.each_key do |k|
         if hash1[k].is_a?(::Hash) && hash2[k].is_a?(::Hash)
           hash1[k] = deep_merge(hash1[k], hash2[k], merged)

--- a/lib/rollbar/util/hash.rb
+++ b/lib/rollbar/util/hash.rb
@@ -1,20 +1,28 @@
 module Rollbar
   module Util
     module Hash
-      def self.deep_stringify_keys(hash)
+      def self.deep_stringify_keys(hash, seen = {})
+        return if seen[hash.object_id]
+        seen[hash.object_id] = true
+
         hash.reduce({}) do |h, (key, value)|
-          h[key.to_s] = map_value(value, :deep_stringify_keys)
+          h[key.to_s] = map_value(value, :deep_stringify_keys, seen)
 
           h
         end
       end
 
-      def self.map_value(thing, m)
+      def self.map_value(thing, m, seen)
         case thing
         when ::Hash
-          send(m, thing)
+          send(m, thing, seen)
         when Array
-          thing.map { |v| map_value(v, m) }
+          if seen[thing.object_id]
+            thing
+          else
+            seen[thing.object_id] = true
+            thing.map { |v| map_value(v, m, seen) }
+          end
         else
           thing
         end

--- a/lib/rollbar/util/hash.rb
+++ b/lib/rollbar/util/hash.rb
@@ -1,8 +1,9 @@
 module Rollbar
   module Util
-    module Hash
+    module Hash # :nodoc:
       def self.deep_stringify_keys(hash, seen = {})
         return if seen[hash.object_id]
+
         seen[hash.object_id] = true
 
         hash.reduce({}) do |h, (key, value)|
@@ -12,16 +13,16 @@ module Rollbar
         end
       end
 
-      def self.map_value(thing, m, seen)
+      def self.map_value(thing, meth, seen)
         case thing
         when ::Hash
-          send(m, thing, seen)
+          send(meth, thing, seen)
         when Array
           if seen[thing.object_id]
             thing
           else
             seen[thing.object_id] = true
-            thing.map { |v| map_value(v, m, seen) }
+            thing.map { |v| map_value(v, meth, seen) }
           end
         else
           thing

--- a/spec/rollbar/util_spec.rb
+++ b/spec/rollbar/util_spec.rb
@@ -67,7 +67,8 @@ describe Rollbar::Util do
         result = Rollbar::Util.deep_merge(data1, data2)
 
         expect(result.keys).to be_eql(merged.keys)
-        expect(result[:array]).to be_eql(merged[:array])
+        # The version of RSpec required by 1.8.7 (2.xx) can't evaluate this correctly.
+        expect(result[:array]).to be_eql(merged[:array]) unless RUBY_VERSION == '1.8.7'
         expect(result[:foo]).to be_eql(merged[:foo])
         expect(result[:bar]).to be_eql(merged[:bar])
         expect(result[:c].keys).to be_eql(merged[:c].keys)
@@ -94,7 +95,12 @@ describe Rollbar::Util do
       it "doesn't crash and returns same hash" do
         result = Rollbar::Util.deep_copy(data)
 
-        expect(result).to be_eql(data)
+        # The version of RSpec required by 1.8.7 (2.xx) can't evaluate this correctly.
+        if RUBY_VERSION == '1.8.7'
+          expect(result.keys).to be_eql(data.keys) unless RUBY_VERSION == '1.8.7'
+        else
+          expect(result).to be_eql(data) unless RUBY_VERSION == '1.8.7'
+        end
       end
     end
   end

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -46,25 +46,18 @@ describe Rollbar do
     end
 
     it 'should not crash with circular extra_data' do
-      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
-      # The example says we should *not* crash with a circular hash, however the matcher
-      # is actually matching on the internal error we get when we *do* crash on a
-      # recursive stack overflow. On some platforms, this will crash deeper in the
-      # interpreter and we don't get the chance to handle the error at all.
-      #
-      # If the intent is to not crash, there are numerous parts of the reporting
-      # code that need to tbe made safe. If not, this spec should be removed because
-      # the behavior at stack overflow is platform dependent at best and undefined
-      # at worst.
-
       a = { :foo => 'bar' }
       b = { :a => a }
       c = { :b => b }
       a[:c] = c
 
-      logger_mock.should_receive(:error).with(/\[Rollbar\] Reporting internal error encountered while sending data to Rollbar./)
+      expect(logger_mock).to_not receive(:error).with(
+        /\[Rollbar\] Reporting internal error encountered while sending data to Rollbar./
+      )
+      logger_mock.should_receive(:info).with('[Rollbar] Scheduling item')
+      logger_mock.should_receive(:info).with('[Rollbar] Success')
 
-      Rollbar.report_message('Test message with circular extra data', 'debug', a)
+      Rollbar.error('Test message with circular extra data', a)
     end
 
     it 'should be able to report form validation errors when they are present' do

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -977,23 +977,31 @@ describe Rollbar do
     # END Backwards
 
     it 'should not crash with circular extra_data' do
-      skip "This example doesn't do what it says, and leads to undefined behavior. See example for comments."
-      # The example says we should *not* crash with a circular hash, however the matcher
-      # is actually matching on the internal error we get when we *do* crash on a
-      # recursive stack overflow. On some platforms, this will crash deeper in the
-      # interpreter and we don't get the chance to handle the error at all.
-      #
-      # If the intent is to not crash, there are numerous parts of the reporting
-      # code that need to tbe made safe. If not, this spec should be removed because
-      # the behavior at stack overflow is platform dependent at best and undefined
-      # at worst.
-
-      a = { :foo => "bar" }
+      a = { :foo => 'bar' }
       b = { :a => a }
       c = { :b => b }
       a[:c] = c
 
-      logger_mock.should_receive(:error).with(/\[Rollbar\] Reporting internal error encountered while sending data to Rollbar./)
+      array1 = ['a', 'b']
+      array2 = ['c', 'd', array1]
+      a[:array] = array1
+
+      # The line below will introduce a cycle in the array, which the rollbar code can handle.
+      # However, both OJ and ActiveSupport `as_json` crash on this when serializing the payload.
+      # We could do without OJ, but it's a moot point because of the ActiveSupport issue.
+      # The gemspec currently uses multi_json to give the user as much control as possible over
+      # choice of JSON serializer. We should continue to allow this flexibility unless it is
+      # determined that cycles of arrays directly referencing arrays (without other objects
+      # in between) must be supported. Then in that case, an appropriate serializer should
+      # be added to the gemspec.
+      #
+      # array1 << array2
+
+      expect(logger_mock).to_not receive(:error).with(
+        /\[Rollbar\] Reporting internal error encountered while sending data to Rollbar./
+      )
+      logger_mock.should_receive(:info).with('[Rollbar] Scheduling item')
+      logger_mock.should_receive(:info).with('[Rollbar] Success')
 
       Rollbar.error("Test message with circular extra data", a)
     end


### PR DESCRIPTION
https://github.com/rollbar/rollbar-gem/issues/545

This PR allows the code paths for constructing a notifier payload to safely handle nested objects with internal cycles. The updated code handles the code paths that recurse the payload object, and expects cycles in both hash and array object types. 

The two JSON serializers used via `multi_json` (OJ and ActiveSupport) do handle hashes and arrays that reference each other only via hashes or other objects, but they do not handle cycles of arrays directly referencing each other. It's not clear (to me at least) that this specific scenario happens in real life, and therefore I'd rather not limit the user's choice of JSON serializer unless or until we find that it's necessary. Importantly, the internal gem code does now handle this case, and if it crashes due to the JSON serializer, that should now be obvious from the backtrace.

There is a comment in the referenced Github issue that the originally reported issue was related to ActiveSupport, but the code paths fixed in this PR existed at that time and would have crashed in the gem itself before the JSON serializer was reached. 

