### PR TITLE
Remove access_token from item payload

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -65,7 +65,6 @@ module Rollbar
     def build
       data = build_data
       self.payload = {
-        'access_token' => configuration.access_token,
         'data' => data
       }
 

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -290,7 +290,6 @@ module Rollbar
       }
 
       failsafe_payload = {
-        'access_token' => configuration.access_token,
         'data' => failsafe_data
       }
 

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -53,7 +53,7 @@ describe Rollbar::Item do
       end
 
       it 'should have the correct root-level keys' do
-        payload.keys.should match_array(['access_token', 'data'])
+        payload.keys.should match_array(['data'])
       end
 
       it 'should have the correct data keys' do
@@ -566,7 +566,6 @@ describe Rollbar::Item do
       context 'with mutation in payload' do
         let(:new_payload) do
           {
-            'access_token' => configuration.access_token,
             'data' => {
             }
           }

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1268,7 +1268,6 @@ describe Rollbar do
       Rollbar.error(exception)
 
       File.exist?(filepath).should eq(true)
-      File.read(filepath).should include test_access_token
       File.delete(filepath)
 
       Rollbar.configure do |config|
@@ -1293,7 +1292,6 @@ describe Rollbar do
       Rollbar.error(exception)
 
       File.exist?(filepath).should eq(true)
-      File.read(filepath).should include test_access_token
       File.delete(filepath)
 
       Rollbar.configure do |config|

--- a/spec/support/deploy_api/report.rb
+++ b/spec/support/deploy_api/report.rb
@@ -5,8 +5,12 @@ module DeployAPI
   class Report < ::RollbarAPI
     protected
 
-    def valid_data?(json, request)
-      !!json['environment'] && !!json['revision'] && super(json, request)
+    def authorized?(json, _request)
+      json['access_token'] != UNAUTHORIZED_ACCESS_TOKEN
+    end
+
+    def valid_data?(json, _request)
+      !!json['environment'] && !!json['revision'] && !!json['access_token']
     end
 
     def success_body(_json, _request)

--- a/spec/support/rollbar_api.rb
+++ b/spec/support/rollbar_api.rb
@@ -16,8 +16,8 @@ class RollbarAPI
 
   protected
 
-  def authorized?(json, _request)
-    json['access_token'] != UNAUTHORIZED_ACCESS_TOKEN
+  def authorized?(_json, request)
+    request.env['HTTP_X_ROLLBAR_ACCESS_TOKEN'] != UNAUTHORIZED_ACCESS_TOKEN
   end
 
   def response_headers
@@ -26,8 +26,8 @@ class RollbarAPI
     }
   end
 
-  def valid_data?(json, _request)
-    !!json['access_token']
+  def valid_data?(_json, request)
+    !!request.env['HTTP_X_ROLLBAR_ACCESS_TOKEN']
   end
 
   def unauthorized


### PR DESCRIPTION
Resolves #965 

After some investigation, it looks like the access_token in the item payload is no longer used in this gem. Notifier requests are now sent with a "X-Rollbar-Access-Token" header. Removing the token from the payload will also remove it from logs. 

The RollbarAPI stub is still expecting the payload to include an access token so I've changed that expectation to look at the header. The Report stub inherits from RollbarAPI but has a different structure now. It's been updated to validate against the access_token in its request body rather than to super RollbarAPI's behavior. 

One more change is that the payload saved to file will also no longer include the access_token. I'm not sure what consequences this might have. If you know that this is a necessary field, we can to make changes to include it here.