### PR TITLE
Remove Ruby 1.8.7, 1.9.2 from Travis matrix, and update gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,6 @@ Metrics/BlockLength:
 
 Style/ExpandPathArguments:
   Enabled: false # syntax requires Ruby >= 2.0
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false # rubocop compares to gemspec, yet won't allow 1.9 as minimum version

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,13 +66,7 @@ gemfile:
   - gemfiles/rails51.gemfile
   - gemfiles/rails52.gemfile
 matrix:
-  include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
-    - rvm: 1.9.2
-      gemfile: gemfiles/ruby_1_8_and_1_9_2.gemfile
-      jdk: openjdk7
+  include: []
 
   allow_failures:
     - rvm: ruby-head
@@ -85,18 +79,6 @@ matrix:
   exclude:
     # Don't run tests for non-jruby environments with the JDK.
     # NOTE: openjdk7 is missing from these exclusions so that Travis will run at least 1 build for the given rvm.
-    - rvm: 1.8.7
-      jdk: openjdk8
-    - rvm: 1.8.7
-      jdk: oraclejdk8
-    - rvm: 1.8.7
-      jdk: oraclejdk9
-    - rvm: 1.9.2
-      jdk: openjdk8
-    - rvm: 1.9.2
-      jdk: oraclejdk8
-    - rvm: 1.9.2
-      jdk: oraclejdk9
     - rvm: 1.9.3
       jdk: openjdk8
     - rvm: 1.9.3
@@ -165,40 +147,6 @@ matrix:
     - rvm: rbx
       jdk: oraclejdk9
 
-    # MRI 1.8.x - 1.9.2 have a separate gemfile and cannot use the
-    # gemfiles for 1.9.3 and higher.
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails32.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails41.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails32.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails41.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails52.gemfile
     # Rails 5.x requires Ruby 2.2.2 or higher
     - rvm: 1.9.3
       gemfile: gemfiles/rails50.gemfile

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ For complete usage instructions and configuration reference, see our [Ruby SDK d
 
 ## Compatibility
 
-Version x.x is compatible with Ruby >= 1.9.3.
+Version >= 2.19.0 is compatible with Ruby >= 1.9.3.
 
-Version < x.x is compatible with Ruby >= 1.8.7.
+Version < 2.19.0 is compatible with Ruby >= 1.8.7.
 
 ## Release History & Changelog
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/rollbar.svg)](http://badge.fury.io/rb/rollbar)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rollbar&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=rollbar&package-manager=bundler&version-scheme=semver&new-version=latest)
 
-> WARNING: Ruby 2.6.0 introduced a new bug bug ([#15472 - 
+> WARNING: Ruby 2.6.0 introduced a new bug bug ([#15472 -
 Invalid JSON data being sent from Net::HTTP in some cases with Ruby 2.6.0](https://bugs.ruby-lang.org/issues/15472)) that may result in the Rollbar API returning an error when an exception is reported.  (See [rollbar-gem issue #797](https://github.com/rollbar/rollbar-gem/issues/797)).
 > Until the Ruby maintainers have released the fix for this bug, we advise Rollbar users to not upgrade their applications to Ruby 2.6.0.
 
@@ -21,6 +21,12 @@ Rollbar-gem is the SDK for Ruby apps and includes support for apps using Rails, 
 ## Usage and Reference
 
 For complete usage instructions and configuration reference, see our [Ruby SDK docs](https://docs.rollbar.com/docs/ruby).
+
+## Compatibility
+
+Version x.x is compatible with Ruby >= 1.9.3.
+
+Version < x.x is compatible with Ruby >= 1.8.7.
 
 ## Release History & Changelog
 

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   gem.name          = 'rollbar'
   gem.require_paths = ['lib']
+  gem.required_ruby_version = '>= 1.9.3'
   gem.version       = Rollbar::VERSION
 
   gem.add_runtime_dependency 'multi_json'


### PR DESCRIPTION
Maintenance ended on Ruby 1.8.7 and 1.9.2 in 2014, including security updates. The latest Rails they work with is 3.x, and especially 1.8.7 doesn't support modern Ruby syntax, which holds back the gem code from using preferred syntax. Finally, in spite of their limited use and usefulness, it's not uncommon for a PR to need special treatment for these in the Travis matrix. RIP.

(Any users of these Ruby versions can still pin to an earlier version of rollbar-gem.)

Todo: Decide what version bump is appropriate for the change in gemspec requirements. (Ruby >= 1.9.3)
- [x] Update version.rb and readme.md with correct gem version.

