### PR TITLE
Fixes ruby 2.7.0 URI.encode depreciation

### DIFF
--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -70,7 +70,7 @@ module Rollbar
         encoded_query = encode_www_form(filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist))
 
         # We want this to rebuild array params like foo[]=1&foo[]=2
-        URI.escape(CGI.unescape(encoded_query))
+        URI.encode_www_form_component(CGI.unescape(encoded_query)).gsub('+', '%20')
       end
 
       def decode_www_form(query)


### PR DESCRIPTION
References:

https://github.com/contentful/contentful.rb/pull/221