### PR TITLE
Rack scrub test

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -119,7 +119,7 @@ module Rollbar
                        :api_key, :access_token, :accessToken, :session_id]
       @scrub_user = true
       @scrub_password = true
-      @randomize_scrub_length = true
+      @randomize_scrub_length = false
       @scrub_whitelist = []
       @uncaught_exception_level = 'error'
       @scrub_headers = ['Authorization']

--- a/lib/rollbar/scrubbers.rb
+++ b/lib/rollbar/scrubbers.rb
@@ -6,11 +6,7 @@ module Rollbar
       if Rollbar.configuration.randomize_scrub_length
         random_filtered_value
       else
-        '*' * (begin
-                 value.length
-               rescue StandardError
-                 8
-               end)
+        '*' * 6
       end
     end
 

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -127,7 +127,7 @@ describe Rollbar::Item do
 
     context 'ActiveSupport >= 4.1', :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
       it 'should have correct configured_options object' do
-        payload['data'][:notifier][:configured_options][:access_token].should == '********'
+        payload['data'][:notifier][:configured_options][:access_token].should == '******'
         payload['data'][:notifier][:configured_options][:root].should == '/foo/'
         payload['data'][:notifier][:configured_options][:framework].should == 'Rails'
       end

--- a/spec/rollbar/plugins/rack_spec.rb
+++ b/spec/rollbar/plugins/rack_spec.rb
@@ -73,6 +73,20 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
     end
   end
 
+  context 'with sensitive body parameters' do
+    let(:params) do
+      { 'password' => 'value' }
+    end
+
+    it 'scrubs the body' do
+      expect do
+        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+      end.to raise_error(exception)
+
+      expect(Rollbar.last_report[:request][:body]).to be_eql("{\"password\":\"******\"}")
+    end
+  end
+
   context 'with array POST parameters' do
     let(:params) do
       [{ :key => 'value' }, 'string', 10]

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -34,7 +34,7 @@ describe Rollbar::RequestDataExtractor do
         :scrub_fields => [:password, :secret, :param1, :param2],
         :scrub_user => true,
         :scrub_password => true,
-        :randomize_scrub_length => true,
+        :randomize_scrub_length => false,
         :whitelist => false
       }
 

--- a/spec/rollbar/scrubbers_spec.rb
+++ b/spec/rollbar/scrubbers_spec.rb
@@ -23,8 +23,8 @@ describe Rollbar::Scrubbers do
 
       let(:value) { 'herecomesaverylongvalue' }
 
-      it 'randomizes the scrubbed string' do
-        expect(described_class.scrub_value(value)).to match(/\*{#{value.length}}/)
+      it 'replaces scrubbed string' do
+        expect(described_class.scrub_value(value)).to match(/\*{6}/)
       end
     end
   end


### PR DESCRIPTION
Makes the scrub replacement string fixed length by default, and adds a test for scrubbing rack request bodies.