### PR TITLE
Handle error encoding string without failing the occurrence

### DIFF
--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -30,6 +30,9 @@ module Rollbar
                         end
 
         object.is_a?(Symbol) ? encoded_value.to_sym : encoded_value
+      rescue StandardError => e
+        # If encoding fails for any reason, replace the string with a diagnostic error.
+        "error encoding string: #{e.class}: #{e.message}"
       end
 
       private

--- a/spec/rollbar/encoding/encoder_spec.rb
+++ b/spec/rollbar/encoding/encoder_spec.rb
@@ -57,5 +57,19 @@ describe Rollbar::Encoding::Encoder do
         let(:expected) { 'Изменение' }
       end
     end
+
+    context 'with unmappable encoding' do
+      # The Vietnamese encoding Windows-1258 has some character sequences
+      # that cannot map to UTF-8. Use this to cause Encoding::ConverterNotFoundError
+      # and test the behavior of unmappble encodings.
+      let(:object) { "\xE3\xEC".force_encoding(::Encoding::Windows_1258) }
+      let(:expected) { 'error encoding string: Encoding::ConverterNotFoundError' }
+
+      it 'replaces string with diagnostic error' do
+        value = subject.encode
+
+        expect(value).to include(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
Specific strings in an occurrence may contain encodings that cannot map to UTF-8. For example, the Vietnamese encoding Windows-1258 allows sequences that have no valid mapping in UTF-8.

When a mapping fails, it is better to provide a diagnostic error for the specific string than to fail the occurrence. Failsafe error occurrences don't show where the failed string mapping happened, and don't provide useful information about the original error. Preserving and sending the original error is an improvement on both points.