### PR TITLE
Allow ActiveJob to lazy load

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -14,5 +14,7 @@ module Rollbar
   end
 end
 
-# Automatically add to ActionMailer::DeliveryJob
-ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)
+ActiveSupport.on_load(:action_mailer) do
+  # Automatically add to ActionMailer::DeliveryJob
+  ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)
+end


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/906

Rollbar plugins are eager loaded, which doesn't interfere with Rails ActiveJob settings, except where ActiveJob is included in `ActionMailer::DeliveryJob`. Eager loading here causes settings in initializers to not get picked up. Using `ActiveSupport.on_load` fixes this, but we take care to hook load of ActionMailer, not ActiveJob.