### PR TITLE
Enable locals in exception frame data

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -26,6 +26,7 @@ module Rollbar
     attr_accessor :framework
     attr_accessor :ignored_person_ids
     attr_accessor :host
+    attr_accessor :locals
     attr_writer :logger
     attr_accessor :payload_options
     attr_accessor :person_method
@@ -105,6 +106,7 @@ module Rollbar
       @net_retries = 3
       @js_enabled = false
       @js_options = {}
+      @locals = {}
       @scrub_fields = [:passwd, :password, :password_confirmation, :secret,
                        :confirm_password, :password_confirmation, :secret_token,
                        :api_key, :access_token, :session_id]

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -66,7 +66,7 @@ module Rollbar
       self.payload = {
         'access_token' => configuration.access_token,
         'data' => data
-      }
+    }
 
       enforce_valid_utf8
       transform

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -66,7 +66,7 @@ module Rollbar
       self.payload = {
         'access_token' => configuration.access_token,
         'data' => data
-    }
+      }
 
       enforce_valid_utf8
       transform

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -74,10 +74,10 @@ module Rollbar
       end
 
       def map_frames(current_exception)
-        exception_backtrace(current_exception).reverse.map do |frame|
+        exception_backtrace(current_exception).map do |frame|
           Rollbar::Item::Frame.new(self, frame,
                                    :configuration => configuration).to_h
-        end
+        end.reverse
       end
 
       # Returns the backtrace to be sent to our API. There are 3 options:

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -1,5 +1,6 @@
 # We want to use Gem.path
 require 'rubygems'
+require 'rollbar/item/locals'
 
 module Rollbar
   class Item
@@ -47,7 +48,8 @@ module Rollbar
 
         {
           :code => code_data(file_lines, lineno),
-          :context => context_data(file_lines, lineno)
+          :context => context_data(file_lines, lineno),
+          :locals => locals_data(filename, lineno)
         }
       end
 
@@ -92,6 +94,10 @@ module Rollbar
           :pre => pre_data(file_lines, lineno),
           :post => post_data(file_lines, lineno)
         }
+      end
+
+      def locals_data(filename, lineno)
+        ::Rollbar::Item::Locals.locals_for_location(filename, lineno)
       end
 
       def post_data(file_lines, lineno)

--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -28,6 +28,8 @@ module Rollbar
           nil
         end
 
+        private
+
         def matching_frame?(frame, filename, lineno)
           frame[:path] == filename && frame[:lineno].to_i <= lineno.to_i
         end

--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -1,0 +1,48 @@
+require 'rollbar/notifier'
+
+module Rollbar
+  class Item
+    class Locals # :nodoc:
+      class << self
+        def exception_frames
+          Rollbar.notifier.exception_bindings
+        end
+
+        def locals_for_location(filename, lineno)
+          puts "Location: #{filename}:#{lineno}"
+          if (frame = frame_for_location(filename, lineno))
+            puts "Frame: #{frame[:path]}:#{frame[:lineno]}"
+            locals_for(frame[:binding]).tap {|locals| puts locals.inspect }
+          else
+            {}
+          end
+        end
+
+        def frame_for_location(filename, lineno)
+          while (frame = exception_frames.pop)
+            return nil unless frame
+            return frame if matching_frame?(frame, filename, lineno)
+            puts "Skipped Frame: #{frame[:path]}:#{frame[:lineno]}"
+          end
+          nil
+        end
+
+        def matching_frame?(frame, filename, lineno)
+          frame[:path] == filename && frame[:lineno].to_i <= lineno.to_i
+        end
+
+        def locals_for(frame)
+          {}.tap do |hash|
+            frame.local_variables.map do |var|
+              hash[var] = prepare_value(frame.local_variable_get(var))
+            end
+          end
+        end
+
+        def prepare_value(value)
+          value.inspect
+        end
+      end
+    end
+  end
+end

--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -12,7 +12,7 @@ module Rollbar
           puts "Location: #{filename}:#{lineno}"
           if (frame = frame_for_location(filename, lineno))
             puts "Frame: #{frame[:path]}:#{frame[:lineno]}"
-            locals_for(frame[:binding]).tap {|locals| puts locals.inspect }
+            locals_for(frame[:binding]).tap { |locals| puts locals.inspect }
           else
             {}
           end
@@ -22,6 +22,7 @@ module Rollbar
           while (frame = exception_frames.pop)
             return nil unless frame
             return frame if matching_frame?(frame, filename, lineno)
+
             puts "Skipped Frame: #{frame[:path]}:#{frame[:lineno]}"
           end
           nil

--- a/lib/rollbar/middleware/rack.rb
+++ b/lib/rollbar/middleware/rack.rb
@@ -17,12 +17,15 @@ module Rollbar
 
         Rollbar.scoped(fetch_scope(env)) do
           begin
+            Rollbar.notifier.enable_locals
             response = @app.call(env)
             report_exception_to_rollbar(env, framework_error(env)) if framework_error(env)
             response
           rescue Exception => e
             report_exception_to_rollbar(env, e)
             raise
+          ensure
+            Rollbar.notifier.disable_locals
           end
         end
       end

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -21,6 +21,7 @@ module Rollbar
 
           Rollbar.scoped(scope) do
             begin
+              Rollbar.notifier.enable_locals
               response = @app.call(env)
 
               if (framework_exception = env['action_dispatch.exception'])
@@ -31,6 +32,8 @@ module Rollbar
             rescue Exception => exception
               report_exception_to_rollbar(env, exception)
               raise
+            ensure
+              Rollbar.notifier.disable_locals
             end
           end
         end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -313,12 +313,16 @@ module Rollbar
       trace_with_bindings.frames
     end
 
+    def enable_locals?
+      configuration.locals[:enabled] && [:app, :all].include?(configuration.send_extra_frame_data)
+    end
+
     def enable_locals
-      trace_with_bindings.enable if configuration.send_extra_frame_data
+      trace_with_bindings.enable if enable_locals?
     end
 
     def disable_locals
-      trace_with_bindings.disable if configuration.send_extra_frame_data
+      trace_with_bindings.disable if enable_locals?
     end
 
     private

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -8,6 +8,7 @@ require 'rollbar/delay/girl_friday'
 require 'rollbar/delay/thread'
 require 'rollbar/logger_proxy'
 require 'rollbar/item'
+require 'rollbar/notifier/trace_with_bindings'
 require 'ostruct'
 
 module Rollbar
@@ -298,6 +299,26 @@ module Rollbar
 
     def logger
       @logger ||= LoggerProxy.new(configuration.logger)
+    end
+
+    def trace_with_bindings
+      @trace_with_bindings ||= TraceWithBindings.new
+    end
+
+    def exception_bindings
+      trace_with_bindings.exception_frames
+    end
+
+    def current_bindings
+      trace_with_bindings.frames
+    end
+
+    def enable_locals
+      trace_with_bindings.enable if configuration.send_extra_frame_data
+    end
+
+    def disable_locals
+      trace_with_bindings.disable if configuration.send_extra_frame_data
     end
 
     private

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -22,6 +22,8 @@ module Rollbar
         trace_point.disable if defined?(TracePoint)
       end
 
+      private
+
       def exception_signature(trace)
         # use the exception backtrace to detect reraised exception.
         trace.raised_exception.backtrace.first

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -1,0 +1,56 @@
+module Rollbar
+  class Notifier
+    class TraceWithBindings # :nodoc:
+      attr_reader :frames, :exception_frames
+
+      def initialize
+        @frames = []
+        @exception_frames = []
+        @exception_signature = nil
+      end
+
+      def enable
+        trace_point.enable
+      end
+
+      def disable
+        trace_point.disable
+      end
+
+      def exception_signature(trace)
+        # use the exception backtrace to detect reraised exception.
+        trace.raised_exception.backtrace.first
+      end
+
+      def detect_reraise(trace)
+        @exception_signature == exception_signature(trace)
+      end
+
+      def trace_point
+        @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call, :c_return, :raise) do |tp|
+          case tp.event
+          when :call, :b_call, :c_call, :class
+            frames.push frame(tp)
+          when :return, :b_return, :c_return, :end
+            frames.pop
+          when :raise
+            unless detect_reraise(tp) # ignore reraised exceptions
+              @exception_frames = @frames.dup # may be possible to optimize better than #dup
+              @exception_signature = exception_signature(tp)
+            end
+          end
+        end
+      end
+
+      def frame(trace)
+        {
+          :binding => trace.binding,
+          :defined_class => trace.defined_class,
+          :method_id => trace.method_id,
+          :path => trace.path,
+          :lineno => trace.lineno
+        }
+      end
+    end
+  end
+end

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -10,11 +10,11 @@ module Rollbar
       end
 
       def enable
-        trace_point.enable
+        trace_point.enable if defined?(TracePoint)
       end
 
       def disable
-        trace_point.disable
+        trace_point.disable if defined?(TracePoint)
       end
 
       def exception_signature(trace)
@@ -27,6 +27,8 @@ module Rollbar
       end
 
       def trace_point
+        return unless defined?(TracePoint)
+
         @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call, :c_return, :raise) do |tp|
           case tp.event
           when :call, :b_call, :c_call, :class

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -4,12 +4,17 @@ module Rollbar
       attr_reader :frames, :exception_frames
 
       def initialize
+        reset
+      end
+
+      def reset
         @frames = []
         @exception_frames = []
         @exception_signature = nil
       end
 
       def enable
+        reset
         trace_point.enable if defined?(TracePoint)
       end
 

--- a/lib/tasks/benchmark.rake
+++ b/lib/tasks/benchmark.rake
@@ -1,0 +1,103 @@
+require 'benchmark'
+
+namespace :benchmark do
+  desc 'Measure TracePoint perf for current Ruby'
+  task :trace_point do
+    ARGV.each { |a| task(a.to_sym { ; }) } # Keep rake from treating these ask task names.
+
+    options = {}.tap do |hash|
+      ARGV.each { |arg| hash[arg] = true }
+    end
+
+    puts "options: #{options}"
+
+    trace_with_bindings = BenchmarkTraceWithBindings.new(options)
+
+    trace_with_bindings.enable
+    puts(Benchmark.measure do
+      TraceTest.benchmark_with_locals
+    end)
+    trace_with_bindings.disable
+
+    puts "counts: #{trace_with_bindings.counts}" if options['counts']
+  end
+end
+
+class TraceTest # :nodoc:
+  class << self
+    def benchmark_with_locals
+      foo = false
+
+      (0..20_000).each do |index|
+        foo = TraceTest
+
+        change_frame_with_locals(foo, index)
+      end
+    end
+
+    def change_frame_with_locals(foo, _index)
+      foo.tap do |obj|
+        bar = 'bar'
+        hash = { :foo => obj, :bar => bar } # rubocop:disable Lint/UselessAssignment
+      end
+    end
+  end
+end
+
+class BenchmarkTraceWithBindings # :nodoc:
+  attr_reader :frames, :exception_frames, :options, :counts
+
+  def initialize(options = {})
+    @options = options
+    @frames = []
+    @exception_frames = []
+    @exception_signature = nil
+    @counts = init_counts({})
+  end
+
+  def init_counts(counts)
+    [:call, :b_call, :c_call, :class].each do |event|
+      counts[event] = 0
+    end
+    counts
+  end
+
+  def enable
+    return if options['disable']
+
+    trace_point.enable if defined?(TracePoint)
+  end
+
+  def disable
+    return if options['disable']
+
+    trace_point.disable if defined?(TracePoint)
+  end
+
+  def trace_point # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    return unless defined?(TracePoint)
+
+    @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call, :c_return, :raise) do |tp|
+      next if options['hook_only']
+
+      case tp.event
+      when :call, :b_call, :c_call, :class
+        @counts[tp.event] += 1 if options['counts']
+        frame = options['frame'] ? frame(tp) : {}
+        frames.push frame if options['stack']
+      when :return, :b_return, :c_return, :end
+        frames.pop if options['stack']
+      end
+    end
+  end
+
+  def frame(trace)
+    {
+      :binding => trace.binding,
+      :defined_class => trace.defined_class,
+      :method_id => trace.method_id,
+      :path => trace.path,
+      :lineno => trace.lineno
+    }
+  end
+end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -285,6 +285,20 @@ describe HomeController do
     end
   end
 
+  describe "'cause_exception_with_locals'", :type => "request" do
+    before do
+      Rollbar.configure do |config|
+        config.send_extra_frame_data = :app
+      end
+    end
+
+    it "should raise an uncaught exception and report a message" do
+      logger_mock.should_receive(:info).with('[Rollbar] Success').once
+
+      expect { get '/cause_exception_with_locals' }.to raise_exception(NoMethodError)
+    end
+  end
+
   describe "'cause_exception'", :type => "request" do
     it "should raise an uncaught exception and report a message" do
       logger_mock.should_receive(:info).with('[Rollbar] Success').once
@@ -441,10 +455,10 @@ describe HomeController do
 
       expect(session_data['some_value']).to be_eql('this-is-a-cool-value')
     end
-    
+
     it 'scrubs session id by default from the request' do
       expect { get '/use_session_data' }.to raise_exception(NoMethodError)
-      
+
       expect(Rollbar.last_report[:request][:session]['session_id']).to match('\*{3,8}')
     end
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -291,8 +291,9 @@ describe HomeController do
     context 'when locals is enabled' do
       before do
         Rollbar.configure do |config|
-          config.send_extra_frame_data = :app
+          config.send_extra_frame_data = :all
           config.locals = { :enabled => true }
+          config.randomize_scrub_length = false
         end
       end
 
@@ -300,7 +301,7 @@ describe HomeController do
         [
           {
             :obj => 'Post',
-            :bar => "\"bar\"", # rubocop:disable Style/StringLiterals
+            :password => '******',
             :hash => "{:foo=>Post, :bar=>\"bar\"}", # rubocop:disable Style/StringLiterals
             :foo => 'Post',
             :_index => '0'

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -28,6 +28,24 @@ class HomeController < ApplicationController
     foo = bar
   end
 
+  def cause_exception_with_locals
+    foo = false
+
+    (0..2).each do |index|
+      foo = Post
+
+      build_hash_with_locals(foo, index)
+    end
+  end
+
+  def build_hash_with_locals(foo, extra)
+    foo.tap do |obj|
+      bar = 'bar'
+      hash = { :foo => obj, :bar => bar }
+      hash.invalid_method
+    end
+  end
+
   def test_rollbar_js
     render 'js/test', :layout => 'simple'
   end

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -40,8 +40,8 @@ class HomeController < ApplicationController
 
   def build_hash_with_locals(foo, _index)
     foo.tap do |obj|
-      bar = 'bar'
-      hash = { :foo => obj, :bar => bar }
+      password = '123456'
+      hash = { :foo => obj, :bar => 'bar' }
       hash.invalid_method
     end
   end

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -38,7 +38,7 @@ class HomeController < ApplicationController
     end
   end
 
-  def build_hash_with_locals(foo, extra)
+  def build_hash_with_locals(foo, _index)
     foo.tap do |obj|
       bar = 'bar'
       hash = { :foo => obj, :bar => bar }

--- a/spec/dummyapp/config/routes.rb
+++ b/spec/dummyapp/config/routes.rb
@@ -5,6 +5,8 @@ Dummy::Application.routes.draw do
   end
 
   match '/cause_exception' => 'home#cause_exception', :via => [:get, :post]
+  match '/cause_exception_with_locals' => 'home#cause_exception_with_locals',
+        :via => [:get, :post]
   put '/deprecated_report_exception' => 'home#deprecated_report_exception'
   match '/report_exception' => 'home#report_exception',
         :via => [:get, :post, :put]

--- a/spec/rollbar/item/frame_spec.rb
+++ b/spec/rollbar/item/frame_spec.rb
@@ -91,7 +91,8 @@ foo13
             :context => {
               :pre => %w(foo3 foo4 foo5 foo6),
               :post => %w(foo8 foo9 foo10 foo11)
-            }
+            },
+            :locals => {}
           }
 
           expect(subject.to_h).to be_eql(expected_result)
@@ -166,7 +167,8 @@ foo13
               :context => {
                 :pre => %w(foo3 foo4 foo5 foo6),
                 :post => %w(foo8 foo9 foo10 foo11)
-              }
+              },
+              :locals => {}
             }
 
             expect(subject.to_h).to be_eql(expected_result)
@@ -190,7 +192,8 @@ foo13
               :context => {
                 :pre => %w(foo3 foo4 foo5 foo6),
                 :post => %w(foo8 foo9 foo10 foo11)
-              }
+              },
+              :locals => {}
             }
 
             expect(subject.to_h).to be_eql(expected_result)
@@ -233,7 +236,8 @@ foo13
                 :context => {
                   :pre => %w(foo1 foo2),
                   :post => %w(foo4 foo5 foo6 foo7)
-                }
+                },
+                :locals => {}
               }
 
               expect(subject.to_h).to be_eql(expected_result)
@@ -254,7 +258,8 @@ foo13
                 :context => {
                   :pre => %w(foo7 foo8 foo9 foo10),
                   :post => %w(foo12 foo13)
-                }
+                },
+                :locals => {}
               }
 
               expect(subject.to_h).to be_eql(expected_result)

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -216,13 +216,12 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
       end
     end
 
-    describe 'configuration.locals', :type => 'request',
-                                    :if => RUBY_VERSION >= '2.3.0' &&
+    describe 'configuration.locals', :if => RUBY_VERSION >= '2.3.0' &&
                                             !(defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
       context 'when locals is enabled' do
         before do
           Rollbar.configure do |config|
-            config.send_extra_frame_data = :app
+            config.send_extra_frame_data = :all
             config.locals = { :enabled => true }
           end
         end
@@ -231,7 +230,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           [
             {
               :obj => 'Post',
-              :bar => "\"bar\"", # rubocop:disable Style/StringLiterals
+              :bar => 'bar',
               :hash => "{:foo=>Post, :bar=>\"bar\"}", # rubocop:disable Style/StringLiterals
               :foo => 'Post',
               :_index => '0'
@@ -271,7 +270,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
       context 'when locals is not enabled' do
         before do
           Rollbar.configure do |config|
-            config.send_extra_frame_data = :app
+            config.send_extra_frame_data = :all
           end
         end
 


### PR DESCRIPTION
https://github.com/rollbar/rollbar-gem/issues/117

This is currently a working proof of concept, to get feedback and to continue testing.

If you use this branch and enable `config.send_extra_frame_data` and `config.locals = { :enabled => true }`, local vars will be included in the frame data and will show up in the Rollbar Traceback for the exception.

The functionality relies on the Ruby `TracePoint` interface, which has been around since ~2.0, but I have found in testing so far that it works as expected in MRI 2.3.0 and up, and has best performance in 2.6.x. For now, if you want to try this in your own Rails project, use >= 2.3.0, and 2.6.1 is preferred.

### Known issues, caveats, etc.

- ~Only the Rails middleware is wrapped yet. The functionality isn't Rails specific; I just haven't wrapped the other middlewares yet.~ Rack/Sinatra middleware is enabled now too.

- A `locals` config option has been added in the style of the python option. (e.g. `config.locals = { :enabled => true }`) Currently, there is just the enable option. It's expected that more of the additional config options used in python, or similar, should be added at some point.

- The values of local vars are added to the payload using `#to_s`, to avoid ActiveSupport serialization issues. More can be done here if we decide to move forward with the feature. Similar to the python feature, objects could be fully or partially serialized or just identified by class name.

- ~No scrubbing is implemented yet.~ The params scrubber is now applied to locals.

### Performance

TracePoint is a thin wrapper around `Kernel#set_trace_func` and is more performant than `set_trace_func` largely because you can avoid hooking all events unnecessarily. But also, TracePoint has become more performant in later versions of Ruby, especially 2.6.x. 

Test timings were generated using a test code path that generated over 20K method calls, 40K block entry calls, and 20K C function calls.

The rake task to generate this data is here: 
https://github.com/rollbar/rollbar-gem/blob/wj-exception-locals/lib/tasks/benchmark.rake

Benchmarks for the instrumented code path are here:
https://docs.google.com/spreadsheets/d/1keJNwA2vHvyCZHKilvcB2JnPRzlvoiZBUHy9lK2ppkk/edit#gid=429472357

And summarized:

Ruby | Without hooks | With hooks | Full locals capture | Production (test branching removed)
-----|---------------|------------|---------------------|-----------
2.3.0 | 0.0100s | 0.0300s | 0.1200s |
2.6.1 | 0.0048s | 0.0292s | 0.1040s | 0.0745s
 
Concerns about peformance can be mitigated in several ways. Currently the hook is only enabled after the exception middleware in the request path. It could also be enabled only for specific requests. The design of the integration to rollbar-gem can allow on-the-fly enable/disable, which could benefit specific production debugging scenarios. Finally, in Ruby 2.6.x, TracePoint has granular enable filters (selecting a single method, for example) that are meant to preserve performance, even in production.

It's not clear whether or not this feature is more or less performant than the python implementation, or by how much. User expectations for that environment may be able to help inform decisions here.