### PR TITLE
Explicitly require rails/command in rollbar-rails-runner

### DIFF
--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -39,7 +39,7 @@ module Rails
     end
 
     def eval_runner
-      if Rails.version >= '5.1.0'
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('5.1.0')
         rails5_runner
       else
         legacy_runner
@@ -55,6 +55,8 @@ module Rails
     end
 
     def rails5_runner
+      require 'rails/command'
+
       Rails::Command.invoke 'runner', ARGV
     end
 


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/935

A default `rails new` project loads other code that happens to require rails/command. That's not assured though, and given a minimal Gemfile, this needs to be required here. 