### PR TITLE
Use string instead of symbol when looking up "failsafe" in payload

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -286,7 +286,7 @@ module Rollbar
           :orig_host => host
         },
         :internal => true,
-        :failsafe => true
+        'failsafe' => true
       }
 
       failsafe_payload = {
@@ -804,7 +804,7 @@ module Rollbar
     end
 
     def via_failsafe?(item)
-      item.payload.fetch('data', {}).fetch(:failsafe, false)
+      item.payload.fetch('data', {}).fetch('failsafe', false)
     end
   end
 end


### PR DESCRIPTION
Unlike ActiveJob, Sidekiq doesn't keep symbols in payloads, and converts them
to strings. Because of this, the failsafe mechanism was not working as expected
as it was reported in https://github.com/rollbar/rollbar-gem/issues/950.

This PR fixes that by always looking up `'failsafe'` in the payload instead of 
`:failsafe`.

An example of what the payload looks like when logged from Rollbar:

```
ERROR -- : [Rollbar] Error processing the item: Net::ReadTimeout, Net::ReadTimeout with #<TCPSocket:(closed)>. Item: {"access_token"=>"abcdefghijklmnop", "data"=>{"level"=>"error", "environment"=>"development", "body"=>{"message"=>{"body"=>"Failsafe from rollbar-gem. Net::ReadTimeout: \"Net::ReadTimeout with #<TCPSocket:(closed)>\" in /usr/local/    lib/ruby/2.6.0/net/protocol.rb:217:in `rbuf_fill': error in process_item"}}, "notifier"=>{"name"=>"rollbar-gem", "version"=>"2.24.0"}, "custom"=>{"orig_uuid"=>nil, "orig_host"=>nil}, "internal"=>true, "failsafe"=>true}}
```