### PR TITLE
Allow raw/native JSON in JS config object, e.g. checkIgnore function

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -120,7 +120,11 @@ module Rollbar
 
         add_person_data(js_config, env)
 
-        script_tag("var _rollbarConfig = #{js_config.to_json};", env)
+        # MUST use the Ruby JSON encoder (JSON#generate).
+        # See lib/rollbar/middleware/js/json_value
+        json = ::JSON.generate(js_config)
+
+        script_tag("var _rollbarConfig = #{json};", env)
       end
 
       def add_person_data(js_config, env)

--- a/lib/rollbar/middleware/js/json_value.rb
+++ b/lib/rollbar/middleware/js/json_value.rb
@@ -1,0 +1,26 @@
+# Allows a Ruby String to be used to create native Javascript objects
+# when calling JSON#generate.
+#
+# Example:
+# JSON.generate({ foo: Rollbar::JSON::Value.new('function(){ alert("bar") }') })
+# => '{"foo":function(){ alert(\"bar\") }}'
+#
+# MUST use the Ruby JSON encoder, as in the example. The ActiveSupport encoder,
+# which is installed with Rails, is invoked when calling Hash#to_json and #as_json,
+# and will not work.
+#
+module Rollbar
+  module JSON
+    class Value # :nodoc:
+      attr_accessor :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def to_json(*_args)
+        value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/648
Fixes https://github.com/rollbar/rollbar-gem/issues/710

Use `Rollbar::JSON::Value` to pass native JSON values, without enclosing string quotes.

Example:
```
Rollbar.configure do |config|
  config.js_enabled = true
  config.js_options = {
    accessToken: "POST_CLIENT_ITEM_ACCESS_TOKEN",
    checkIgnore: Rollbar::JSON::Value.new('function(){ alert("bar") }')
  }
end
```

### Ruby `JSON.generate` vs. ActiveSupport `#to_json` and `#as_json` 
When serializing the js_options object, the middleware now uses Ruby `JSON.generate` instead of ActiveSupport's `#to_json`.

Early versions of ActiveSupport could use the `#encode_json` method to get a similar ability to inject values without enclosing quote marks.
 
ActiveSupport before version 4.1.0 supported the `#encode_json` method, and then the activesupport-json_encoder gem did for Rails < 5.x. For Rails 5.x, the desired functionality doesn't appear achievable via ActiveSupport. For all versions, the dependencies and requirements are fragmented, and the functionality would not work at all on a Rack app without ActiveSupport.

The native Ruby `JSON#generate` works consistently across all versions of Ruby and imposes no dependencies on users of the gem. The encoder requirement is only on the generation of the js_options object in the middleware and has no impact on other JSON objects in the gem, or on the host application.

 