### PR TITLE
Require json necessary in some environments

### DIFF
--- a/lib/rollbar/deploy.rb
+++ b/lib/rollbar/deploy.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Rollbar
   # Deploy Tracking API wrapper module
   module Deploy

--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -1,4 +1,5 @@
 require 'rollbar/language_support'
+require 'json'
 
 module Rollbar
   module JSON # :nodoc:

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -121,6 +121,8 @@ module Rollbar
       end
 
       def config_js_tag(env)
+        require 'json'
+
         js_config = Rollbar::Util.deep_copy(config[:options])
 
         add_person_data(js_config, env)


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/943

The missing require doesn't fail on rvm installed rubies, even when testing with a minimal Ruby script and no other dependencies. It does fail on these docker images however: https://hub.docker.com/_/ruby