### PR TITLE
Tolerate connection pool errors

### DIFF
--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -65,7 +65,13 @@ module Rollbar
           block = proc { extract_person_data_from_controller(env) }
           return block unless defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?
 
-          proc { ActiveRecord::Base.connection_pool.with_connection(&block) }
+          proc do
+            begin
+              ActiveRecord::Base.connection_pool.with_connection(&block)
+            rescue ActiveRecord::ConnectionTimeoutError
+              {}
+            end
+          end
         end
 
         def context(request_data)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -458,6 +458,16 @@ describe HomeController do
             end
           end
         end
+
+        context 'when ActiveRecord times out' do
+          it 'succeeds with empty person object' do
+            allow_any_instance_of(ActiveRecord::ConnectionAdapters::ConnectionPool)
+              .to receive(:with_connection)
+              .and_raise(ActiveRecord::ConnectionTimeoutError)
+
+            expect(person_data).to eq({})
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/620

If ActiveRecord times out while getting person data, rescue the exception and return an empty person object. This allows sending the original exception report, rather than an internal error report.