### PR TITLE
Add guard to ensure CAPISTRANO::VERSION is defined

### DIFF
--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -61,7 +61,11 @@ module Rollbar
       end
 
       def capistrano_300_warning(logger)
-        logger.warn("You need to upgrade capistrano to '>= 3.1' version in order to correctly report deploys to Rollbar. (On 3.0, the reported revision will be incorrect.)") if ::Capistrano::VERSION =~ /^3\.0/
+        return unless ::Capistrano.const_defined?('VERSION') && ::Capistrano::VERSION =~ /^3\.0/
+
+        logger.warn('You need to upgrade capistrano to >= 3.1 version in order'\
+          'to correctly report deploys to Rollbar. (On 3.0, the reported revision'\
+          'will be incorrect.)')
       end
 
       def report_deploy_started(capistrano, dry_run)

--- a/spec/rollbar/capistrano_tasks_spec.rb
+++ b/spec/rollbar/capistrano_tasks_spec.rb
@@ -293,4 +293,44 @@ describe ::Rollbar::CapistranoTasks do
       end
     end
   end
+
+  describe '.capistrano_300_warning' do
+    context 'when ::Capistrano::VERSION is defined' do
+      it 'does nothing' do
+        expect(logger).not_to receive(:warn)
+
+        subject.send(:capistrano_300_warning, logger)
+      end
+    end
+
+    context 'when ::Capistrano::VERSION is 3.0' do
+      it 'logs a warning' do
+        # The class is not reloaded between tests, so prepare to restore the constant.
+        original_version = ::Capistrano::VERSION
+        ::Capistrano.send(:remove_const, 'VERSION')
+        ::Capistrano.const_set('VERSION', '3.0.0')
+
+        expect(logger).to receive(:warn)
+
+        subject.send(:capistrano_300_warning, logger)
+
+        ::Capistrano.send(:remove_const, 'VERSION')
+        ::Capistrano.const_set('VERSION', original_version)
+      end
+    end
+
+    context 'when ::Capistrano::VERSION is undefined' do
+      it 'does nothing' do
+        # The class is not reloaded between tests, so prepare to restore the constant.
+        original_version = ::Capistrano::VERSION
+        ::Capistrano.send(:remove_const, 'VERSION')
+
+        expect(logger).not_to receive(:warn)
+
+        subject.send(:capistrano_300_warning, logger)
+
+        ::Capistrano.const_set('VERSION', original_version)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-gem/issues/975

Capistrano 2.x doesn't have a `VERSION` constant. (Instead it has a `Version` property.) This PR ensures the constant is present before testing its value. If the constant isn't present, no further check is needed since the code path only cares about >= 3.0.

There's also some light refactoring for line length and rubocop.