### PR TITLE
Support Regex entries in scrub_whitelist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,15 @@ Fields to scrub out of the parsed request data. Will scrub from `GET`, `POST`,
 url, and several other locations. Does not currently recurse into the full
 payload.
 
+If set to `[:scrub_all]` it will scrub all fields. It will not scrub anything
+that is in the scrub_whitelist configuration array even if :scrub_all is true.
+
+### scrub_whitelist
+
+Set the list of fields to be whitelisted when `scrub_fields` is set to `[:scrub_all]`.
+
+Supports regex entries for partial matching e.g. `[:foo, /\A.+_id\z/, :bar]`
+
 ### scrub_user
 
 **Default** `true`

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -52,10 +52,10 @@ module Rollbar
       end
 
       def build_whitelist_regex(whitelist)
-        fields = whitelist.find_all { |f| f.is_a?(String) || f.is_a?(Symbol) }
+        fields = whitelist.find_all { |f| f.is_a?(String) || f.is_a?(Symbol) || f.is_a?(Regexp) }
         return unless fields.any?
 
-        Regexp.new(fields.map { |val| /\A#{Regexp.escape(val.to_s)}\z/ }.join('|'))
+        Regexp.new(fields.map { |val| val.is_a?(Regexp) ? val : /\A#{Regexp.escape(val.to_s)}\z/ }.join('|'))
       end
 
       def scrub(params, options)


### PR DESCRIPTION
## Why / Rationale

This allows developers who may have a scrub-by-default the opportunity to whitelist large swaths of fields they know to be safe.

Given a company (hi! 👋 ) that deals with sensitive information, they scrub all by default as they want to reduce the spread of confidential information. However there could be hundreds and hundreds of different resources in a microservice architecture. Rollbar invaluable for debugging operational data issues in production and knowing the IDs of resources at play is paramount.

It is a fool's errand to manually whitelist every resource id field that could be entered explicitly via `extra` or automatically via the request context (eg `[:foo_id, :bar_id, :baz_id, ...]`) so the developer instead uses:

```ruby
Rollbar.configure do |c|
  c.scrub_fields = [:scrub_all]
  c.scrub_whitelist = [
    :a_specific_field,
    /\A.+_id\z/,
    /\A.+_at\z/,
  ]
end
```

which would whitelist every field ending in _id or _at which suggest either opaque identifiers or timestamps.

I believe this is a truly valuable solution for those who want a scrub-by-default but need a practical way to declare "these things are safe" vs the opposite.

## What

`Rollbar::Scrubbers::Params#build_whitelist_regex` will check if an array element is a regex object and, if so, simply let it be a part of the overall whitelist Regex un-touched.