### PR TITLE
Disable sending reports to rollbar if no access token is configured

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -126,7 +126,7 @@ module Rollbar
     #   Rollbar.log(e, 'This is a description of the exception')
     #
     def log(level, *args)
-      return 'disabled' unless configuration.enabled
+      return 'disabled' unless enabled?
 
       message, exception, extra, context = extract_arguments(args)
       use_exception_level_filters = use_exception_level_filters?(extra)
@@ -183,6 +183,11 @@ module Rollbar
     # See log() above
     def critical(*args)
       log('critical', *args)
+    end
+
+    def enabled?
+      # Require access_token so we don't try to send events when unconfigured.
+      configuration.enabled && configuration.access_token && !configuration.access_token.empty?
     end
 
     def process_item(item)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -52,6 +52,19 @@ describe Rollbar do
     end
   end
 
+  context 'when rollbar is unconfigured' do
+    before do
+      reset_configuration
+    end
+
+    it 'should not send events, and should be disabled' do
+      expect(Rollbar.configuration.access_token).to be_eql(nil)
+      expect(Rollbar.notifier).to receive(:log).and_call_original
+      expect(Rollbar.notifier).to_not receive(:report)
+      expect(Rollbar.error('error message')).to be_eql('disabled')
+    end
+  end
+
   shared_examples 'stores the root notifier' do
 
   end
@@ -1346,6 +1359,7 @@ describe Rollbar do
       context 'with async failover handlers' do
         before do
           Rollbar.reconfigure do |config|
+            config.access_token = test_access_token
             config.use_async = true
             config.async_handler = async_handler
             config.failover_handlers = handlers

--- a/spec/support/rollbar_api.rb
+++ b/spec/support/rollbar_api.rb
@@ -24,11 +24,6 @@ class RollbarAPI
   end
 
   def bad_request(json)
-    # We don't have for now any test doing bad requests
-    # so raise here in order to detect that scenario
-    raise
-
-
     [400, response_headers, [bad_request_body]]
   end
 


### PR DESCRIPTION
This update only tries to send reports to Rollbar if an access token is configured. 

Currently, if the gem is bundled in a project but not configured (e.g. via `Rollbar.configure`) the default state is for the gem to be enabled to send, and enabled to capture unhandled exceptions. This change ensures that in the default unconfigured state, the gem will not try to send reports without an access token.