### PR TITLE
Don't try and call ActiveSupport without checking if it's defined

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -14,7 +14,9 @@ module Rollbar
   end
 end
 
-ActiveSupport.on_load(:action_mailer) do
-  # Automatically add to ActionMailer::DeliveryJob
-  ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)
+if defined?(ActiveSupport)
+  ActiveSupport.on_load(:action_mailer) do
+    # Automatically add to ActionMailer::DeliveryJob
+    ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)
+  end
 end


### PR DESCRIPTION
Non-Rails Ruby apps may not have ActiveSupport.

Perhaps a non-Rails build should be added to the Travis matrix?