### PR TITLE
Skip configured_options when using async payload handlers

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -109,6 +109,15 @@ module Rollbar
         # the risk just to send this diagnostic object. In versions < 4.1, ActiveSupport hooks
         # Ruby's JSON.generate so deeply there's no workaround.
         'not serialized in ActiveSupport < 4.1'
+      elsif configuration.use_async
+        # Currently serialization is performed by each handler, and this invariably
+        # means it is actually performed by ActiveSupport.
+        #
+        # TODO: Since serialization must be done prior to scheduling the job,
+        # it should at least be done by rollbar-gem itself. Much work has been done
+        # to avoid the bugs in ActiveSupport JSON. The async handlers are currently
+        # still subject to all those knnown issues.
+        'not serialized for async/delayed handlers'
       else
         scrub(configuration.configured_options.configured)
       end

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1401,6 +1401,21 @@ describe Rollbar do
       Rollbar.error(exception)
     end
 
+    # Temporary. See comments at Item#configured_options
+    it 'should not send configured_options in payload', :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
+      logger_mock.should_receive(:info).with('not serialized for async/delayed handlers')
+
+      Rollbar.configure do |config|
+        config.use_async = true
+        config.async_handler = proc { |payload|
+          logger_mock.info payload['data'][:notifier][:configured_options]
+          Rollbar.process_from_async_handler(payload)
+        }
+      end
+
+      Rollbar.error(exception)
+    end
+
     # We should be able to send String payloads, generated
     # by a previous version of the gem. This can happend just
     # after a deploy with an gem upgrade.


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/903

Temporary fix to resolve https://github.com/rollbar/rollbar-gem/issues/903, however this surfaces a broader issue. There are many known issues with ActiveSupport serialization, and work that has been done in the gem to ensure it isn't used. The async handlers currently use their own serializers, which most of the time means ActiveSupport again. A future PR should serialize before calling the async handler.