### PR TITLE
Use alias_method to replace #as_json

### DIFF
--- a/lib/rollbar/plugins/basic_socket.rb
+++ b/lib/rollbar/plugins/basic_socket.rb
@@ -10,17 +10,22 @@ Rollbar.plugins.define('basic_socket') do
   end
 
   execute do
-    @original_as_json = ::BasicSocket.public_instance_method(:as_json)
     class BasicSocket # :nodoc:
-      def as_json(_options = nil)
+      def new_as_json(_options = nil)
         {
           :value => inspect
         }
       end
+      # alias_method is recommended over alias when aliasing at runtime.
+      # https://github.com/rubocop-hq/ruby-style-guide#alias-method
+      alias_method :original_as_json, :as_json # rubocop:disable Style/Alias
+      alias_method :as_json, :new_as_json # rubocop:disable Style/Alias
     end
   end
 
   revert do
-    ::BasicSocket.send(:define_method, :as_json, @original_as_json)
+    class BasicSocket # :nodoc:
+      alias_method :as_json, :original_as_json # rubocop:disable Style/Alias
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/850

`BasicSocket#define_method` causes "TypeError: bind argument must be an instance of Enumerable".

I'm seeing this in JRuby specifically, and when the `#load_scoped!` spec runs in isolation or runs before the `#load!` spec. So, using JRuby (I'm using 9.1.9.0), either of these will repro 100%:

bundle exec rspec spec/rollbar/plugins/basic_socket_spec.rb:35

bundle exec rspec --seed 26852 spec/rollbar/plugins/basic_socket_spec.rb

It turns out `#unload!` always fails in JRuby, but running the specs in a different order will mask the failure.

Root cause is:
* ActiveSupport adds `#as_json` to `Enumerable`, which is included in `BasicSocket`.
* The original UnboundMethod that is saved to be bound later has `#owner == Enumerable` on it.
* `BasicSocket#define_method` fails with "TypeError: bind argument must be an instance of Enumerable" because JRuby `#define_method` can't see that BasicSocket is an instance of enumerable.

On any Ruby, unbound methods can only be bound to the same type as their original owner. In JRuby, the binding won't work because the owner is `Enumerable`.

I tried a variety of things, none of which would work in JRuby.
```
@original_as_json.bind(@original_as_json.owner)
```
uses the actual owner from the `UnboundMethod` object, but fails with the same exception.

And, here I tried converting the `UnboundMethod` to a proc (which is said to work in MRI), but it fails with "TypeError: no implicit conversion of UnboundMethod into Proc".
```
::BasicSocket.send(:define_method, :as_json, &@original_as_json)
```

The final solution using `alias_method` should work on all Rubies, and doesn't need to know how `#as_json` was originally added or by what module. 