### PR TITLE
Issue #696: Fix rake rollbar:test and update for rubocop and rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
-gem 'resque'
+gem 'resque', '< 2.0.0'
 gem 'rspec-command'
 gem 'rubocop', :require => false
 gem 'sinatra'

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -47,7 +47,6 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'sinatra'
-gem 'resque'
 gem 'delayed_job', :require => false
 gem 'redis'
 gem 'database_cleaner', '~> 1.0.0'
@@ -63,7 +62,7 @@ else
   gem 'webmock', :require => false
 end
 
-gem 'resque'
+gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
 
 gemspec :path => '../'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -45,7 +45,6 @@ elsif RUBY_VERSION.start_with?('2')
 end
 
 gem 'sinatra'
-gem 'resque'
 gem 'delayed_job', :require => false
 gem 'redis'
 gem 'database_cleaner'
@@ -61,7 +60,7 @@ else
   gem 'webmock', :require => false
 end
 
-gem 'resque'
+gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
 
 gemspec :path => '../'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -48,7 +48,6 @@ end
 
 gem 'delayed_job', :require => false
 gem 'redis'
-gem 'resque'
 gem 'sinatra'
 
 gem 'database_cleaner', '~> 1.0.0'
@@ -64,7 +63,7 @@ else
   gem 'webmock', :require => false
 end
 
-gem 'resque'
+gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
 
 gemspec :path => '../'

--- a/gemfiles/ruby_1_8_and_1_9_2.gemfile
+++ b/gemfiles/ruby_1_8_and_1_9_2.gemfile
@@ -37,7 +37,7 @@ gem 'delayed_job', '4.1.3', :require => false
 gem 'genspec', '= 0.2.8'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis', '< 3.3.5'
-gem 'resque'
+gem 'resque', '< 2.0.0'
 gem 'sinatra'
 
 ruby_version = RUBY_VERSION.dup

--- a/lib/rollbar/rake_tasks.rb
+++ b/lib/rollbar/rake_tasks.rb
@@ -2,92 +2,123 @@ require 'rollbar'
 begin
   require 'rack/mock'
 rescue LoadError
+  puts 'Cannot load rack/mock'
 end
 require 'logger'
 
 namespace :rollbar do
   desc 'Verify your gem installation by sending a test exception to Rollbar'
   task :test => [:environment] do
-    if defined?(Rails)
-      Rails.logger = if defined?(ActiveSupport::TaggedLogging)
-                       ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-                     else
-                       Logger.new(STDOUT)
-                     end
+    RollbarTest.run
+  end
+end
 
-      Rails.logger.level = Logger::DEBUG
-      Rollbar.preconfigure do |config|
-        config.logger = Rails.logger
-      end
-    end
+# Module to inject into the Rails controllers or rack apps
+module RollbarTest # :nodoc:
+  def test_rollbar
+    puts 'Raising RollbarTestingException to simulate app failure.'
 
-    class RollbarTestingException < RuntimeError; end
+    raise RollbarTestingException.new, 'Testing rollbar with "rake rollbar:test". If you can see this, it works.'
+  end
 
-    unless Rollbar.configuration.access_token
-      puts 'Rollbar needs an access token configured. Check the README for instructions.'
+  def self.run
+    configure_rails if defined?(Rails)
 
-      exit
-    end
+    exit unless confirmed_token?
 
     puts 'Testing manual report...'
     Rollbar.error('Test error from rollbar:test')
 
-    # Module to inject into the Rails controllers or
-    # rack apps
-    module RollbarTest
-      def test_rollbar
-        puts 'Raising RollbarTestingException to simulate app failure.'
+    return unless defined?(Rack::MockRequest)
 
-        raise RollbarTestingException.new, 'Testing rollbar with "rake rollbar:test". If you can see this, it works.'
+    protocol, app = setup_app
+
+    puts 'Processing...'
+    env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify")
+    status, = app.call(env)
+
+    puts error_message unless status.to_i == 500
+  end
+
+  def self.configure_rails
+    Rails.logger = if defined?(ActiveSupport::TaggedLogging)
+                     ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+                   else
+                     Logger.new(STDOUT)
+                   end
+
+    Rails.logger.level = Logger::DEBUG
+    Rollbar.preconfigure do |config|
+      config.logger = Rails.logger
+    end
+  end
+
+  def self.confirmed_token?
+    return true if Rollbar.configuration.access_token
+
+    puts token_error_message
+
+    false
+  end
+
+  def self.token_error_message
+    'Rollbar needs an access token configured. Check the README for instructions.'
+  end
+
+  def self.draw_rails_route
+    Rails.application.routes_reloader.execute_if_updated
+    Rails.application.routes.draw do
+      get 'verify' => 'rollbar_test#verify', :as => 'verify'
+    end
+  end
+
+  def self.authlogic_config
+    # from http://stackoverflow.com/questions/5270835/authlogic-activation-problems
+    return unless defined?(Authlogic)
+
+    Authlogic::Session::Base.controller = Authlogic::ControllerAdapters::RailsAdapter.new(self)
+  end
+
+  def self.setup_app
+    puts 'Setting up the test app.'
+
+    if defined?(Rails)
+      draw_rails_route
+
+      authlogic_config
+
+      protocol = defined?(Rails.application.config.force_ssl && Rails.application.config.force_ssl) ? 'https' : 'http'
+      [protocol, Rails.application]
+    else
+      ['http', rack_app]
+    end
+  end
+
+  def self.rack_app
+    Class.new do
+      include RollbarTest
+
+      def self.call(_env)
+        new.test_rollbar
       end
     end
+  end
 
-    if defined?(Rack::MockRequest)
-      if defined?(Rails)
-        puts 'Setting up the controller.'
+  def self.error_message
+    'Test failed! You may have a configuration issue, or you could be using a gem that\'s blocking the test. Contact support@rollbar.com if you need help troubleshooting.'
+  end
+end
 
-        class RollbarTestController < ActionController::Base
-          include RollbarTest
+class RollbarTestingException < RuntimeError; end
 
-          def verify
-            test_rollbar
-          end
+class RollbarTestController < ActionController::Base # :nodoc:
+  include RollbarTest
 
-          def logger
-            nil
-          end
-        end
+  def verify
+    test_rollbar
+  end
 
-        Rails.application.routes_reloader.execute_if_updated
-        Rails.application.routes.draw do
-          get 'verify' => 'rollbar_test#verify', :as => 'verify'
-        end
-
-        # from http://stackoverflow.com/questions/5270835/authlogic-activation-problems
-        if defined? Authlogic
-          Authlogic::Session::Base.controller = Authlogic::ControllerAdapters::RailsAdapter.new(self)
-        end
-
-        protocol = (defined? Rails.application.config.force_ssl && Rails.application.config.force_ssl) ? 'https' : 'http'
-        app = Rails.application
-      else
-        protocol = 'http'
-        app = Class.new do
-          include RollbarTest
-
-          def self.call(_env)
-            new.test_rollbar
-          end
-        end
-      end
-
-      puts 'Processing...'
-      env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify")
-      status, = app.call(env)
-
-      unless status.to_i == 500
-        puts 'Test failed! You may have a configuration issue, or you could be using a gem that\'s blocking the test. Contact support@rollbar.com if you need help troubleshooting.'
-      end
-    end
+  def logger
+    nil
   end
 end

--- a/lib/rollbar/rake_tasks.rb
+++ b/lib/rollbar/rake_tasks.rb
@@ -34,7 +34,7 @@ module RollbarTest # :nodoc:
     protocol, app = setup_app
 
     puts 'Processing...'
-    env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify")
+    env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify", 'REMOTE_ADDR' => '127.0.0.1')
     status, = app.call(env)
 
     puts error_message unless status.to_i == 500
@@ -85,6 +85,10 @@ module RollbarTest # :nodoc:
   end
 
   def self.rails_app
+    # The setup below is needed for Rails 5.x, but not for Rails 4.x and below.
+    # (And fails on Rails 4.x in various ways depending on the exact version.)
+    return Rails.application if Rails.version < '5.0.0'
+
     # Spring now runs by default in development on all new Rails installs. This causes
     # the new `/verify` route to not get picked up if `config.cache_classes == false`
     # which is also a default in development env.

--- a/spec/rollbar/rake_tasks_spec.rb
+++ b/spec/rollbar/rake_tasks_spec.rb
@@ -9,19 +9,15 @@ describe RollbarTest do
         reconfigure_notifier
       end
 
-      it 'raises the test exception' do
+      it 'raises the test exception and exits with success message' do
         expect { subject.run }.to raise_exception(RollbarTestingException)
-
-        exception_info = Rollbar.last_report[:body][:trace][:exception]
-        exception_info[:class].should == 'RollbarTestingException'
+          .with_message(Regexp.new(subject.success_message))
       end
     end
 
     context 'when rollbar is not configured' do
-      it 'exits with message' do
-        subject.run
-
-        STDOUT.should_receive(:puts).with(subject.token_error_message)
+      it 'exits with error message' do
+        expect { subject.run }.to output(Regexp.new(subject.token_error_message)).to_stdout
       end
     end
   end

--- a/spec/rollbar/rake_tasks_spec.rb
+++ b/spec/rollbar/rake_tasks_spec.rb
@@ -9,6 +9,11 @@ describe RollbarTest do
         reconfigure_notifier
       end
 
+      after do
+        # Rails <= 4.x needs this, since we modify the default RouteSet in RollbarTest#run.
+        Rails.application.reload_routes!
+      end
+
       it 'raises the test exception and exits with success message' do
         expect { subject.run }.to raise_exception(RollbarTestingException)
           .with_message(Regexp.new(subject.success_message))

--- a/spec/rollbar/rake_tasks_spec.rb
+++ b/spec/rollbar/rake_tasks_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'rollbar/rake_tasks'
 
-describe RollbarTest do
+describe RollbarTest, :if => RUBY_VERSION >= '1.9.3' do
   describe '#run' do
     context 'when rollbar is configured' do
       before do
@@ -15,7 +15,7 @@ describe RollbarTest do
       end
 
       it 'raises the test exception and exits with success message' do
-        expect { subject.run }.to raise_exception(RollbarTestingException)
+        expect { subject.run }.to raise_exception(RollbarTestingException) \
           .with_message(Regexp.new(subject.success_message))
       end
     end

--- a/spec/rollbar/rake_tasks_spec.rb
+++ b/spec/rollbar/rake_tasks_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'rollbar/rake_tasks'
+
+describe RollbarTest do
+  describe '#run' do
+    context 'when rollbar is configured' do
+      before do
+        reset_configuration
+        reconfigure_notifier
+      end
+
+      it 'raises the test exception' do
+        expect { subject.run }.to raise_exception(RollbarTestingException)
+
+        exception_info = Rollbar.last_report[:body][:trace][:exception]
+        exception_info[:class].should == 'RollbarTestingException'
+      end
+    end
+
+    context 'when rollbar is not configured' do
+      it 'exits with message' do
+        subject.run
+
+        STDOUT.should_receive(:puts).with(subject.token_error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/rollbar/rollbar-gem/issues/696

Refactor rake rollbar:test:
- [x] Refactors rake_tasks.rb to use a module callable from Rspec
- [x] Refactors rake_tasks.rb to pass rubocop
- [x] Adds RSpec examples for primary use cases

Fix https://github.com/rollbar/rollbar-gem/issues/696:
- [x] Run the verification test using a clone of the default Rails app.
- [x] Resolve RSpec issues with Rails 4.x

The root cause of the issue, "ActionController::RoutingError (No route matches [GET] "/verify")" when running `rake rollbar:test:`, is that when Spring is running in the background and `config.cache_classes == false` in the current Rails environment, routes are reset on each request and the new test route can't be found.

The issue was initially difficult to reproduce because, even if Spring is already running, `bin/rake` will use Spring and reproduce the error. However, `bundle exec rake` does not use Spring and therefore does not reproduce the error.

In short, to see this error you must have Spring running, have `config.cache_classes == false`, and use `bin/rake` (or at least a way of invoking rake that does use Spring.)

Several techniques were considered to work around this issue. Neither the middleware chain (`ActionDispatch::Reloader` does the actual work resetting the routes) nor the `cache_classes` flag can be changed after Rails is loaded.

Cloning the app allows the config to be updated without modifying the default app. While changes to the default app config could be safely reverted by using `ensure` sections, the code is shorter and cleaner when using the cloned app.