### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.5.3
   - 2.6.0
   - 2.6.3
+  - 2.7.0
   - rbx
   # Travis's own rvm installer is failing on JRuby builds, TODO: reenable when fixed.
   # - jruby-9.1.9.0
@@ -136,6 +137,12 @@ matrix:
       jdk: oraclejdk8
     - rvm: 2.6.3
       jdk: oraclejdk9
+    - rvm: 2.7.0
+      jdk: openjdk8
+    - rvm: 2.7.0
+      jdk: oraclejdk8
+    - rvm: 2.7.0
+      jdk: oraclejdk9
 
     - rvm: ruby-head
       jdk: openjdk8
@@ -249,6 +256,27 @@ matrix:
       gemfile: gemfiles/rails41.gemfile
     - rvm: 2.6.3
       gemfile: gemfiles/rails42.gemfile
+    # Rails 6.x tries to be compatible with Ruby 2.7, though
+    # it still throws a lot of warnings. No point testing earlier
+    # Rails with Ruby 2.7.
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails30.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails31.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails32.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails41.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails42.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails52.gemfile
     # JRuby JDBC Adapter is only compatible with Rails >= 5.x
     - rvm: jruby-9.1.9.0
       gemfile: gemfiles/rails30.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ dist: trusty
 services:
   - redis-server
 language: ruby
-# Broken bundler on travis CI - https://github.com/bundler/bundler/issues/2784
-before_install:
-  - gem update --system 2.7.7
-  - gem --version
-  - gem install bundler -v 1.6.1
-  - bundle --version
 
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
-  - 2.6.3
+  - 2.6.5
   - 2.7.0
   - rbx
   # Travis's own rvm installer is failing on JRuby builds, TODO: reenable when fixed.
@@ -68,9 +67,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    # Ruby 2.6.x is still being eveluated and may have test failures
-    - rvm: 2.6.0
-    - rvm: 2.6.3
     # oraclejdk9 has a dependency issue that needs to be investigated
     - jdk: oraclejdk9
 
@@ -119,17 +115,11 @@ matrix:
       jdk: oraclejdk8
     - rvm: 2.5.3
       jdk: oraclejdk9
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       jdk: openjdk8
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       jdk: oraclejdk8
-    - rvm: 2.6.0
-      jdk: oraclejdk9
-    - rvm: 2.6.3
-      jdk: openjdk8
-    - rvm: 2.6.3
-      jdk: oraclejdk8
-    - rvm: 2.6.3
+    - rvm: 2.6.5
       jdk: oraclejdk9
     - rvm: 2.7.0
       jdk: openjdk8
@@ -226,29 +216,17 @@ matrix:
       gemfile: gemfiles/rails40.gemfile
     - rvm: 2.5.3
       gemfile: gemfiles/rails41.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       gemfile: gemfiles/rails30.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       gemfile: gemfiles/rails31.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       gemfile: gemfiles/rails32.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       gemfile: gemfiles/rails40.gemfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       gemfile: gemfiles/rails41.gemfile
-    - rvm: 2.6.0
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: 2.6.3
-      gemfile: gemfiles/rails30.gemfile
-    - rvm: 2.6.3
-      gemfile: gemfiles/rails31.gemfile
-    - rvm: 2.6.3
-      gemfile: gemfiles/rails32.gemfile
-    - rvm: 2.6.3
-      gemfile: gemfiles/rails40.gemfile
-    - rvm: 2.6.3
-      gemfile: gemfiles/rails41.gemfile
-    - rvm: 2.6.3
+    - rvm: 2.6.5
       gemfile: gemfiles/rails42.gemfile
     # Rails 6.x tries to be compatible with Ruby 2.7, though
     # it still throws a lot of warnings. No point testing earlier

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -15,7 +15,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 gem 'appraisal'
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '6.0.0.rc1'
+gem 'rails', '6.0.2.1'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.8.0'


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/929

Originally tried this:
```
        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
          force_encoding(value).encode(*args, **ENCODING_OPTIONS)
        else
          force_encoding(value).encode(*args, ENCODING_OPTIONS)
        end
```
but Ruby 1.9.3 doesn't tolerate the double splat being present at all. Ruby 2.7 won't tolerate the keyword args being a hash data type, and true keyword args can't be assigned to a constant. This PR satisfies each of these requirements.

This PR also removes an old travis directive to set the bundler version. This is no longer needed, and the specified version doesn't work with Ruby 2.7.