### PR TITLE
Fix Travis error: unable to reap all threads within 3 seconds

### DIFF
--- a/lib/rollbar/delay/thread.rb
+++ b/lib/rollbar/delay/thread.rb
@@ -5,7 +5,7 @@ module Rollbar
   module Delay
     class Thread
       EXIT_SIGNAL  = :exit
-      EXIT_TIMEOUT = 3
+      EXIT_TIMEOUT = 6
 
       Error        = Class.new(StandardError)
       TimeoutError = Class.new(Error)


### PR DESCRIPTION
A small percentage of builds will randomly fail on Travis with Rollbar::Delay::Thread::TimeoutError: "unable to reap all threads within 3 seconds". This merely happens because Travis itself is slow, and the build passes if restarted.

This PR doubles the timeout threshold. I wanted to do this only for test env, but `Rollbar.configuration` isn't available yet when the delay modules are loaded. (They are required by notifier, which in turn is required by rollbar.rb.)

Moving the timeout constant (so that it is read after Rollbar module loads), or resynthesizing an environment value inside `Delay::Thread` both looked like worse options than just changing the value for all environments. 