### PR TITLE
support report_level configuration just like rollbar.js

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -39,6 +39,7 @@ module Rollbar
     attr_accessor :open_timeout
     attr_accessor :request_timeout
     attr_accessor :net_retries
+    attr_accessor :report_level
     attr_accessor :root
     attr_accessor :js_options
     attr_accessor :js_enabled
@@ -122,6 +123,7 @@ module Rollbar
       @js_enabled = false
       @js_options = {}
       @locals = {}
+      @report_level = :info
       @scrub_fields = [:passwd, :password, :password_confirmation, :secret,
                        :confirm_password, :password_confirmation, :secret_token,
                        :api_key, :access_token, :accessToken, :session_id]

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -172,6 +172,29 @@ describe Rollbar do
       Rollbar.report_exception(@exception).should == 'disabled'
     end
 
+    it 'should not report when level is lower than report_level' do
+      Rollbar.debug('debug message').should == 'not_reported'
+
+      Rollbar.configure do |config|
+        config.enabled = true
+        config.report_level = 'error'
+      end
+
+      Rollbar.configuration.report_level.should == 'error'
+      Rollbar.warning('warning message').should == 'not_reported'
+    end
+
+
+    it 'should report when level is higher than or equal to report_level' do
+      Rollbar.configure do |config|
+        config.report_level = 'error'
+      end
+
+      logger_mock.should_receive(:info).with('[Rollbar] Scheduling item')
+      logger_mock.should_receive(:info).with('[Rollbar] Success')
+      Rollbar.report_exception(@exception)
+    end
+
     it 'should stay disabled if configure is called again' do
       Rollbar.clear_notifier!
 


### PR DESCRIPTION
Disable reporting based on `report_level` configuration, similar to https://docs.rollbar.com/docs/rollbarjs-configuration-reference