### PR TITLE
Issue #487: Automatically add Rollbar::ActiveJob to ActionMailer::DeliveryJob

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -13,3 +13,6 @@ module Rollbar
     end
   end
 end
+
+# Automatically add to ActionMailer::DeliveryJob
+ActionMailer::DeliveryJob.include Rollbar::ActiveJob if defined?(ActionMailer::DeliveryJob)

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -15,4 +15,4 @@ module Rollbar
 end
 
 # Automatically add to ActionMailer::DeliveryJob
-ActionMailer::DeliveryJob.include Rollbar::ActiveJob if defined?(ActionMailer::DeliveryJob)
+ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)

--- a/spec/rollbar/delay/active_job_spec.rb
+++ b/spec/rollbar/delay/active_job_spec.rb
@@ -5,11 +5,16 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
     require 'rollbar/delay/active_job'
 
     describe Rollbar::Delay::ActiveJob do
+      include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper) # rubocop:disable Style/MixinUsage
+
       describe '.call' do
         let(:payload) { {} }
         it 'calls Rollbar' do
           expect(Rollbar).to receive(:process_from_async_handler).with(payload)
-          Rollbar::Delay::ActiveJob.call(payload)
+
+          perform_enqueued_jobs do
+            Rollbar::Delay::ActiveJob.call(payload)
+          end
         end
       end
     end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -2,52 +2,23 @@ require 'spec_helper'
 
 require 'active_support/rescuable'
 
-if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
-  context 'using rails4.2 and up' do
-    describe Rollbar::ActiveJob do
-      class TestJob
-        # To mix in rescue_from
-        include ActiveSupport::Rescuable
-        include Rollbar::ActiveJob
+describe Rollbar::ActiveJob do
+  class TestJob
+    # To mix in rescue_from
+    include ActiveSupport::Rescuable
+    include Rollbar::ActiveJob
 
-        attr_reader :job_id
-        attr_accessor :arguments
+    attr_reader :job_id
+    attr_accessor :arguments
 
-        def initialize(*arguments)
-          @arguments = arguments
-        end
+    def initialize(*arguments)
+      @arguments = arguments
+    end
 
-        def perform(exception, job_id)
-          @job_id = job_id
-          # ActiveJob calls rescue_with_handler when a job raises an exception
-          rescue_with_handler(exception) || raise(exception)
-        end
-      end
-
-      before { reconfigure_notifier }
-
-      let(:exception) { StandardError.new('oh no') }
-      let(:job_id) { '123' }
-      let(:argument) { 12 }
-
-      it 'reports the error to Rollbar' do
-        expected_params = {
-          :job => 'TestJob',
-          :job_id => job_id,
-          :use_exception_level_filters => true,
-          :arguments => [argument]
-        }
-        expect(Rollbar).to receive(:error).with(exception, expected_params)
-        begin
-          TestJob.new(argument).perform(exception, job_id)
-        rescue StandardError
-          nil
-        end
-      end
-
-      it 'reraises the error so the job backend can handle the failure and retry' do
-        expect { TestJob.new(argument).perform(exception, job_id) }.to raise_error exception
-      end
+    def perform(exception, job_id)
+      @job_id = job_id
+      # ActiveJob calls rescue_with_handler when a job raises an exception
+      rescue_with_handler(exception) || raise(exception)
     end
   end
 

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -25,21 +25,53 @@ describe Rollbar::ActiveJob do
   before { reconfigure_notifier }
 
   let(:exception) { StandardError.new('oh no') }
-  let(:job_id) { "123" }
+  let(:job_id) { '123' }
   let(:argument) { 12 }
 
-  it "reports the error to Rollbar" do
+  it 'reports the error to Rollbar' do
     expected_params = {
-      :job => "TestJob",
+      :job => 'TestJob',
       :job_id => job_id,
       :use_exception_level_filters => true,
       :arguments => [argument]
     }
     expect(Rollbar).to receive(:error).with(exception, expected_params)
-    TestJob.new(argument).perform(exception, job_id) rescue nil
+    TestJob.new(argument).perform(exception, job_id) rescue nil # rubocop:disable Style/RescueModifier
   end
 
-  it "reraises the error so the job backend can handle the failure and retry" do
+  it 'reraises the error so the job backend can handle the failure and retry' do
     expect { TestJob.new(argument).perform(exception, job_id) }.to raise_error exception
+  end
+
+  context 'using ActionMailer::DeliveryJob', :if => defined?(ActionMailer::DeliveryJob) do
+    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper) # rubocop:disable Style/MixinUsage
+
+    class TestMailer < ActionMailer::Base
+      attr_accessor :arguments
+
+      def test_email(*_arguments)
+        error = StandardError.new('oh no')
+        raise(error)
+      end
+    end
+
+    it 'job is created' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        TestMailer.test_email(argument).deliver_later
+      end.to have_enqueued_job.on_queue('mailers')
+    end
+
+    it 'reports the error to Rollbar' do
+      expected_params = {
+        :job => 'ActionMailer::DeliveryJob',
+        :use_exception_level_filters => true,
+        :arguments => ['TestMailer', 'test_email', 'deliver_now', 12]
+      }
+      expect(Rollbar).to receive(:error).with(kind_of(StandardError), hash_including(expected_params))
+      perform_enqueued_jobs do
+        TestMailer.test_email(argument).deliver_later rescue nil # rubocop:disable Style/RescueModifier
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/487

From the issue report:
> Rails has a built-in job called `ActionMailer::DeliveryJob` which is used when you call `deliver_later` on your action mailer emails. Currently errors in that job are not being reported.

This PR automatically hooks into that job as part of Rails integration.