### PR TITLE
Send notifier.configured_options in payload

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -85,7 +85,7 @@ module Rollbar
         :notifier => {
           :name => 'rollbar-gem',
           :version => VERSION,
-          :configured_options => scrub(configuration.configured_options.configured)
+          :configured_options => configured_options
         },
         :body => build_body
       }
@@ -101,6 +101,17 @@ module Rollbar
       data.delete(:context) unless data[:context]
 
       data
+    end
+
+    def configured_options
+      if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1')
+        # There are too many types that crash ActiveSupport JSON serialization, and not worth
+        # the risk just to send this diagnostic object. In versions < 4.1, ActiveSupport hooks
+        # Ruby's JSON.generate so deeply there's no workaround.
+        'not serialized in ActiveSupport < 4.1'
+      else
+        scrub(configuration.configured_options.configured)
+      end
     end
 
     def dump

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -84,7 +84,8 @@ module Rollbar
         :server => server_data,
         :notifier => {
           :name => 'rollbar-gem',
-          :version => VERSION
+          :version => VERSION,
+          :configured_options => scrub(configuration.configured_options.configured)
         },
         :body => build_body
       }

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -42,21 +42,21 @@ module Rollbar
     # Similar to configure below, but used only internally within the gem
     # to configure it without initializing any of the third party hooks
     def preconfigure
-      yield(configuration)
+      yield(configuration.configured_options)
     end
 
     # Configures the notifier instance
     def configure
       configuration.enabled = true if configuration.enabled.nil?
 
-      yield(configuration)
+      yield(configuration.configured_options)
     end
 
     def reconfigure
       self.configuration = Configuration.new
       configuration.enabled = true
 
-      yield(configuration)
+      yield(configuration.configured_options)
     end
 
     def unconfigure

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -125,10 +125,18 @@ describe Rollbar::Item do
       payload['data'][:body][:message][:extra][:b][2].should == 4
     end
 
-    it 'should have correct configured_options object' do
-      payload['data'][:notifier][:configured_options][:access_token].should == '********'
-      payload['data'][:notifier][:configured_options][:root].should == '/foo/'
-      payload['data'][:notifier][:configured_options][:framework].should == 'Rails'
+    context 'ActiveSupport >= 4.1', :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
+      it 'should have correct configured_options object' do
+        payload['data'][:notifier][:configured_options][:access_token].should == '********'
+        payload['data'][:notifier][:configured_options][:root].should == '/foo/'
+        payload['data'][:notifier][:configured_options][:framework].should == 'Rails'
+      end
+    end
+
+    context 'ActiveSupport < 4.1', :if => Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1') do
+      it 'should have configured_options message' do
+        payload['data'][:notifier][:configured_options].class == 'String'
+      end
     end
 
     context do

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -8,12 +8,14 @@ describe Rollbar::Item do
   let(:safely_notifier) { double('safely_notifier') }
   let(:logger) { double }
   let(:configuration) do
-    c = Rollbar::Configuration.new
-    c.enabled = true
-    c.access_token = 'footoken'
-    c.root = '/foo/'
-    c.framework = 'Rails'
-    c
+    Rollbar.configure do |c|
+      c.enabled = true
+      c.access_token = 'footoken'
+      c.randomize_scrub_length = false
+      c.root = '/foo/'
+      c.framework = 'Rails'
+    end
+    Rollbar.configuration
   end
   let(:level) { 'info' }
   let(:message) { 'message' }
@@ -121,6 +123,12 @@ describe Rollbar::Item do
       payload['data'][:body][:message][:extra].should_not be_nil
       payload['data'][:body][:message][:extra][:a].should == 1
       payload['data'][:body][:message][:extra][:b][2].should == 4
+    end
+
+    it 'should have correct configured_options object' do
+      payload['data'][:notifier][:configured_options][:access_token].should == '********'
+      payload['data'][:notifier][:configured_options][:root].should == '/foo/'
+      payload['data'][:notifier][:configured_options][:framework].should == 'Rails'
     end
 
     context do

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -63,9 +63,22 @@ describe Rollbar do
       expect(Rollbar.notifier).to_not receive(:report)
       expect(Rollbar.error('error message')).to be_eql('disabled')
     end
+
+    it 'should have empty configured options' do
+      expect(Rollbar.configuration.configured_options.configured).to be_eql({})
+    end
   end
 
   shared_examples 'stores the root notifier' do
+  end
+
+  shared_examples 'configured options' do
+    it 'tracks the configured options' do
+      Rollbar.reconfigure do |c|
+        c.environment = 'staging'
+      end
+      expect(Rollbar.configuration.configured_options.configured[:environment]).to be_eql('staging')
+    end
   end
 
   describe '.configure' do
@@ -75,6 +88,8 @@ describe Rollbar do
       Rollbar.configure { |c| }
       expect(Rollbar.root_notifier).to be(Rollbar.notifier)
     end
+
+    it_behaves_like 'configured options'
   end
 
   describe '.preconfigure' do
@@ -84,6 +99,8 @@ describe Rollbar do
       Rollbar.preconfigure { |c| }
       expect(Rollbar.root_notifier).to be(Rollbar.notifier)
     end
+
+    it_behaves_like 'configured options'
   end
 
   describe '.reconfigure' do
@@ -93,6 +110,8 @@ describe Rollbar do
       Rollbar.reconfigure { |c| }
       expect(Rollbar.root_notifier).to be(Rollbar.notifier)
     end
+
+    it_behaves_like 'configured options'
   end
 
   describe '.unconfigure' do


### PR DESCRIPTION
Enables the diagnostic key under `notifier` showing user configured options. Anything set using `configure`, `preconfigure`, or `reconfigure` is included.

Example payload:
```
"notifier": {
    "version": "2.22.0", 
    "name": "rollbar-gem", 
    "configured_options": {
      "framework": "Rails: 5.2.2", 
      "access_token": "****", 
      "filepath": "Rails522.rollbar", 
      "environment": "development", 
      "js_options": {
        "captureUncaught": true, 
        "accessToken": "****"
      }, 
      "send_extra_frame_data": "all", 
      "js_enabled": true, 
      "sidekiq_threshold": 2, 
      "root": "/home/walt/projects/rollbar/rails522",
      "logger_level": "warn"
    }
```