### PR TITLE
Case insensitive scrub headers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,10 @@ Style/FrozenStringLiteralComment:
   # throughout the project, in order to prepare for a future Ruby 3.x.
   Enabled: false
 
+Style/SafeNavigation:
+  # Not available in Ruby < 2.3.
+  Enabled: false
+
 #
 # Performance cops are opt in, and `Enabled: true` is always required.
 # Full list is here: https://github.com/rubocop-hq/rubocop-performance/tree/master/lib/rubocop/cop/performance

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -247,7 +247,12 @@ module Rollbar
     end
 
     def sensitive_headers_list
-      Rollbar.configuration.scrub_headers || []
+      return [] unless Rollbar.configuration.scrub_headers && Rollbar.configuration.scrub_headers.is_a?(Array)
+
+      # Normalize into the expected matching format
+      Rollbar.configuration.scrub_headers.map do |header|
+        header.split(/[-_]/).map(&:capitalize).join('-').gsub(/^Http-/, '')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/934

Would be nice to move the normalization into configuration.rb, but `config.scrub_headers` currently allows any array methods on `config.scrub_headers`, so just adding a custom setter won't work.