### PR TITLE
Capistrano Deploy Rollbar Comment Fix

### DIFF
--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -83,6 +83,7 @@ module Rollbar
       def report_deploy_succeeded(capistrano, dry_run)
         ::Rollbar::Deploy.update(
           {
+            :comment => capistrano.fetch(:rollbar_comment),
             :proxy => :ENV,
             :dry_run => dry_run
           },
@@ -95,6 +96,7 @@ module Rollbar
       def report_deploy_failed(capistrano, dry_run)
         ::Rollbar::Deploy.update(
           {
+            :comment => capistrano.fetch(:rollbar_comment),
             :proxy => :ENV,
             :dry_run => dry_run
           },

--- a/spec/rollbar/capistrano_tasks_spec.rb
+++ b/spec/rollbar/capistrano_tasks_spec.rb
@@ -109,6 +109,7 @@ describe ::Rollbar::CapistranoTasks do
         it 'prints the API request, response and updates the appropriate deploy to succeeded' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
+                    :comment => rollbar_comment,
                     :proxy => :ENV,
                     :dry_run => dry_run
                   ),
@@ -204,6 +205,7 @@ describe ::Rollbar::CapistranoTasks do
         it 'prints the API request, response and updates the appropriate deploy to failed' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
+                    :comment => rollbar_comment,
                     :proxy => :ENV,
                     :dry_run => dry_run
                   ),


### PR DESCRIPTION
The Issue:
- When deploying with capistrano the rollbar_comment is not passed
  through to Rollbar::Update during a report_deploy_succeeded or a report_deploy_failed

The Fix:
- Added `:comment => capistrano.fetch(:rollbar_comment)` to the
  report_deploy_succeeded and report_deploy_failed tasks