### PR TITLE
Enable travis builds to test rails runner process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Testing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
@@ -47,6 +54,11 @@ elsif RUBY_VERSION.start_with?('2')
   gem 'sucker_punch', '~> 2.0' # rubocop:disable Bundler/DuplicatedGem
 end
 
+unless is_jruby
+  # JRuby doesn't support fork, which is required for this test helper.
+  gem 'rspec-command'
+end
+
 gem 'aws-sdk-sqs'
 gem 'database_cleaner'
 gem 'delayed_job', :require => false
@@ -54,7 +66,6 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque', '< 2.0.0'
-gem 'rspec-command'
 gem 'rubocop', :require => false
 gem 'sinatra'
 gem 'webmock', :require => false

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 is_not_jruby = !is_jruby
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -58,9 +58,13 @@ gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
-gem 'rspec-command'
 gem 'redis'
 gem 'resque'
+
+unless is_jruby
+  # JRuby doesn't support fork, which is required for this test helper.
+  gem 'rspec-command'
+end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -59,9 +59,13 @@ gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
-gem 'rspec-command'
 gem 'redis'
 gem 'resque'
+
+unless is_jruby
+  # JRuby doesn't support fork, which is required for this test helper.
+  gem 'rspec-command'
+end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
   gem 'mime-types', '< 3.0'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -52,10 +52,14 @@ gem 'codacy-coverage'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
-gem 'rspec-command'
 gem 'redis'
 gem 'resque'
 gem 'simplecov'
+
+unless is_jruby
+  # JRuby doesn't support fork, which is required for this test helper.
+  gem 'rspec-command'
+end
 
 gem 'mime-types'
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -2,6 +2,11 @@ require 'rubygems/version'
 
 source 'https://rubygems.org'
 
+# Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
+# new process is created during tests. (Executing rake tasks, for example.)
+# This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+ENV['CURRENT_GEMFILE'] ||= __FILE__
+
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
 gem 'appraisal'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -3,8 +3,10 @@ require 'rubygems/version'
 source 'https://rubygems.org'
 
 # Used by spec/commands/rollbar_rails_runner_spec, and can be used whenever a
-# new process is created during tests. (Executing rake tasks, for example.)
+# new process is created during tests. (Testing rake tasks, for example.)
 # This is a workaround for ENV['BUNDLE_GEMFILE'] not working as expected on Travis.
+# We use the ||= assignment because Travis loads the gemfile twice, the second time
+# with the wrong gemfile path.
 ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)

--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -39,7 +39,7 @@ module Rails
     end
 
     def eval_runner
-      if Rails.version >= '5.0.0'
+      if Rails.version >= '5.1.0'
         rails5_runner
       else
         legacy_runner

--- a/spec/commands/rollbar_rails_runner_spec.rb
+++ b/spec/commands/rollbar_rails_runner_spec.rb
@@ -7,10 +7,12 @@ if defined?(RSpecCommand)
     # This example works locally, but Travis tries to run the runner process with
     # the wrong Gemfile. Also, neither `echo $BUNDLE_GEMFILE` nor ENV['BUNDLE_GEMFILE']
     # show the correct value when read from within this example.
+    puts "ENV['CURRENT_GEMFILE']: #{ENV['CURRENT_GEMFILE']}"
+    puts "ENV['BUNDLE_GEMFILE']: #{ENV['BUNDLE_GEMFILE']}"
     command %q[rollbar-rails-runner "puts 'hello'"]
-    environment :BUNDLE_GEMFILE => ENV['BUNDLE_GEMFILE']
+    environment :BUNDLE_GEMFILE => ENV['CURRENT_GEMFILE']
     its(:stdout) do
-      skip 'Travis tries to run the runner process with the wrong Gemfile.'
+      #skip 'Travis tries to run the runner process with the wrong Gemfile.'
       is_expected.to include('hello')
     end
   end

--- a/spec/commands/rollbar_rails_runner_spec.rb
+++ b/spec/commands/rollbar_rails_runner_spec.rb
@@ -4,15 +4,11 @@ if defined?(RSpecCommand)
   require 'rails/rollbar_runner'
 
   describe 'rollbar-rails-runner' do
-    # This example works locally, but Travis tries to run the runner process with
-    # the wrong Gemfile. Also, neither `echo $BUNDLE_GEMFILE` nor ENV['BUNDLE_GEMFILE']
-    # show the correct value when read from within this example.
-    puts "ENV['CURRENT_GEMFILE']: #{ENV['CURRENT_GEMFILE']}"
-    puts "ENV['BUNDLE_GEMFILE']: #{ENV['BUNDLE_GEMFILE']}"
+    # We set ENV['CURRENT_GEMFILE'] in the gemfile because Travis doesn't set
+    # ENV['BUNDLE_GEMFILE'] correctly.
     command %q[rollbar-rails-runner "puts 'hello'"]
     environment :BUNDLE_GEMFILE => ENV['CURRENT_GEMFILE']
     its(:stdout) do
-      #skip 'Travis tries to run the runner process with the wrong Gemfile.'
       is_expected.to include('hello')
     end
   end


### PR DESCRIPTION
This spec had been marked pending because `ENV['BUNDLE_GEMFILE']` doesn't work as expected in Travis. The workaround here is to set a different env var in the gemfile. This works, and the complete matrix coverage exposed a couple issues that are also fixed here:

- [x] Rails 5.0.x needs to use the old runner, only 5.1.x and up should use the new Rails 5 runner.
- [x] JRuby doesn't have `fork` and can't use the rspec-command gem.