### PR TITLE
Remove dependency on redis server endpoint

### DIFF
--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -9,13 +9,16 @@ rescue LoadError
 end
 
 module Rollbar
-  module JSON
+  module JSON # :nodoc:
     extend self
 
     attr_writer :options_module
 
     def dump(object)
-      with_adapter { MultiJson.dump(object, adapter_options) }
+      # `basic_socket` plugin addresses the following issue: https://github.com/rollbar/rollbar-gem/issues/845
+      Rollbar.plugins.get('basic_socket').load_scoped!(true) do
+        with_adapter { MultiJson.dump(object, adapter_options) }
+      end
     end
 
     def load(string)

--- a/lib/rollbar/plugin.rb
+++ b/lib/rollbar/plugin.rb
@@ -68,7 +68,7 @@ module Rollbar
       begin
         revert_callables.each(&:call)
       rescue StandardError => e
-        log_loading_error(e)
+        log_unloading_error(e)
       ensure
         self.loaded = false
       end
@@ -117,6 +117,10 @@ module Rollbar
 
     def log_loading_error(error)
       Rollbar.log_error("Error trying to load plugin '#{name}': #{error.class}, #{error.message}")
+    end
+
+    def log_unloading_error(error)
+      Rollbar.log_error("Error trying to unload plugin '#{name}': #{error.class}, #{error.message}")
     end
   end
 end

--- a/lib/rollbar/plugin.rb
+++ b/lib/rollbar/plugin.rb
@@ -32,7 +32,7 @@ module Rollbar
 
     def load_scoped!(transparent = false)
       if transparent
-        load! unless load?
+        load! if load?
 
         result = yield
 

--- a/lib/rollbar/plugin.rb
+++ b/lib/rollbar/plugin.rb
@@ -7,6 +7,8 @@ module Rollbar
     attr_reader :name
     attr_reader :dependencies
     attr_reader :callables
+    attr_reader :revert_callables
+    attr_accessor :on_demand
     attr_accessor :loaded
 
     private :loaded=
@@ -15,11 +17,37 @@ module Rollbar
       @name = name
       @dependencies = []
       @callables = []
+      @revert_callables = []
       @loaded = false
+      @on_demand = false
+    end
+
+    def load_on_demand
+      @on_demand = true
     end
 
     def configuration
       Rollbar.configuration
+    end
+
+    def load_scoped!(transparent = false)
+      if transparent
+        load! unless load?
+
+        result = yield
+
+        unload! if loaded
+      else
+        return unless load?
+
+        load!
+
+        result = yield
+
+        unload!
+      end
+
+      result
     end
 
     def load!
@@ -27,10 +55,22 @@ module Rollbar
 
       begin
         callables.each(&:call)
-      rescue => e
+      rescue StandardError => e
         log_loading_error(e)
       ensure
         self.loaded = true
+      end
+    end
+
+    def unload!
+      return unless loaded
+
+      begin
+        revert_callables.each(&:call)
+      rescue StandardError => e
+        log_loading_error(e)
+      ensure
+        self.loaded = false
       end
     end
 
@@ -38,8 +78,12 @@ module Rollbar
       callables << block
     end
 
-    def execute!(&block)
-      block.call if load?
+    def execute!
+      yield if load?
+    end
+
+    def revert(&block)
+      revert_callables << block
     end
 
     private
@@ -61,7 +105,7 @@ module Rollbar
 
     def load?
       !loaded && dependencies_satisfy?
-    rescue => e
+    rescue StandardError => e
       log_loading_error(e)
 
       false
@@ -71,8 +115,8 @@ module Rollbar
       dependencies.all?(&:call)
     end
 
-    def log_loading_error(e)
-      Rollbar.log_error("Error trying to load plugin '#{name}': #{e.class}, #{e.message}")
+    def log_loading_error(error)
+      Rollbar.log_error("Error trying to load plugin '#{name}': #{error.class}, #{error.message}")
     end
   end
 end

--- a/lib/rollbar/plugins.rb
+++ b/lib/rollbar/plugins.rb
@@ -29,7 +29,13 @@ module Rollbar
     end
 
     def load!
-      collection.each(&:load!)
+      collection.each do |plugin|
+        plugin.load! unless plugin.on_demand
+      end
+    end
+
+    def get(name)
+      collection.find { |plugin| plugin.name == name }
     end
 
     private

--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -1,4 +1,5 @@
 Rollbar.plugins.define('basic_socket') do
+  
   load_on_demand
 
   dependency { !configuration.disable_core_monkey_patch }
@@ -9,11 +10,8 @@ Rollbar.plugins.define('basic_socket') do
       Gem::Version.new(ActiveSupport::VERSION::STRING) < Gem::Version.new('5.2.0')
   end
 
-  @original_as_json = ::BasicSocket.public_instance_method(:as_json)
-
   execute do
-    require 'socket'
-
+    @original_as_json = ::BasicSocket.public_instance_method(:as_json)
     class BasicSocket # :nodoc:
       def as_json(_options = nil)
         {

--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -1,16 +1,29 @@
 Rollbar.plugins.define('basic_socket') do
+  load_on_demand
+
   dependency { !configuration.disable_core_monkey_patch }
 
   # Needed to avoid active_support (< 4.1.0) bug serializing JSONs
-  dependency { defined?(ActiveSupport::VERSION::STRING) }
+  dependency do
+    defined?(ActiveSupport::VERSION::STRING) &&
+      Gem::Version.new(ActiveSupport::VERSION::STRING) < Gem::Version.new('5.2.0')
+  end
+
+  @original_as_json = ::BasicSocket.public_instance_method(:as_json)
 
   execute do
     require 'socket'
 
-    class BasicSocket
-      def as_json(*)
-        to_s
+    class BasicSocket # :nodoc:
+      def as_json(_options = nil)
+        {
+          :value => inspect
+        }.to_json
       end
     end
+  end
+
+  revert do
+    ::BasicSocket.define_method(:as_json, @original_as_json)
   end
 end

--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -18,7 +18,7 @@ Rollbar.plugins.define('basic_socket') do
       def as_json(_options = nil)
         {
           :value => inspect
-        }.to_json
+        }
       end
     end
   end

--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -24,6 +24,6 @@ Rollbar.plugins.define('basic_socket') do
   end
 
   revert do
-    ::BasicSocket.define_method(:as_json, @original_as_json)
+    ::BasicSocket.send(:define_method, :as_json, @original_as_json)
   end
 end

--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -1,5 +1,4 @@
 Rollbar.plugins.define('basic_socket') do
-  
   load_on_demand
 
   dependency { !configuration.disable_core_monkey_patch }

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -689,8 +689,8 @@ describe Rollbar::Item do
 
       it 'fails in ActiveSupport with stack too deep' do
         begin
-          json = item.dump
-        rescue NoMemoryError, SystemStackError
+          _json = item.dump
+        rescue NoMemoryError, SystemStackError, Java::JavaLang::StackOverflowError
           # Item#dump fails with SystemStackError (ActiveSupport > 4.0)
           # or NoMemoryError (ActiveSupport <= 4.0) which, as system exceptions
           # not a StandardError, cannot be tested by `expect().to raise_error`

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -122,42 +122,42 @@ describe Rollbar::Item do
       payload['data'][:body][:message][:extra][:a].should == 1
       payload['data'][:body][:message][:extra][:b][2].should == 4
     end
-    
+
     context do
       let(:context) { { :controller => "ExampleController" } }
-    
+
       it 'should have access to the context in custom_data_method' do
         configuration.custom_data_method = lambda do |message, exception, context|
           { :result => "MyApp#" + context[:controller] }
         end
-  
+
         payload['data'][:body][:message][:extra].should_not be_nil
         payload['data'][:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
       end
-      
+
       it 'should not include data passed in :context if there is no custom_data_method configured' do
         configuration.custom_data_method = nil
-  
+
         payload['data'][:body][:message][:extra].should be_nil
       end
-      
+
       it 'should have access to the message in custom_data_method' do
         configuration.custom_data_method = lambda do |message, exception, context|
           { :result => "Transformed in custom_data_method: " + message }
         end
-        
+
         payload['data'][:body][:message][:extra].should_not be_nil
         payload['data'][:body][:message][:extra][:result].should == "Transformed in custom_data_method: " + message
       end
-      
+
       context do
         let(:exception) { Exception.new "Exception to test custom_data_method" }
-        
+
         it 'should have access to the current exception in custom_data_method' do
           configuration.custom_data_method = lambda do |message, exception, context|
             { :result => "Transformed in custom_data_method: " + exception.message }
           end
-          
+
           payload['data'][:body][:trace][:extra].should_not be_nil
           payload['data'][:body][:trace][:extra][:result].should == "Transformed in custom_data_method: " + exception.message
         end
@@ -668,21 +668,36 @@ describe Rollbar::Item do
   end # end #build
 
   describe '#dump' do
-    context 'with Redis instance in payload and ActiveSupport is enabled' do
-      let(:redis) { ::Redis.new }
+    context 'with recursing instance in payload and ActiveSupport is enabled' do
+      class Recurse
+        # ActiveSupport also hijacks #to_json, but relies on #as_json to do its real work.
+        # The implementation is different earlier vs later than 4.0, but both can
+        # be made to fail in the same way with this construct.
+        def as_json(*)
+          { :self => self }
+        end
+      end
+
       let(:payload) do
         {
           :key => {
-            :value => redis
+            :value => Recurse.new
           }
         }
       end
       let(:item) { Rollbar::Item.build_with(payload) }
 
-      it 'dumps to JSON correctly' do
-        json = item.dump
+      it 'fails in ActiveSupport with stack too deep' do
+        begin
+          json = item.dump
+        rescue NoMemoryError, SystemStackError
+          # Item#dump fails with SystemStackError (ActiveSupport > 4.0)
+          # or NoMemoryError (ActiveSupport <= 4.0) which, as system exceptions
+          # not a StandardError, cannot be tested by `expect().to raise_error`
+          error = :SystemError
+        end
 
-        expect(json).to be_kind_of(String)
+        expect(error).to be_eql(:SystemError)
       end
     end
 

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -680,7 +680,6 @@ describe Rollbar::Item do
       let(:item) { Rollbar::Item.build_with(payload) }
 
       it 'dumps to JSON correctly' do
-        redis.set('foo', 'bar')
         json = item.dump
 
         expect(json).to be_kind_of(String)

--- a/spec/rollbar/json_spec.rb
+++ b/spec/rollbar/json_spec.rb
@@ -46,6 +46,18 @@ describe Rollbar::JSON do
 
       described_class.dump(payload)
     end
+
+    context 'with basic_socket plugin unloadable' do
+      before do
+        Rollbar.configuration.disable_core_monkey_patch = true
+      end
+
+      it 'still calls MultiJson.dump' do
+        expect(::MultiJson).to receive(:dump).once.with(payload, adapter_options)
+
+        described_class.dump(payload)
+      end
+    end
   end
 
   describe '.load' do

--- a/spec/rollbar/plugin_spec.rb
+++ b/spec/rollbar/plugin_spec.rb
@@ -114,6 +114,22 @@ describe Rollbar::Plugin do
 
         expect(subject.loaded).to be_eql(false)
       end
+
+      context 'with exceptions thrown in the reversals' do
+        let(:plugin_proc) do
+          proc do
+            revert do
+              raise StandardError
+            end
+          end
+        end
+
+        it 'it logs a plugin unload error message' do
+          expect(::Rollbar).to receive(:log_error).with(/Error trying to unload plugin/)
+
+          subject.unload!
+        end
+      end
     end
   end
 

--- a/spec/rollbar/plugin_spec.rb
+++ b/spec/rollbar/plugin_spec.rb
@@ -32,6 +32,18 @@ describe Rollbar::Plugin do
       end
     end
 
+    context 'when called as transparent' do
+      it 'loads the plugin and executes the block' do
+        expect(dummy_object).to receive(:upcase).ordered
+        expect(dummy_object).to receive(:reverse!).ordered
+        expect(dummy_object).to receive(:downcase).ordered
+
+        subject.load_scoped!(true) do
+          dummy_object.reverse!
+        end
+      end
+    end
+
     context 'with false dependencies' do
       let(:dummy_object) { '' }
       let(:plugin_proc) do

--- a/spec/rollbar/plugins/basic_socket_spec.rb
+++ b/spec/rollbar/plugins/basic_socket_spec.rb
@@ -39,8 +39,8 @@ describe 'basic_socket plugin' do
 
             subject.load_scoped! do
               socket = TCPSocket.new 'example.com', 80
-              expect(JSON.parse(socket.as_json)).to include('value')
-              expect(JSON.parse(socket.as_json)['value']).to match(/TCPSocket/)
+              expect(socket.as_json).to include(:value)
+              expect(socket.as_json[:value]).to match(/TCPSocket/)
             end
 
             expect(BasicSocket.public_instance_method(:as_json).source_location).
@@ -77,8 +77,8 @@ describe 'basic_socket plugin' do
           it 'changes implementation of ::BasicSocket#as_json' do
             subject.load!
             socket = TCPSocket.new 'example.com', 80
-            expect(JSON.parse(socket.as_json)).to include('value')
-            expect(JSON.parse(socket.as_json)['value']).to match(/TCPSocket/)
+            expect(socket.as_json).to include(:value)
+            expect(socket.as_json[:value]).to match(/TCPSocket/)
           end
         end
 

--- a/spec/rollbar/plugins/basic_socket_spec.rb
+++ b/spec/rollbar/plugins/basic_socket_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'rollbar'
+
+Rollbar.plugins.load!
+
+shared_examples 'unloadable' do
+  it "doesn't load" do
+    subject.load!
+    expect(subject.loaded).to eq(false)
+  end
+end
+
+describe 'basic_socket plugin' do
+  subject { Rollbar.plugins.get('basic_socket') }
+
+  after(:each) do
+    subject.unload!
+  end
+
+  it 'is an on demand plugin' do
+    expect(subject.on_demand).to eq(true)
+  end
+
+  it "doesn't load by default" do
+    expect(subject.loaded).to eq(false)
+  end
+
+  describe '#load_scoped!' do
+    context 'with core monkey patching enabled' do
+      before { subject.configuration.disable_core_monkey_patch = false }
+
+      if Gem::Version.new(ActiveSupport::VERSION::STRING) < Gem::Version.new('5.2.0')
+        context 'using active_support < 5.2' do
+          it 'changes implementation of ::BasicSocket#as_json temporarily' do
+            original_implementation = BasicSocket.public_instance_method(:as_json)
+
+            subject.load_scoped! do
+              socket = TCPSocket.new 'example.com', 80
+              expect(JSON.parse(socket.as_json)).to include('value')
+              expect(JSON.parse(socket.as_json)['value']).to match(/TCPSocket/)
+            end
+
+            expect(BasicSocket.public_instance_method(:as_json)).to eq(original_implementation)
+          end
+        end
+      else
+        context 'using active_support >= 5.2' do
+          context 'when called as transparent' do
+            it 'executes provided block even when depencies are unmet' do
+              result = false
+              subject.load_scoped!(true) do
+                result = true
+              end
+              expect(result).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#load!' do
+    if Gem::Version.new(ActiveSupport::VERSION::STRING) < Gem::Version.new('5.2.0')
+      context 'using active_support < 5.2' do
+        context 'with core monkey patching enabled' do
+          before { subject.configuration.disable_core_monkey_patch = false }
+
+          it 'loads' do
+            subject.load!
+            expect(subject.loaded).to eq(true)
+          end
+
+          it 'changes implementation of ::BasicSocket#as_json' do
+            subject.load!
+            socket = TCPSocket.new 'example.com', 80
+            expect(JSON.parse(socket.as_json)).to include('value')
+            expect(JSON.parse(socket.as_json)['value']).to match(/TCPSocket/)
+          end
+        end
+
+        context 'with core monkey patching disabled' do
+          before { subject.configuration.disable_core_monkey_patch = true }
+
+          it_should_behave_like 'unloadable'
+        end
+      end
+    else
+      context 'using active_support >= 5.2' do
+        it_should_behave_like 'unloadable'
+      end
+    end
+  end
+end

--- a/spec/rollbar/plugins_spec.rb
+++ b/spec/rollbar/plugins_spec.rb
@@ -64,5 +64,31 @@ describe Rollbar::Plugins do
 
       subject.load!
     end
+
+    context 'with on demand plugins' do
+      before do
+        subject.define(:on_demand_plugin) do
+          load_on_demand
+        end
+      end
+
+      it 'it doesn\'t load on demand plugins by default' do
+        expect(subject.get(:on_demand_plugin)).to_not receive(:load!)
+
+        subject.load!
+      end
+    end
+  end
+
+  describe '#get' do
+    context 'with a defined plugin' do
+      before do
+        subject.define('#get_plugin', &plugin1_proc)
+      end
+
+      it 'finds the plugin' do
+        expect(subject.get('#get_plugin')).to be_kind_of(Rollbar::Plugin)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/724

It looks like the main point of this rspec example is to serialize the object, but it's this single call to `Redis#set` that requires having a live redis server. 