### PR TITLE
Iterate more aggressive string truncation if needed

### DIFF
--- a/lib/rollbar/truncation.rb
+++ b/lib/rollbar/truncation.rb
@@ -15,11 +15,12 @@ module Rollbar
                   StringsStrategy,
                   MinBodyStrategy].freeze
 
-    def self.truncate(payload)
+    def self.truncate(payload, attempts = [])
       result = nil
 
       STRATEGIES.each do |strategy|
         result = strategy.call(payload)
+        attempts << result.bytesize
         break unless truncate?(result)
       end
 

--- a/lib/rollbar/truncation/strings_strategy.rb
+++ b/lib/rollbar/truncation/strings_strategy.rb
@@ -6,7 +6,7 @@ module Rollbar
     class StringsStrategy
       include ::Rollbar::Truncation::Mixin
 
-      STRING_THRESHOLDS = [1024, 512, 256].freeze
+      STRING_THRESHOLDS = [1024, 512, 256, 128, 64].freeze
 
       def self.call(payload)
         new.call(payload)

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -750,9 +750,10 @@ describe Rollbar::Item do
 
       it 'calls Notifier#send_failsafe and logs the error' do
         original_size = Rollbar::JSON.dump(payload).bytesize
-        final_size = Rollbar::Truncation.truncate(payload.clone).bytesize
+        attempts = []
+        final_size = Rollbar::Truncation.truncate(payload.clone, attempts).bytesize
         # final_size = original_size
-        rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Final size: #{final_size}"
+        rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
         uuid = payload['data']['uuid']
         host = payload['data']['server']['host']
         log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
@@ -767,9 +768,10 @@ describe Rollbar::Item do
         it 'calls Notifier#send_failsafe and logs the error' do
           payload['data'].delete('server')
           original_size = Rollbar::JSON.dump(payload).bytesize
-          final_size = Rollbar::Truncation.truncate(payload.clone).bytesize
+          attempts = []
+          final_size = Rollbar::Truncation.truncate(payload.clone, attempts).bytesize
           # final_size = original_size
-          rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Final size: #{final_size}"
+          rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
           uuid = payload['data']['uuid']
           log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
 

--- a/spec/rollbar/truncation_spec.rb
+++ b/spec/rollbar/truncation_spec.rb
@@ -8,7 +8,7 @@ describe Rollbar::Truncation do
     context 'if truncation is not needed' do
       it 'only calls RawStrategy is truncation is not needed' do
         allow(described_class).to receive(:truncate?).and_return(false)
-        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload)
+        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload).and_return('')
 
         Rollbar::Truncation.truncate(payload)
       end
@@ -17,8 +17,8 @@ describe Rollbar::Truncation do
     context 'if truncation is needed' do
       it 'calls the next strategy, FramesStrategy' do
         allow(described_class).to receive(:truncate?).and_return(true, false)
-        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload)
-        expect(Rollbar::Truncation::FramesStrategy).to receive(:call).with(payload)
+        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload).and_return('')
+        expect(Rollbar::Truncation::FramesStrategy).to receive(:call).with(payload).and_return('')
 
         Rollbar::Truncation.truncate(payload)
       end


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-gem/issues/864

Current truncation strategy:
1) Limit the number if stack frames
2) Truncate all strings to 1024, then 512, then 256 bytes.
3) Limit to only the most current stack frame.

This PR extends string truncation to 128 and 64 bytes, and adds the size of all truncation attempts to the error message when truncation fails.

It has been suggested that parts of the payload can be removed entirely as a truncation step. This may be appropriate, but we don't know yet which part is causing the issue or the nature of why it's oversized.