### PR TITLE
Add rubocop performance extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   Exclude:
     - 'vendor/**/*'
@@ -66,3 +68,133 @@ Style/FrozenStringLiteralComment:
   # If we do this, it will be in its own PR. It requires adding these magic comments
   # throughout the project, in order to prepare for a future Ruby 3.x.
   Enabled: false
+
+#
+# Performance cops are opt in, and `Enabled: true` is always required.
+# Full list is here: https://github.com/rubocop-hq/rubocop-performance/tree/master/lib/rubocop/cop/performance
+# For travis builds, Codacy will see and use these directives.
+#
+Performance/Caller:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/CaseWhenSplat:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/Casecmp:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/ChainArrayAllocation:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/CompareWithBlock:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/Count:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/Detect:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/DoubleStartEndWith:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/EndWith:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/FixedSize:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/FlatMap:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/InefficientHashSearch:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/OpenStruct:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/RangeInclude:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/RedundantBlockCall:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/RedundantMatch:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/RedundantMerge:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/RegexpMatch:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/ReverseEach:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/Size:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/StartWith:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/StringReplacement:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/TimesMap:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/UnfreezeString:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
+Performance/UriDefaultParser:
+  Enabled: true
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque', '< 2.0.0'
 gem 'rubocop', :require => false
+gem 'rubocop-performance', :require => false
 gem 'sinatra'
 gem 'webmock', :require => false
 gemspec

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -261,7 +261,10 @@ module Rollbar
         found = Gem::Specification.each.select { |spec| name === spec.name }
         puts "[Rollbar] No gems found matching #{name.inspect}" if found.empty?
         found
-      end.flatten.uniq.map(&:gem_dir)
+      end
+      @project_gem_paths.flatten!
+      @project_gem_paths.uniq!
+      @project_gem_paths.map!(&:gem_dir)
     end
 
     def before_process=(*handler)

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -74,10 +74,11 @@ module Rollbar
       end
 
       def map_frames(current_exception)
-        exception_backtrace(current_exception).map do |frame|
+        frames = exception_backtrace(current_exception).map do |frame|
           Rollbar::Item::Frame.new(self, frame,
                                    :configuration => configuration).to_h
-        end.reverse
+        end
+        frames.reverse!
       end
 
       # Returns the backtrace to be sent to our API. There are 3 options:


### PR DESCRIPTION
Rubocop provides a number of performance cops in an extension. The new cops will run from plain `bundle exec rubocop`, and Codacy will pick them up from the .rubocop.yml.