### PR TITLE
Support any object as extra data when notifying errors

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -389,8 +389,8 @@ module Rollbar
           exception = arg
         elsif RUBY_PLATFORM == 'java' && arg.is_a?(java.lang.Throwable)
           exception = arg
-        elsif arg.is_a?(Hash)
-          extra = arg
+        elsif arg.respond_to?(:to_h)
+          extra = arg.to_h
 
           context = extra[:custom_data_method_context]
           extra.delete :custom_data_method_context


### PR DESCRIPTION
Currently the extra_data support in rollbar-ruby relies on the object
being of a specific set of types. This is a bit uncessary, as we do
support hashes. So instead of limiting the types by their class name,
lets instead check the response to `to_h` (which always returns hash)
and then treat the result as a hash.

This enables support for a larger number of extra_data objects being
passed in, including ActiveModel::Errors, the original object that was
being passed in at my work.