### PR TITLE
Rescue exceptions in deploy tasks, allow deploy to continue

### DIFF
--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -40,6 +40,9 @@ module Rollbar
         capistrano_300_warning(logger)
         logger.info opts[:desc] if opts[:desc]
         yield
+
+      rescue StandardError => e
+        logger.error "Error reporting to Rollbar: #{e.inspect}"
       end
 
       def deploy_update(capistrano, logger, dry_run, opts = {})

--- a/spec/rollbar/capistrano_tasks_spec.rb
+++ b/spec/rollbar/capistrano_tasks_spec.rb
@@ -79,6 +79,17 @@ describe ::Rollbar::CapistranoTasks do
       end
     end
 
+    context 'when an an exception is raised' do
+      it "logs the error to the logger" do
+        expect(::Rollbar::Deploy).to receive(:report)
+          .and_raise('an API exception')
+
+        expect(logger).to receive(:error).with(/an API exception/)
+
+        subject.deploy_started(capistrano, logger, dry_run)
+      end
+    end
+
     context 'with --dry-run provided' do
       let(:dry_run) { true }
 
@@ -149,6 +160,17 @@ describe ::Rollbar::CapistranoTasks do
           expect(logger).to receive(:debug).with('dummy request content')
           expect(logger).to receive(:debug).with('dummy response info')
           expect(logger).to receive(:error).with(/Unable(.*)error message from the api/)
+
+          subject.deploy_succeeded(capistrano, logger, dry_run)
+        end
+      end
+
+      context 'when an an exception is raised' do
+        it "logs the error to the logger" do
+          expect(::Rollbar::Deploy).to receive(:update)
+            .and_raise('an API exception')
+
+          expect(logger).to receive(:error).with(/an API exception/)
 
           subject.deploy_succeeded(capistrano, logger, dry_run)
         end
@@ -246,6 +268,17 @@ describe ::Rollbar::CapistranoTasks do
           expect(logger).to receive(:debug).with('dummy request content')
           expect(logger).to receive(:debug).with('dummy response info')
           expect(logger).to receive(:error).with(/Unable(.*)error message from the api/)
+
+          subject.deploy_failed(capistrano, logger, dry_run)
+        end
+      end
+
+      context 'when an an exception is raised' do
+        it "logs the error to the logger" do
+          expect(::Rollbar::Deploy).to receive(:update)
+            .and_raise('an API exception')
+
+          expect(logger).to receive(:error).with(/an API exception/)
 
           subject.deploy_failed(capistrano, logger, dry_run)
         end


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/982

Rescue and log unexpected exceptions in the deploy reporting tasks. This ensures a Rollbar reporting failure won't block the deploy workflow itself.

These exceptions are usually (or always) API/network related (e.g. API is offline), so no attempt is made to send a failsafe error. Instead, the error is logged to the registered local logger. 