### PR TITLE
Apply trace chain in the correct order

### DIFF
--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -55,7 +55,7 @@ module Rollbar
         current_exception = exception
 
         while current_exception.respond_to?(:cause) && (cause = current_exception.cause) && cause.is_a?(Exception) && !visited.include?(cause)
-          traces << trace_data(cause)
+          traces.unshift(trace_data(cause))
           visited << cause
           current_exception = cause
         end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -428,11 +428,12 @@ describe Rollbar::Item do
             body[:trace_chain].should be_kind_of(Array)
 
             chain = body[:trace_chain]
-            chain[0][:exception][:class].should match(/StandardError/)
-            chain[0][:exception][:message].should match(/the error/)
+            chain[0][:exception][:class].should match(/CauseException/)
+            chain[0][:exception][:message].should match(/the cause/)
 
-            chain[1][:exception][:class].should match(/CauseException/)
-            chain[1][:exception][:message].should match(/the cause/)
+            chain[1][:exception][:class].should match(/StandardError/)
+            chain[1][:exception][:message].should match(/the error/)
+
           end
 
           context 'when cause is not an Exception' do
@@ -458,8 +459,8 @@ describe Rollbar::Item do
             it 'doesnt loop for ever' do
               chain = payload['data'][:body][:trace_chain]
 
-              expect(chain[0][:exception][:message]).to be_eql('exception1')
-              expect(chain[1][:exception][:message]).to be_eql('exception2')
+              expect(chain[0][:exception][:message]).to be_eql('exception2')
+              expect(chain[1][:exception][:message]).to be_eql('exception1')
             end
           end
         end


### PR DESCRIPTION
Use the standard trace chain order. This helps the grouping logic on the Rollbar back end, which uses the trace chain ordering as a signal.