### PR TITLE
Enable Rails/ActiveSupport backtrace cleaner in config

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -66,6 +66,7 @@ module Rollbar
     attr_accessor :raise_on_error
     attr_accessor :transmit
     attr_accessor :log_payload
+    attr_accessor :backtrace_cleaner
 
     attr_reader :project_gem_paths
     attr_accessor :configured_options
@@ -139,6 +140,7 @@ module Rollbar
       @log_payload = false
       @collect_user_ip = true
       @anonymize_user_ip = false
+      @backtrace_cleaner = nil
       @hooks = {
         :on_error_response => nil, # params: response
         :on_report_internal_error => nil # params: exception

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -74,11 +74,20 @@ module Rollbar
       end
 
       def map_frames(current_exception)
-        frames = exception_backtrace(current_exception).map do |frame|
+        frames = cleaned_backtrace(current_exception).map do |frame|
           Rollbar::Item::Frame.new(self, frame,
                                    :configuration => configuration).to_h
         end
         frames.reverse!
+      end
+
+      def cleaned_backtrace(current_exception)
+        normalized_backtrace = exception_backtrace(current_exception)
+        if configuration.backtrace_cleaner
+          configuration.backtrace_cleaner.clean(normalized_backtrace)
+        else
+          normalized_backtrace
+        end
       end
 
       # Returns the backtrace to be sent to our API. There are 3 options:


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/900

Allows setting a Rails or ActiveSupport backtrace cleaner in the config.

Example:
```
Rollbar.configure do |config|
  config.backtrace_cleaner = Rails::BacktraceCleaner.new
end
```
This option is compatible with any object that implements the `ActiveSupport::BacktraceCleaner` interface.

It is also possible to apply a backtrace cleaner in a `before_process` handler, but it will have no effect on traces generated using `populate_empty_backtraces`. The new option is compatible with `populate_empty_backtraces`, is simpler to use, and will be called only for message types that contain a stack trace.