### PR TITLE
Use content-type to detect json

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -210,8 +210,7 @@ module Rollbar
     def json_request?(rack_req)
       json_regex = /\bjson\b/
 
-      !!(rack_req.env['CONTENT_TYPE'] =~ json_regex ||
-         rack_req.env['HTTP_ACCEPT'] =~ json_regex)
+      !!(rack_req.env['CONTENT_TYPE'] =~ json_regex)
     end
 
     def rollbar_route_params(env)

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -228,6 +228,22 @@ describe Rollbar::RequestDataExtractor do
       end
     end
 
+    context 'with form POST body (non-json)' do
+      let(:body) { 'foo=1&bar=2' }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                                  'HTTP_ACCEPT' => 'application/json',
+                                  :input => body,
+                                  :method => 'POST')
+      end
+
+      it 'skips extracting the body' do
+        result = subject.extract_request_data_from_rack(env)
+        expect(result[:body]).to be_eql('{}')
+      end
+    end
+
     context 'with JSON POST body' do
       let(:params) { { 'key' => 'value' } }
       let(:body) { params.to_json }
@@ -254,6 +270,8 @@ describe Rollbar::RequestDataExtractor do
         result = subject.extract_request_data_from_rack(env)
         expect(result[:body]).to be_eql(body)
       end
+
+
     end
 
     context 'with JSON DELETE body' do


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/877

We should use (only) Content-Type to detect the content type. 

Long ago this code that decides whether to parse JSON also tried to check the Accept header. But it used the wrong rack env key, so it never really did check the Accept header. When https://github.com/rollbar/rollbar-gem/pull/868 fixed the regex for matching Content-Type, it also updated the rack env key for the Accept header. This has caused the code to try to parse JSON just because the request says it can accept JSON. 