### PR TITLE
Dev config flags: raise_on_error, log_payload, transmit, logger_level

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -63,6 +63,7 @@ module Rollbar
     attr_reader :send_extra_frame_data
     attr_accessor :use_exception_level_filters_default
     attr_accessor :proxy
+    attr_accessor :raise_on_error
 
     attr_reader :project_gem_paths
 
@@ -130,6 +131,7 @@ module Rollbar
       @project_gem_paths = []
       @use_exception_level_filters_default = false
       @proxy = nil
+      @raise_on_error = false
       @collect_user_ip = true
       @anonymize_user_ip = false
       @hooks = {

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -276,7 +276,11 @@ module Rollbar
     end
 
     def logger_level=(level)
-      @logger_level = level.to_sym
+      @logger_level = if level
+                        level.to_sym
+                      else
+                        level
+                      end
     end
 
     def logger

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -64,6 +64,8 @@ module Rollbar
     attr_accessor :use_exception_level_filters_default
     attr_accessor :proxy
     attr_accessor :raise_on_error
+    attr_accessor :transmit
+    attr_accessor :log_payload
 
     attr_reader :project_gem_paths
 
@@ -132,6 +134,8 @@ module Rollbar
       @use_exception_level_filters_default = false
       @proxy = nil
       @raise_on_error = false
+      @transmit = true
+      @log_payload = false
       @collect_user_ip = true
       @anonymize_user_ip = false
       @hooks = {

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -36,7 +36,11 @@ module Rollbar
     def acceptable_levels
       @acceptable_levels ||= begin
         levels = [:debug, :info, :warn, :error]
-        levels[levels.find_index(Rollbar.configuration.logger_level)..-1]
+        if Rollbar.configuration.logger_level
+          levels[levels.find_index(Rollbar.configuration.logger_level)..-1]
+        else
+          []
+        end
       end
     end
   end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -147,13 +147,17 @@ module Rollbar
       level = lookup_exception_level(level, exception,
                                      use_exception_level_filters)
 
-      begin
+      ret = begin
         report(level, message, exception, extra, context)
       rescue StandardError, SystemStackError => e
         report_internal_error(e)
 
         'error'
       end
+
+      raise(exception) if configuration.raise_on_error && exception
+
+      ret
     end
 
     # See log() above

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -147,17 +147,19 @@ module Rollbar
       level = lookup_exception_level(level, exception,
                                      use_exception_level_filters)
 
-      ret = begin
-        report(level, message, exception, extra, context)
-      rescue StandardError, SystemStackError => e
-        report_internal_error(e)
-
-        'error'
-      end
+      ret = report_with_rescue(level, message, exception, extra, context)
 
       raise(exception) if configuration.raise_on_error && exception
 
       ret
+    end
+
+    def report_with_rescue(level, message, exception, extra, context)
+      report(level, message, exception, extra, context)
+    rescue StandardError, SystemStackError => e
+      report_internal_error(e)
+
+      'error'
     end
 
     # See log() above
@@ -433,13 +435,22 @@ module Rollbar
 
       return 'ignored' if item.ignored?
 
-      schedule_item(item)
+      schedule_item(item) if configuration.transmit
 
+      log_and_return_item_data(item)
+    end
+
+    def log_and_return_item_data(item)
       data = item['data']
       log_instance_link(data)
       Rollbar.last_report = data
+      log_data(data) if configuration.log_payload
 
       data
+    end
+
+    def log_data(data)
+      log_info "[Rollbar] Data: #{data}"
     end
 
     # Reports an internal error in the Rollbar library. This will be reported within the configured

--- a/spec/rollbar/logger_proxy_spec.rb
+++ b/spec/rollbar/logger_proxy_spec.rb
@@ -65,5 +65,23 @@ describe Rollbar::LoggerProxy do
         subject.log('error', 'foo')
       end
     end
+
+    context 'if logger_level is false' do
+      before do
+        allow(Rollbar.configuration).to receive(:logger_level).and_return(false)
+      end
+
+      it 'doesnt call the logger (debug)' do
+        expect(logger).to_not receive(:debug)
+
+        subject.log('debug', 'foo')
+      end
+
+      it 'doesnt call the logger (error)' do
+        expect(logger).to_not receive(:error)
+
+        subject.log('error', 'foo')
+      end
+    end
   end
 end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -290,6 +290,32 @@ describe Rollbar do
           notifier.log('error', 'Call to Rollbar with custom_data_method')
         end
       end
+
+      context 'when raise_on_error is set' do
+        before do
+          Rollbar.configure do |config|
+            config.raise_on_error = true
+          end
+        end
+
+        let(:exception) { StandardError.new('error') }
+
+        it 'should raise on an exception event' do
+          expect(Rollbar.notifier).to receive(:report).and_return(nil)
+
+          expect do
+            Rollbar.notifier.log('error', exception)
+          end.to raise_error(exception)
+        end
+
+        it 'should not raise on a non-exception event' do
+          expect(Rollbar.notifier).to receive(:report).and_return(nil)
+
+          expect do
+            Rollbar.notifier.log('error', 'message')
+          end.not_to raise_error
+        end
+      end
     end
 
     context 'with before_process handlers in configuration' do

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -316,6 +316,51 @@ describe Rollbar do
           end.not_to raise_error
         end
       end
+
+      context 'when transmit is not set' do
+        before do
+          Rollbar.configure do |config|
+            config.transmit = false
+          end
+        end
+
+        it 'should not transmit the payload' do
+          expect(Rollbar.notifier).to_not receive(:do_post)
+
+          Rollbar.notifier.log('error', exception)
+        end
+      end
+
+      context 'when log_payload is set' do
+        before do
+          Rollbar.configure do |config|
+            config.log_payload = true
+          end
+        end
+
+        it 'should log the payload' do
+          data = nil
+          allow(Rollbar.notifier).to receive(:log_info) { |arg| data = arg }
+
+          Rollbar.notifier.log('info', 'message')
+
+          expect(data).to eql("[Rollbar] Data: #{Rollbar.last_report}")
+        end
+      end
+
+      context 'when log_payload is not set' do
+        before do
+          Rollbar.configure do |config|
+            config.log_payload = false
+          end
+        end
+
+        it 'should log the payload' do
+          expect(Rollbar.notifier).to_not receive(:log_data)
+
+          Rollbar.notifier.log('info', 'message')
+        end
+      end
     end
 
     context 'with before_process handlers in configuration' do


### PR DESCRIPTION
Implements the dev flags recently defined for all SDKs.

The `verbose` flag has already been implemented in this SDK as `logger_level`, and this remains unchanged. Further, the existing default `logger_level` setting of `:info` is retained. Finally, in keeping with the expected way of disabling config settings, setting a falsey value for `logger_level` disables the verbose logging completely.

Fixes https://github.com/rollbar/rollbar-gem/issues/708
Fixes https://github.com/rollbar/rollbar-gem/issues/813