### PR TITLE
Gemfile: use json < 2.x on Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 if RUBY_VERSION.start_with?('1.9')
   gem 'capistrano', '<= 3.4.1', :require => false
+  gem 'json', '1.8.6'
   gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
   gem 'sucker_punch', '~> 1.0'
 elsif RUBY_VERSION.start_with?('2')

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -27,6 +27,10 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
+if RUBY_VERSION < '2.0.0'
+  gem 'json', '1.8.6'
+end
+
 if RUBY_VERSION < '2.2.2'
   gem 'sidekiq', '~> 2.13.0'
 else


### PR DESCRIPTION
json 2.x uses Ruby 2.0 double splat operator. 