### PR TITLE
Truncation improvements

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -121,7 +121,7 @@ module Rollbar
       host = stringified_payload['data'].fetch('server', {})['host']
 
       notifier.send_failsafe(
-        too_large_payload_string(stringified_payload, final_payload, attempts),
+        too_large_payload_string(attempts),
         nil,
         uuid,
         host
@@ -129,12 +129,9 @@ module Rollbar
       logger.error("[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}")
     end
 
-    def too_large_payload_string(stringified_payload, final_payload, attempts)
-      original_size = Rollbar::JSON.dump(stringified_payload).bytesize
-      final_size = final_payload.bytesize
-
+    def too_large_payload_string(attempts)
       'Could not send payload due to it being too large after truncating attempts. ' \
-        "Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
+        "Original size: #{attempts.first} Attempts: #{attempts.join(', ')} Final size: #{attempts.last}"
     end
 
     def ignored?

--- a/lib/rollbar/truncation.rb
+++ b/lib/rollbar/truncation.rb
@@ -4,6 +4,8 @@ require 'rollbar/truncation/raw_strategy'
 require 'rollbar/truncation/frames_strategy'
 require 'rollbar/truncation/strings_strategy'
 require 'rollbar/truncation/min_body_strategy'
+require 'rollbar/truncation/remove_request_strategy'
+require 'rollbar/truncation/remove_extra_strategy'
 
 module Rollbar
   module Truncation
@@ -13,7 +15,9 @@ module Rollbar
     STRATEGIES = [RawStrategy,
                   FramesStrategy,
                   StringsStrategy,
-                  MinBodyStrategy].freeze
+                  MinBodyStrategy,
+                  RemoveRequestStrategy,
+                  RemoveExtraStrategy].freeze
 
     def self.truncate(payload, attempts = [])
       result = nil

--- a/lib/rollbar/truncation/min_body_strategy.rb
+++ b/lib/rollbar/truncation/min_body_strategy.rb
@@ -11,8 +11,7 @@ module Rollbar
       end
 
       def call(payload)
-        new_payload = Rollbar::Util.deep_copy(payload)
-        body = new_payload['data']['body']
+        body = payload['data']['body']
 
         if body['trace_chain']
           body['trace_chain'] = body['trace_chain'].map do |trace_data|
@@ -22,7 +21,7 @@ module Rollbar
           body['trace'] = truncate_trace_data(body['trace'])
         end
 
-        dump(new_payload)
+        dump(payload)
       end
 
       def truncate_trace_data(trace_data)

--- a/lib/rollbar/truncation/remove_extra_strategy.rb
+++ b/lib/rollbar/truncation/remove_extra_strategy.rb
@@ -1,0 +1,35 @@
+require 'rollbar/util'
+
+module Rollbar
+  module Truncation
+    class RemoveExtraStrategy
+      include ::Rollbar::Truncation::Mixin
+
+      def self.call(payload)
+        new.call(payload)
+      end
+
+      def call(payload)
+        body = payload['data']['body']
+
+        delete_message_extra(body)
+        delete_trace_chain_extra(body)
+        delete_trace_extra(body)
+
+        dump(payload)
+      end
+
+      def delete_message_extra(body)
+        body['message'].delete('extra') if body['message'] && body['message']['extra']
+      end
+
+      def delete_trace_chain_extra(body)
+        body['trace_chain'][0].delete('extra') if body['trace_chain'] && body['trace_chain'][0]['extra']
+      end
+
+      def delete_trace_extra(body)
+        body['trace'].delete('extra') if body['trace'] && body['trace']['extra']
+      end
+    end
+  end
+end

--- a/lib/rollbar/truncation/remove_request_strategy.rb
+++ b/lib/rollbar/truncation/remove_request_strategy.rb
@@ -1,0 +1,21 @@
+require 'rollbar/util'
+
+module Rollbar
+  module Truncation
+    class RemoveRequestStrategy
+      include ::Rollbar::Truncation::Mixin
+
+      def self.call(payload)
+        new.call(payload)
+      end
+
+      def call(payload)
+        data = payload['data']
+
+        data.delete('request') if data['request']
+
+        dump(payload)
+      end
+    end
+  end
+end

--- a/lib/rollbar/truncation/strings_strategy.rb
+++ b/lib/rollbar/truncation/strings_strategy.rb
@@ -6,7 +6,7 @@ module Rollbar
     class StringsStrategy
       include ::Rollbar::Truncation::Mixin
 
-      STRING_THRESHOLDS = [1024, 512, 256, 128, 64].freeze
+      STRING_THRESHOLDS = [1024, 512, 256].freeze
 
       def self.call(payload)
         new.call(payload)
@@ -14,13 +14,12 @@ module Rollbar
 
       def call(payload)
         result = nil
-        new_payload = Rollbar::Util.deep_copy(payload)
 
         STRING_THRESHOLDS.each do |threshold|
           truncate_proc = truncate_strings_proc(threshold)
 
-          ::Rollbar::Util.iterate_and_update(new_payload, truncate_proc)
-          result = dump(new_payload)
+          ::Rollbar::Util.iterate_and_update(payload, truncate_proc)
+          result = dump(payload)
 
           break unless truncate?(result)
         end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -751,7 +751,7 @@ describe Rollbar::Item do
       it 'calls Notifier#send_failsafe and logs the error' do
         original_size = Rollbar::JSON.dump(payload).bytesize
         attempts = []
-        final_size = Rollbar::Truncation.truncate(payload.clone, attempts).bytesize
+        final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload), attempts).bytesize
         # final_size = original_size
         rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
         uuid = payload['data']['uuid']
@@ -769,7 +769,7 @@ describe Rollbar::Item do
           payload['data'].delete('server')
           original_size = Rollbar::JSON.dump(payload).bytesize
           attempts = []
-          final_size = Rollbar::Truncation.truncate(payload.clone, attempts).bytesize
+          final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload), attempts).bytesize
           # final_size = original_size
           rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
           uuid = payload['data']['uuid']

--- a/spec/rollbar/truncation/remove_extra_strategy_spec.rb
+++ b/spec/rollbar/truncation/remove_extra_strategy_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'rollbar/truncation/remove_extra_strategy'
+
+describe Rollbar::Truncation::RemoveExtraStrategy do
+  describe '.call' do
+    let(:extra) { { 'bar' => 'baz' } }
+    let(:request) { { 'baz' => 'fizz' } }
+
+    context 'with message payload type' do
+      let(:message_body) { { 'foo' => 'bar' } }
+
+      let(:payload) do
+        {
+          'data' => {
+            'body' => {
+              'message' => {
+                'body' => message_body,
+                'extra' => extra
+              }
+            },
+            'request' => request
+          }
+        }
+      end
+
+      it 'should truncate the extra data in the payload' do
+        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+
+        expect(result['data']['body']['message']['extra']).to be_nil
+        expect(result['data']['body']['message']['body']).to be_eql(message_body)
+        expect(result['data']['request']).to be_eql(request)
+      end
+    end
+
+    context 'with trace payload type' do
+      let(:trace_frames) { { 'foo' => 'bar' } }
+
+      let(:payload) do
+        {
+          'data' => {
+            'body' => {
+              'trace' => {
+                'frames' => trace_frames,
+                'extra' => extra
+              }
+            },
+            'request' => request
+          }
+        }
+      end
+
+      it 'should truncate the extra data in the payload' do
+        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+
+        expect(result['data']['body']['trace']['extra']).to be_nil
+        expect(result['data']['body']['trace']['frames']).to be_eql(trace_frames)
+        expect(result['data']['request']).to be_eql(request)
+      end
+    end
+
+    context 'with trace_chain payload type' do
+      let(:trace_frames) { { 'foo' => 'bar' } }
+
+      let(:payload) do
+        {
+          'data' => {
+            'body' => {
+              'trace_chain' => [{
+                'frames' => trace_frames,
+                'extra' => extra
+              }]
+            },
+            'request' => request
+          }
+        }
+      end
+
+      it 'should truncate the extra data in the payload' do
+        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+
+        expect(result['data']['body']['trace_chain'][0]['extra']).to be_nil
+        expect(result['data']['body']['trace_chain'][0]['frames']).to be_eql(trace_frames)
+        expect(result['data']['request']).to be_eql(request)
+      end
+    end
+  end
+end

--- a/spec/rollbar/truncation/remove_request_strategy_spec.rb
+++ b/spec/rollbar/truncation/remove_request_strategy_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'rollbar/truncation/remove_request_strategy'
+
+describe Rollbar::Truncation::RemoveRequestStrategy do
+  describe '.call' do
+    let(:body) { { 'foo' => 'bar' } }
+    let(:request) { { 'bar' => 'baz' } }
+    let(:payload) do
+      {
+        'data' => {
+          'body' => body,
+          'request' => request
+        }
+      }
+    end
+
+    it 'should truncate the request in the payload' do
+      result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+
+      expect(result['data']['body']).to be_eql(body)
+      expect(result['data']['request']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
These changes are intended to mitigate a commonly occurring problem: Failsafe errors due to payloads that could not be truncated to less than 512KB.

1) If needed, the data in the request key is removed. There is one known situation where this will help. The DelayedJob plugin puts the job data in the request key, and some users have very large job data payloads.

2) If needed, the `extra` data (whether in a message or trace payload) is removed.

3) Strategies are each applied to the current truncated payload (rather than using the original full sized payload for each attempt) in order to have the best opportunity to return an acceptable payload.