### PR TITLE
DelayedJob plugin: verify job data is added correctly

### DIFF
--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -44,8 +44,12 @@ elsif RUBY_VERSION.start_with?('2')
   gem 'simplecov'
 end
 
-# We need last sinatra that uses rack 2.x
-gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+  gem 'rack', '2.1.2'
+end
+
+# We need last sinatra that uses rack 2.1.x
+gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -44,8 +44,12 @@ elsif RUBY_VERSION.start_with?('2')
   gem 'simplecov'
 end
 
-# We need last sinatra that uses rack 2.x
-gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
+  gem 'rack', '2.1.2'
+end
+
+# We need last sinatra that uses rack 2.1.x
+gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 
 gem 'database_cleaner'
 gem 'delayed_job', :require => false

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -32,6 +32,19 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
     end
+
+    it 'adds the job data' do
+      payload = nil
+
+      ::Rollbar::Item.any_instance.stub(:dump) do |item|
+        payload = item.payload
+        nil
+      end
+
+      FailingJob.new.delay.do_job_please!(:foo, :bar)
+
+      expect(payload['data'][:request]["handler"]).to include({:args=>[:foo, :bar], :method_name=>:do_job_please!})
+    end
   end
 
   context 'with failed deserialization' do


### PR DESCRIPTION
Also in this PR:
A new sinatra version was released with an updated rack version dependency that requires Ruby >= 2.3. The travis gemfiles for rails 5.0, 5.1 have been updated to ensure working dependencies for Ruby 2.2. 