### PR TITLE
Re-enable JRuby builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ rvm:
   - 2.6.0
   - 2.6.3
   - rbx
-  # Travis's own rvm installer is failing on JRuby builds, TODO: reenable when fixed.
-  # - jruby-9.1.9.0
+  - jruby-9.1.9.0
 
   #
   # # About legacy JRuby


### PR DESCRIPTION
Previously disabled JRuby due to RVM installer issue at Travis. DM from Travis people says it might be fixed, so giving it a try.

Discussion here: https://travis-ci.community/t/rvm-tries-to-download-blank-version-of-itself/3972