### PR TITLE
Recreate REQUEST_URI using Rack SPEC-compliant variables

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -131,6 +131,7 @@ module Rollbar
       host = host.split(',').first.strip unless host.empty?
 
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
+      path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{"?#{env['QUERY_STRING']}" unless env['QUERY_STRING'].to_s.empty?}"
       unless path.nil? || path.empty?
         path = '/' + path.to_s if path.to_s.slice(0, 1) != '/'
       end


### PR DESCRIPTION
Turns out `REQUEST_URI` is not in the Rack SPEC, and [the recommendation](https://github.com/rack/rack/issues/1342#issuecomment-573926795) is to reproduce the same value value using SPEC-compliant variables. [`Rack::Request#fullpath`](https://github.com/rack/rack/blob/e15eafc28170ea759407a031b68d690fbd83d3be/lib/rack/request.rb#L515) builds the equivalent of `REQUEST_URI`, but we don't want to add a dependency on `Rack` directly.

The update uses Rack-compliant variables.