### PR TITLE
Add capture_uncaught flag to config options

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -8,6 +8,7 @@ module Rollbar
     attr_accessor :async_handler
     attr_accessor :branch
     attr_reader :before_process
+    attr_accessor :capture_uncaught
     attr_accessor :code_version
     attr_accessor :custom_data_method
     attr_accessor :delayed_job_enabled
@@ -72,6 +73,7 @@ module Rollbar
     def initialize
       @async_handler = nil
       @before_process = []
+      @capture_uncaught = nil
       @code_version = nil
       @custom_data_method = nil
       @default_logger = lambda { ::Logger.new(STDERR) }

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -1,6 +1,8 @@
 module Rollbar
   module ExceptionReporter
     def report_exception_to_rollbar(env, exception)
+      return unless capture_uncaught?
+
       exception_message = exception.respond_to?(:message) ? exception.message : 'No Exception Message'
       Rollbar.log_debug "[Rollbar] Reporting exception: #{exception_message}"
 
@@ -16,6 +18,10 @@ module Rollbar
       end
     rescue => e
       Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e.message}"
+    end
+
+    def capture_uncaught?
+      Rollbar.configuration.capture_uncaught != false
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -335,6 +335,18 @@ describe HomeController do
         get '/cause_exception'
       end
 
+      context 'with capture_uncaught == false' do
+        it 'should not report the exception' do
+          Rollbar.configure do |config|
+            config.capture_uncaught = false
+          end
+
+          expect(notifier).to_not receive(:log)
+
+          get '/cause_exception'
+        end
+      end
+
       context 'with logged user' do
         let(:user) do
           User.create(:email => 'foo@bar.com',
@@ -441,10 +453,10 @@ describe HomeController do
 
       expect(session_data['some_value']).to be_eql('this-is-a-cool-value')
     end
-    
+
     it 'scrubs session id by default from the request' do
       expect { get '/use_session_data' }.to raise_exception(NoMethodError)
-      
+
       expect(Rollbar.last_report[:request][:session]['session_id']).to match('\*{3,8}')
     end
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -292,6 +292,18 @@ describe HomeController do
       expect { get '/cause_exception' }.to raise_exception(NameError)
     end
 
+    context 'with capture_uncaught == false' do
+      it 'should not report the exception' do
+        Rollbar.configure do |config|
+          config.capture_uncaught = false
+        end
+
+        expect(Rollbar).to_not receive(:log)
+
+        expect { get '/cause_exception' }.to raise_exception(NameError)
+      end
+    end
+
     context 'show_exceptions' do
       before(:each) do
         if Dummy::Application.respond_to? :env_config
@@ -333,18 +345,6 @@ describe HomeController do
         end
 
         get '/cause_exception'
-      end
-
-      context 'with capture_uncaught == false' do
-        it 'should not report the exception' do
-          Rollbar.configure do |config|
-            config.capture_uncaught = false
-          end
-
-          expect(notifier).to_not receive(:log)
-
-          get '/cause_exception'
-        end
       end
 
       context 'with logged user' do

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -62,6 +62,20 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
             get '/foo'
           end.to raise_error(SinatraDummy::DummyError)
         end
+
+        context 'with capture_uncaught == false' do
+          before do
+            Rollbar.configure do |config|
+              config.capture_uncaught = false
+            end
+          end
+
+          it 'should not report the exception' do
+            expect(Rollbar).to_not receive(:log)
+
+            expect { get '/foo' }.to raise_error(SinatraDummy::DummyError)
+          end
+        end
       end
 
       context 'with raise_errors? == false' do

--- a/spec/rollbar/plugins/rack_spec.rb
+++ b/spec/rollbar/plugins/rack_spec.rb
@@ -31,6 +31,20 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
     expect { request.get('/will_crash') }.to raise_error(exception)
   end
 
+  context 'with capture_uncaught == false' do
+    before do
+      Rollbar.configure do |config|
+        config.capture_uncaught = false
+      end
+    end
+
+    it 'should not report the exception' do
+      expect(Rollbar).to_not receive(:log)
+
+      expect { request.get('/will_crash') }.to raise_error(exception)
+    end
+  end
+
   context 'with GET parameters' do
     let(:params) do
       { 'key' => 'value' }


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/719

Set `capture_uncaught = false` to disable Rollbar handling of uncaught exceptions.

- [x] Add capture_uncaught behavior.
- [x] Refactor lib/rollbar/exception_reporter.rb for rubocop compliance.