### PR TITLE
DelayedJob: use job#error when available

### DIFF
--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -12,7 +12,13 @@ module Rollbar
         lifecycle.around(:invoke_job, &Delayed.invoke_job_callback)
         lifecycle.after(:failure) do |_, job, _, _|
           data = Rollbar::Delayed.build_job_data(job)
-          ::Rollbar.scope(:request => data).error("Job has failed and won't be retried anymore: " + job.last_error, :use_exception_level_filters => true) if job.last_error
+
+          # DelayedJob < 4.1 doesn't provide job#error
+          if job.class.method_defined? :error
+            ::Rollbar.scope(:request => data).error(job.error, :use_exception_level_filters => true) if job.error
+          elsif job.last_error
+            ::Rollbar.scope(:request => data).error("Job has failed and won't be retried anymore: " + job.last_error, :use_exception_level_filters => true)
+          end
         end
       end
     end


### PR DESCRIPTION
DelayedJob provides the error object in 4.1.x and later. Using it instead of the `#last_error` string allows better item grouping and a more usable report.