### PR TITLE
support customizing skipping error report for delayed job

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,13 @@ Rollbar notifier.
 
 The number of job failures before reporting the failure to Rollbar.
 
+### dj_skip_report_handler
+
+**Default** `nil`
+**Example** `-> (job) { job.cron? }`
+
+A handler, should respond to `#call`, receives the job and returns a boolean. If true, reporting errors will be skipped. If provided dj_threshold isn't checked.
+
 ### enabled
 
 **Default** `true`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,12 +108,12 @@ Rollbar notifier.
 
 The number of job failures before reporting the failure to Rollbar.
 
-### dj_skip_report_handler
+### async_skip_report_handler
 
 **Default** `nil`
 **Example** `-> (job) { job.cron? }`
 
-A handler, should respond to `#call`, receives the job and returns a boolean. If true, reporting errors will be skipped. If provided dj_threshold isn't checked.
+A handler, should respond to `#call`, receives the job and returns a boolean. If true, reporting errors will be skipped. If provided, dj_threshold isn't checked.
 
 ### enabled
 

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -19,6 +19,7 @@ module Rollbar
     attr_accessor :disable_core_monkey_patch
     attr_accessor :enable_error_context
     attr_accessor :dj_threshold
+    attr_accessor :dj_skip_report_handler
     attr_accessor :enabled
     attr_accessor :endpoint
     attr_accessor :environment
@@ -97,6 +98,7 @@ module Rollbar
       @disable_rack_monkey_patch = false
       @enable_error_context = true
       @dj_threshold = 0
+      @dj_skip_report_handler = nil
       @enabled = nil # set to true when configure is called
       @endpoint = DEFAULT_ENDPOINT
       @environment = nil

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -19,7 +19,7 @@ module Rollbar
     attr_accessor :disable_core_monkey_patch
     attr_accessor :enable_error_context
     attr_accessor :dj_threshold
-    attr_accessor :dj_skip_report_handler
+    attr_accessor :async_skip_report_handler
     attr_accessor :enabled
     attr_accessor :endpoint
     attr_accessor :environment
@@ -98,7 +98,7 @@ module Rollbar
       @disable_rack_monkey_patch = false
       @enable_error_context = true
       @dj_threshold = 0
-      @dj_skip_report_handler = nil
+      @async_skip_report_handler = nil
       @enabled = nil # set to true when configure is called
       @endpoint = DEFAULT_ENDPOINT
       @environment = nil

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -60,6 +60,10 @@ module Rollbar
     end
 
     def self.skip_report?(job)
+      handler = ::Rollbar.configuration.dj_skip_report_handler
+
+      return handler.call(job) if handler.respond_to?(:call)
+
       job.attempts < ::Rollbar.configuration.dj_threshold
     end
 

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -60,7 +60,7 @@ module Rollbar
     end
 
     def self.skip_report?(job)
-      handler = ::Rollbar.configuration.dj_skip_report_handler
+      handler = ::Rollbar.configuration.async_skip_report_handler
 
       return handler.call(job) if handler.respond_to?(:call)
 

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -115,6 +115,7 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
   end
 
   describe '.skip_report' do
+    subject(:call_skip_report) { described_class.skip_report?(job) }
     let(:configuration) { Rollbar.configuration }
     let(:threshold) { 5 }
 
@@ -139,7 +140,7 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
       end
 
       it 'returns true' do
-        expect(described_class.skip_report?(job)).to be(false)
+        expect(call_skip_report).to be(false)
       end
     end
 
@@ -147,7 +148,27 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
       let(:job) { double(:attempts => 3) }
 
       it 'returns false' do
-        expect(described_class.skip_report?(job)).to be(true)
+        expect(call_skip_report).to be(true)
+      end
+    end
+
+    context 'with dj_skip_report_handler set' do
+      let(:job) { double(:attempts => 3) }
+      let(:handler) { double('handler') }
+
+      before do
+        allow(configuration).to receive(:dj_skip_report_handler).and_return(handler)
+        allow(handler).to receive(:respond_to).with(:call).and_return(true)
+      end
+
+      it 'when handler.call returns false' do
+        expect(handler).to receive(:call).with(job).and_return(false)
+        expect(call_skip_report).to be(false)
+      end
+
+      it 'when handler.call returns true' do
+        expect(handler).to receive(:call).with(job).and_return(true)
+        expect(call_skip_report).to be(true)
       end
     end
   end

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -152,12 +152,12 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
       end
     end
 
-    context 'with dj_skip_report_handler set' do
+    context 'with async_skip_report_handler set' do
       let(:job) { double(:attempts => 3) }
       let(:handler) { double('handler') }
 
       before do
-        allow(configuration).to receive(:dj_skip_report_handler).and_return(handler)
+        allow(configuration).to receive(:async_skip_report_handler).and_return(handler)
         allow(handler).to receive(:respond_to).with(:call).and_return(true)
       end
 


### PR DESCRIPTION
## Description of the change

* Allow skipping error reports for delayed jobs based on a provided handler, providing the job as an argument. 


## Type of change
- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
