### PR TITLE
Rollbar pid files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,7 @@ An array of backup handlers if the async handlers fails. Each should respond to
 
 For use with `write_to_file`. Indicates location of the rollbar log file being
 tracked by [rollbar-agent](https://github.com/rollbar/rollbar-agent).
+Enable `files_with_pid_name_enabled` if you want to have different files for each process(only works if extension `rollbar`)
 
 ### framework
 

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -24,7 +24,6 @@ module Rollbar
     attr_accessor :environment
     attr_accessor :exception_level_filters
     attr_accessor :failover_handlers
-    attr_accessor :filepath
     attr_accessor :framework
     attr_accessor :ignored_person_ids
     attr_accessor :host
@@ -61,7 +60,6 @@ module Rollbar
     attr_accessor :async_json_payload
     attr_reader :use_eventmachine
     attr_accessor :web_base
-    attr_accessor :write_to_file
     attr_reader :send_extra_frame_data
     attr_accessor :use_exception_level_filters_default
     attr_accessor :proxy
@@ -69,6 +67,13 @@ module Rollbar
     attr_accessor :transmit
     attr_accessor :log_payload
     attr_accessor :backtrace_cleaner
+
+    attr_accessor :write_to_file
+    attr_accessor :filepath
+    attr_accessor :files_with_pid_name_enabled
+    attr_accessor :files_processed_enabled
+    attr_accessor :files_processed_duration # seconds
+    attr_accessor :files_processed_size # bytes
 
     attr_reader :project_gem_paths
     attr_accessor :configured_options
@@ -134,7 +139,6 @@ module Rollbar
       @use_eventmachine = false
       @verify_ssl_peer = true
       @web_base = DEFAULT_WEB_BASE
-      @write_to_file = false
       @send_extra_frame_data = :none
       @project_gem_paths = []
       @use_exception_level_filters_default = false
@@ -149,6 +153,12 @@ module Rollbar
         :on_error_response => nil, # params: response
         :on_report_internal_error => nil # params: exception
       }
+
+      @write_to_file = false
+      @files_with_pid_name_enabled = false
+      @files_processed_enabled = false
+      @files_processed_duration = 60
+      @files_processed_size = 5 * 1000 * 1000
 
       @configured_options = ConfiguredOptions.new(self)
     end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -19,7 +19,8 @@ module Rollbar
     attr_accessor :last_report
     attr_accessor :scope_object
 
-    @file_semaphore = Mutex.new
+    MUTEX = Mutex.new
+    EXTENSION_REGEXP = /.rollbar\z/.freeze
 
     def initialize(parent_notifier = nil, payload_options = nil, scope = nil)
       if parent_notifier
@@ -200,11 +201,11 @@ module Rollbar
     def process_item(item)
       if configuration.write_to_file
         if configuration.use_async
-          @file_semaphore.synchronize do
-            write_item(item)
+          MUTEX.synchronize do
+            do_write_item(item)
           end
         else
-          write_item(item)
+          do_write_item(item)
         end
       else
         send_item(item)
@@ -675,31 +676,38 @@ module Rollbar
       end
     end
 
-    def write_item(item)
-      if configuration.use_async
-        @file_semaphore.synchronize do
-          do_write_item(item)
-        end
-      else
-        do_write_item(item)
-      end
-    end
-
     def do_write_item(item)
       log_info '[Rollbar] Writing item to file'
 
       body = item.dump
       return unless body
 
+      file_name = if configuration.files_with_pid_name_enabled
+                    configuration.filepath.gsub(EXTENSION_REGEXP, "_#{Process.pid}\\0")
+                  else
+                    configuration.filepath
+                  end
+
       begin
-        @file ||= File.open(configuration.filepath, 'a')
+        @file ||= File.open(file_name, 'a')
 
         @file.puts(body)
         @file.flush
+        update_file(@file, file_name)
 
         log_info '[Rollbar] Success'
       rescue IOError => e
         log_error "[Rollbar] Error opening/writing to file: #{e}"
+      end
+    end
+
+    def update_file(file, file_name)
+      return unless configuration.files_processed_enabled
+
+      time_now = Time.now
+      if time_now - file.birthtime > configuration.files_processed_duration || file.size > configuration.files_processed_size
+        new_file_name = file_name.gsub(EXTENSION_REGEXP, "_processed_#{time_now.to_i}\\0")
+        File.rename(file, new_file_name)
       end
     end
 

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -705,10 +705,10 @@ module Rollbar
       return unless configuration.files_processed_enabled
 
       time_now = Time.now
-      if time_now - file.birthtime > configuration.files_processed_duration || file.size > configuration.files_processed_size
-        new_file_name = file_name.gsub(EXTENSION_REGEXP, "_processed_#{time_now.to_i}\\0")
-        File.rename(file, new_file_name)
-      end
+      return if configuration.files_processed_duration > time_now - file.birthtime && file.size < configuration.files_processed_size
+
+      new_file_name = file_name.gsub(EXTENSION_REGEXP, "_processed_#{time_now.to_i}\\0")
+      File.rename(file, new_file_name)
     end
 
     def failsafe_reason(message, exception)


### PR DESCRIPTION
Hi! We want to save the logs to different files for each puma workers, is it possible to add such a PR to the gem?

in addition:
+ small refactor old code
+ added functionality for rename `processed` files(for smooth file processing by our agent)

thanks!