### PR TITLE
Prevent recursive failsafes

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -211,7 +211,9 @@ module Rollbar
       end
     rescue StandardError => e
       log_error("[Rollbar] Error processing the item: #{e.class}, #{e.message}. Item: #{item.payload.inspect}")
-      raise e unless item.payload.fetch('data', {}).fetch(:failsafe, false)
+      raise e unless via_failsafe?(item)
+
+      log_error('[Rollbar] Item has already failed. Not re-raising')
     end
 
     # We will reraise exceptions in this method so async queues
@@ -771,6 +773,10 @@ module Rollbar
 
       uuid_url = Util.uuid_rollbar_url(data, configuration)
       log_info "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
+    end
+
+    def via_failsafe?(item)
+      item.payload.fetch('data', {}).fetch(:failsafe, false)
     end
   end
 end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -211,7 +211,7 @@ module Rollbar
       end
     rescue StandardError => e
       log_error("[Rollbar] Error processing the item: #{e.class}, #{e.message}. Item: #{item.payload.inspect}")
-      raise e
+      raise e unless item.payload.fetch('data', {}).fetch(:failsafe, false)
     end
 
     # We will reraise exceptions in this method so async queues

--- a/spec/dummyapp/config/application.rb
+++ b/spec/dummyapp/config/application.rb
@@ -56,5 +56,7 @@ module Dummy
     # config.assets.version = '1.0'
 
     config.active_job.queue_adapter = :inline if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
+
+    config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end

--- a/spec/dummyapp/config/environments/development.rb
+++ b/spec/dummyapp/config/environments/development.rb
@@ -34,4 +34,5 @@ Dummy::Application.configure do
 
   # Expands the lines which load the assets
   # config.assets.debug = true
+  config.eager_load = false
 end

--- a/spec/dummyapp/config/environments/production.rb
+++ b/spec/dummyapp/config/environments/production.rb
@@ -64,4 +64,6 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.eager_load = false
 end

--- a/spec/dummyapp/config/environments/test.rb
+++ b/spec/dummyapp/config/environments/test.rb
@@ -34,4 +34,6 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = false
 end

--- a/spec/dummyapp/config/initializers/secret_token.rb
+++ b/spec/dummyapp/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = '61f244779bab3ceba188492a31fb02b0a975fb64b93e217c03966ef065f5f1aba3b145c165defe0f8256e45cc6c526a60c9780a506a16e730815a3f812b5f9e9'
+Dummy::Application.config.secret_key_base = '61f244779bab3ceba188492a31fb02b0a975fb64b93e217c03966ef065f5f1aba3b145c165defe0f8256e45cc6c526a60c9780a506a16e730815a3f812b5f9e9'

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -1,5 +1,6 @@
 require 'rollbar'
 require 'rollbar/notifier'
+require 'spec_helper'
 
 describe Rollbar::Notifier do
   describe '#scope' do
@@ -38,6 +39,29 @@ describe Rollbar::Notifier do
       expect(subject.scope_object['foo']).to be_eql('bar')
       expect(subject.configuration).to be(subject.configuration)
       expect(subject.scope_object).to be(subject.scope_object)
+    end
+  end
+
+  describe '#process_item' do
+    subject(:process_item) { notifier.process_item(item) }
+    let(:notifier) { described_class.new }
+    let(:item) { double(Rollbar::Item).as_null_object }
+    let(:logger) { double(Logger).as_null_object }
+
+    before { notifier.configuration.logger = logger }
+
+    context 'when configured to write' do
+      before { notifier.configuration.write_to_file = true }
+
+      let(:dummy_file) { double(File).as_null_object }
+
+      it 'writes to the file' do
+        allow(File).to receive(:open).with(nil, 'a').and_return(dummy_file)
+
+        process_item
+
+        expect(dummy_file).to have_received(:puts).with(item)
+      end
     end
   end
 

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -108,6 +108,16 @@ describe Rollbar::Notifier do
     end
   end
 
+  describe '#send_failsafe' do
+    subject(:send_failsafe) { described_class.new.send_failsafe(message, exception) }
+    let(:message) { 'testing failsafe' }
+    let(:exception) { StandardError.new }
+
+    it 'sets a flag on the payload so we know the payload has come through this way' do
+      expect(send_failsafe['data']).to include(:failsafe => true)
+    end
+  end
+
   if RUBY_PLATFORM == 'java'
     describe '#extract_arguments' do
       # See https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ begin
   require 'simplecov'
   require 'codacy-coverage'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
     SimpleCov::Formatter::HTMLFormatter,
     Codacy::Formatter
   ]


### PR DESCRIPTION
#### Context

See https://github.com/rollbar/rollbar-gem/issues/632

#### Change

 - d6d3f5b : necessary to get `rspec` to run
 - 3e42f31 : me familiarising myself with the `#process_item` method
 - 297aac4 : is the work to address #632 
 - 9cf0ad2 : is some refactoring I needed to do to be happy to push this upstream
 - 9779b37 : removes a whole lot of deprecation warnings making the spec output legible

#### Confirmation

```
E, [2019-10-31T04:39:43.508233 #1135] ERROR -- : [Rollbar] Sending failsafe response due to SocketError: "Failed to open TCP connection to api.rollbar.com:443 (getaddrinfo: Temporary failure in name resolution)" in /usr/lib/ruby/2.5.0/net/http.rb:939:in `rescue in block in connect': error in process_item
I, [2019-10-31T04:39:43.508357 #1135]  INFO -- : [Rollbar] Scheduling item
E, [2019-10-31T04:39:43.508698 #1135] ERROR -- : [Rollbar] Item: #<Rollbar::Item:0x0000000004c314b0>
I, [2019-10-31T04:39:43.508853 #1135]  INFO -- : [Rollbar] Sending item
E, [2019-10-31T04:39:43.509462 #1135] ERROR -- : [Rollbar] Error processing the item: SocketError, Failed to open TCP connection to api.rollbar.com:443 (getaddrinfo: Temporary failure in name resolution). Item: {"access_token"=>"*******", "data"=>{:level=>"error", :environment=>"staging", :body=>{:message=>{:body=>"Failsafe from rollbar-gem. SocketError: \"Failed to open TCP connection to api.rollbar.com:443 (getaddrinfo: Temporary failure in name resolution)\" in /usr/lib/ruby/2.5.0/net/http.rb:939:in `rescue in block in connect': error in process_item"}}, :notifier=>{:name=>"rollbar-gem", :version=>"2.22.1"}, :custom=>{:orig_uuid=>nil, :orig_host=>nil}, :internal=>true, :failsafe=>true}}
E, [2019-10-31T04:39:43.509560 #1135] ERROR -- : [Rollbar] Item has already failed. Not re-raising
```