### PR TITLE
Rake rollbar:test needs host setting in rails 6.x

### DIFF
--- a/lib/rollbar/rollbar_test.rb
+++ b/lib/rollbar/rollbar_test.rb
@@ -28,6 +28,10 @@ module RollbarTest # :nodoc:
 
     puts 'Processing...'
     env = Rack::MockRequest.env_for("#{protocol}://www.example.com/verify", 'REMOTE_ADDR' => '127.0.0.1')
+
+    # Needed for Rails 6.x ActionDispatch::HostAuthorization (DNS rebinding protection)
+    env['HTTP_HOST'] = 'localhost'
+
     status, = app.call(env)
 
     puts error_message unless status.to_i == 500


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/976

Adds the http host to the env, as required by the new DNS rebinding protection in Rails.

The relevant change in Rails. https://github.com/rails/rails/pull/33145