### PR TITLE
Pin sqlite gem to 1.3.x or less (after incompatible 1.4.0 was released)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '4.2.8'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 unless is_jruby
   if RUBY_VERSION >= '2.5'

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 gem 'jruby-openssl', :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal', '= 1.0.2'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 gem 'jruby-openssl', :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal', '= 1.0.2'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -10,7 +10,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '3.2.22'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 # Please see https://github.com/rspec/rspec-rails/issues/1273
 gem 'test-unit'
 

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -10,7 +10,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '4.0.13'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 # Please see https://github.com/rspec/rspec-rails/issues/1273
 gem 'test-unit'
 

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -10,7 +10,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '4.1.12'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 unless is_jruby
   if RUBY_VERSION >= '2.4.0'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -11,7 +11,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '4.2.8'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 platforms :rbx do
   gem 'minitest'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -8,7 +8,7 @@ gem 'appraisal'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '~> 5.0.0'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.5.0.beta3'
 gem 'rspec-rails', '~> 3.5.0.beta3'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -8,7 +8,7 @@ gem 'appraisal'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '~> 5.1.0'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.5.0.beta3'
 gem 'rspec-rails', '~> 3.5.0.beta3'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -8,7 +8,7 @@ gem 'appraisal'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '~> 5.2.0'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.8.0'
 gem 'rspec-rails', '~> 3.8.0'

--- a/gemfiles/ruby_1_8_and_1_9_2.gemfile
+++ b/gemfiles/ruby_1_8_and_1_9_2.gemfile
@@ -11,7 +11,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '3.0.20'
 gem 'rake', '< 11'
 gem 'rspec-rails', '>= 2.14.0'
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'oj', '~> 2.12.14' unless is_jruby
 if RUBY_VERSION > '1.8.7' && RUBY_VERSION < '2.2.2'


### PR DESCRIPTION
Latest sqlite3 gem version is 1.4.0, but ActiveRecord (including latest 5.2.x) still needs 1.3.x.

sqlite3 version bump:
https://github.com/sparklemotion/sqlite3-ruby/blob/v1.4.0/lib/sqlite3/version.rb