### PR TITLE
Configurable thread priority for Thread async handler

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -232,9 +232,10 @@ module Rollbar
       value.is_a?(Hash) ? use_sidekiq(value) : use_sidekiq
     end
 
-    def use_thread
+    def use_thread(options = {})
       require 'rollbar/delay/thread'
       @use_async = true
+      Rollbar::Delay::Thread.options = options
       @async_handler = Rollbar::Delay::Thread
     end
 


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/901

Now supports
```
Rollbar.configure do |config|
  config.use_thread({ :priority => 2 })
end
```
in addition to the default
```
Rollbar.configure do |config|
  config.use_thread
end
```
The default thread priority is 1.