### PR TITLE
Allow sending payloads as serialized json to delayed job handlers

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -58,6 +58,7 @@ module Rollbar
     attr_reader :transform
     attr_accessor :verify_ssl_peer
     attr_accessor :use_async
+    attr_accessor :async_json_payload
     attr_reader :use_eventmachine
     attr_accessor :web_base
     attr_accessor :write_to_file
@@ -129,6 +130,7 @@ module Rollbar
       @safely = false
       @transform = []
       @use_async = false
+      @async_json_payload = false
       @use_eventmachine = false
       @verify_ssl_peer = true
       @web_base = DEFAULT_WEB_BASE

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -109,15 +109,11 @@ module Rollbar
         # the risk just to send this diagnostic object. In versions < 4.1, ActiveSupport hooks
         # Ruby's JSON.generate so deeply there's no workaround.
         'not serialized in ActiveSupport < 4.1'
-      elsif configuration.use_async
-        # Currently serialization is performed by each handler, and this invariably
-        # means it is actually performed by ActiveSupport.
-        #
-        # TODO: Since serialization must be done prior to scheduling the job,
-        # it should at least be done by rollbar-gem itself. Much work has been done
-        # to avoid the bugs in ActiveSupport JSON. The async handlers are currently
-        # still subject to all those knnown issues.
-        'not serialized for async/delayed handlers'
+      elsif configuration.use_async && !configuration.async_json_payload
+        # The setting allows serialization to be performed by each handler,
+        # and this usually means it is actually performed by ActiveSupport,
+        # which cannot safely serialize this key.
+        'not serialized when async_json_payload is not set'
       else
         scrub(configuration.configured_options.configured)
       end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -247,9 +247,9 @@ module Rollbar
             send_body(payload)
           else
             item = Item.build_with(payload,
-                                  :notifier => self,
-                                  :configuration => configuration,
-                                  :logger => logger)
+                                   :notifier => self,
+                                   :configuration => configuration,
+                                   :logger => logger)
 
             process_item(item)
           end
@@ -521,6 +521,11 @@ module Rollbar
       options = http_proxy_for_em(uri)
       req = EventMachine::HttpRequest.new(uri.to_s, options).post(:body => body, :head => headers)
 
+      eventmachine_callback(req)
+      eventmachine_errback(req)
+    end
+
+    def eventmachine_callback(req)
       req.callback do
         if req.response_header.status == 200
           log_info '[Rollbar] Success'
@@ -529,7 +534,9 @@ module Rollbar
           log_info "[Rollbar] Response: #{req.response}"
         end
       end
+    end
 
+    def eventmachine_errback(req)
       req.errback do
         log_warning "[Rollbar] Call to API failed, status code: #{req.response_header.status}"
         log_info "[Rollbar] Error's response: #{req.response}"

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -240,16 +240,19 @@ module Rollbar
     # Using Rollbar.silenced we avoid the above behavior but Sidekiq
     # will have a chance to retry the original job.
     def process_from_async_handler(payload)
-      payload = Rollbar::JSON.load(payload) if payload.is_a?(String)
-
-      item = Item.build_with(payload,
-                             :notifier => self,
-                             :configuration => configuration,
-                             :logger => logger)
-
       Rollbar.silenced do
         begin
-          process_item(item)
+          if payload.is_a?(String)
+            # The final payload has already been built.
+            send_body(payload)
+          else
+            item = Item.build_with(payload,
+                                  :notifier => self,
+                                  :configuration => configuration,
+                                  :logger => logger)
+
+            process_item(item)
+          end
         rescue StandardError => e
           report_internal_error(e)
 
@@ -511,11 +514,10 @@ module Rollbar
 
     ## Delivery functions
 
-    def send_item_using_eventmachine(item, uri)
-      body = item.dump
-      return unless body
+    def send_using_eventmachine(body)
+      uri = URI.parse(configuration.endpoint)
 
-      headers = { 'X-Rollbar-Access-Token' => item['access_token'] }
+      headers = { 'X-Rollbar-Access-Token' => configuration.access_token }
       options = http_proxy_for_em(uri)
       req = EventMachine::HttpRequest.new(uri.to_s, options).post(:body => body, :head => headers)
 
@@ -540,14 +542,20 @@ module Rollbar
       body = item.dump
       return unless body
 
-      uri = URI.parse(configuration.endpoint)
-
       if configuration.use_eventmachine
-        send_item_using_eventmachine(item, uri)
+        send_using_eventmachine(body)
         return
       end
 
-      handle_response(do_post(uri, body, item['access_token']))
+      send_body(body)
+    end
+
+    def send_body(body)
+      log_info '[Rollbar] Sending json'
+
+      uri = URI.parse(configuration.endpoint)
+
+      handle_response(do_post(uri, body, configuration.access_token))
     end
 
     def do_post(uri, body, access_token)
@@ -739,8 +747,11 @@ module Rollbar
     end
 
     def process_async_item(item)
+      # Send async payloads as JSON string when async_json_payload is set.
+      payload = configuration.async_json_payload ? item.dump : item.payload
+
       configuration.async_handler ||= default_async_handler
-      configuration.async_handler.call(item.payload)
+      configuration.async_handler.call(payload)
     rescue StandardError
       if configuration.failover_handlers.empty?
         log_error '[Rollbar] Async handler failed, and there are no failover handlers configured. See the docs for "failover_handlers"'


### PR DESCRIPTION
Currently payloads are sent to delayed handlers as a Ruby hash of the payload, which causes most job queue frameworks to perform JSON serialization in order to put the payload on the job queue. This PR allows Rollbar-gem to perform the serialization and present the payload as a JSON string.

There are several motivations for allowing this.

1. Rollbar-gem now reliably uses Ruby's JSON class for all payload serialization. However when sending unserialized objects to job frameworks (Resque, Sidekiq, etc.) or custom delayed handlers, Rollbar-gem no longer has control over what serializer is used when enqueueing the job. See https://github.com/rollbar/rollbar-gem/issues/886 for more background. Letting Rollbar-gem control serialization ensures payloads can be encoded and sent that would otherwise fail.

2. Rollbar-gem's serialization includes payload truncation where needed. This ensures a reliable max size (500 KB) of the data that goes on the queue, preserving the performance and reliability of the queue. Without this, payload sizes can be many tens (or hundreds!) of megabytes. These worst case scenarios do happen, partly because the ActiveSupport serializer that frequently gets used produces deep, runaway recursive serializations of objects.

3. Because the payload must be serialized to go on the queue, work on the main thread isn't reduced by trying to defer serialization to the worker. Since some kind of serialization must be done on the application thread anyway, it might as well be the final one. Currently, the payload is first serialized by the job framework, then deserialized by Rollbar-gem in the worker in order to perform truncation, and finally serialized again before posting to the network. Serializing once before queueing cuts out most of this.

It would be nice to make the new behavior the default, but there are custom async handlers that will expect the hash of the payload. The current behavior remains the default, and the new behavior can be enabled by setting `config.async_json_payload = true`.