### PR TITLE
ag scrub the extra field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,4 @@ gem 'rspec-command'
 gem 'rubocop', :require => false
 gem 'sinatra'
 gem 'webmock', :require => false
-
 gemspec

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -159,7 +159,7 @@ module Rollbar
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
         Util.deep_merge(scrub(custom_data), scrub(extra) || {})
       else
-        extra
+        scrub(extra)
       end
     end
 

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -157,17 +157,17 @@ module Rollbar
 
     def build_extra
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
-        Util.deep_merge(custom_data, scrub_extra || {})
+        Util.deep_merge(scrub(custom_data), scrub(extra) || {})
       else
         extra
       end
     end
 
-    def scrub_extra
-      return extra unless extra.is_a? Hash
+    def scrub(data)
+      return data unless data.is_a? Hash
 
       options = {
-        :params => extra,
+        :params => data,
         :config => Rollbar.configuration.scrub_fields,
         :whitelist => Rollbar.configuration.scrub_whitelist
       }

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -157,10 +157,20 @@ module Rollbar
 
     def build_extra
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
-        Util.deep_merge(custom_data, extra || {})
+        Util.deep_merge(custom_data, scrub_extra || {})
       else
-        extra
+        scrub_extra
       end
+    end
+
+    def scrub_extra
+      return extra unless extra.is_a? Hash
+      options = {
+        :params => extra,
+        :config => Rollbar.configuration.scrub_fields,
+        :whitelist => Rollbar.configuration.scrub_whitelist
+      }
+      Rollbar::Scrubbers::Params.call(options)
     end
 
     def custom_data_method?

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -165,6 +165,7 @@ module Rollbar
 
     def scrub_extra
       return extra unless extra.is_a? Hash
+
       options = {
         :params => extra,
         :config => Rollbar.configuration.scrub_fields,

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -159,7 +159,7 @@ module Rollbar
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
         Util.deep_merge(custom_data, scrub_extra || {})
       else
-        scrub_extra
+        extra
       end
     end
 

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -145,6 +145,7 @@ module Rollbar
 
       level = lookup_exception_level(level, exception,
                                      use_exception_level_filters)
+
       begin
         report(level, message, exception, extra, context)
       rescue StandardError, SystemStackError => e

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -145,7 +145,6 @@ module Rollbar
 
       level = lookup_exception_level(level, exception,
                                      use_exception_level_filters)
-
       begin
         report(level, message, exception, extra, context)
       rescue StandardError, SystemStackError => e

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -20,6 +20,7 @@ module Rollbar
       def call(options = {})
         params = options[:params]
         return {} unless params
+
         @scrubbed_object_ids = {}
 
         config = options[:config]
@@ -57,7 +58,7 @@ module Rollbar
       end
 
       def scrub(params, options)
-        return params if @scrubbed_object_ids[params.object_id].present?
+        return params if @scrubbed_object_ids[params.object_id]
 
         @scrubbed_object_ids[params.object_id] = true
 

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -58,6 +58,7 @@ module Rollbar
 
       def scrub(params, options)
         return params if @scrubbed_object_ids[params.object_id].present?
+
         @scrubbed_object_ids[params.object_id] = true
 
         fields_regex = options[:fields_regex]

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -20,6 +20,7 @@ module Rollbar
       def call(options = {})
         params = options[:params]
         return {} unless params
+        @scrubbed_object_ids = {}
 
         config = options[:config]
         extra_fields = options[:extra_fields]
@@ -56,6 +57,9 @@ module Rollbar
       end
 
       def scrub(params, options)
+        return params if @scrubbed_object_ids[params.object_id].present?
+        @scrubbed_object_ids[params.object_id] = true
+
         fields_regex = options[:fields_regex]
         scrub_all = options[:scrub_all]
         whitelist_regex = options[:whitelist]

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1132,6 +1132,15 @@ describe Rollbar do
     end
   end
 
+  it 'should scrub the extra field' do
+    Rollbar.configure do |config|
+      config.scrub_fields |= [:scrubbed_field]
+    end
+
+    Rollbar.error("test error", {scrubbed_field: "sensitive_info"})
+    Rollbar.last_report[:body][:message][:extra][:scrubbed_field].should match(/^*+$/)
+  end
+
   context 'payload_destination' do
     before(:each) do
       configure


### PR DESCRIPTION
The extra field is not being scrubbed according to the scrub fields, this could lead to PII leaking internally as many would assume that the extra params are scrubbed.

in particular, calling `Rollbar.error(e, extra_params: some_request_params)` for example.