### PR TITLE
BREAKING CHANGE: Remove support for Ruby 1.9.3, support >=2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.2
@@ -73,12 +72,6 @@ matrix:
   exclude:
     # Don't run tests for non-jruby environments with the JDK.
     # NOTE: openjdk7 is missing from these exclusions so that Travis will run at least 1 build for the given rvm.
-    - rvm: 1.9.3
-      jdk: openjdk8
-    - rvm: 1.9.3
-      jdk: oraclejdk8
-    - rvm: 1.9.3
-      jdk: oraclejdk9
     - rvm: 2.0.0
       jdk: openjdk8
     - rvm: 2.0.0
@@ -147,15 +140,6 @@ matrix:
     - rvm: 2.3.8
       gemfile: gemfiles/rails60.gemfile
     - rvm: 2.4.5
-      gemfile: gemfiles/rails60.gemfile
-    # Rails 5.x requires Ruby 2.2.2 or higher
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: 1.9.3
       gemfile: gemfiles/rails60.gemfile
     # Rails 5.x requires Ruby 2.2.2 or higher
     - rvm: 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -44,18 +44,11 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'json', '1.8.6'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-  gem 'sucker_punch', '~> 1.0'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false # rubocop:disable Bundler/DuplicatedGem
-  gem 'codacy-coverage'
-  gem 'shoryuken' # rubocop:disable Bundler/DuplicatedGem
-  gem 'simplecov'
-  gem 'sucker_punch', '~> 2.0' # rubocop:disable Bundler/DuplicatedGem
-end
+gem 'capistrano', :require => false
+gem 'codacy-coverage'
+gem 'shoryuken'
+gem 'simplecov'
+gem 'sucker_punch', '~> 2.0'
 
 unless is_jruby
   # JRuby doesn't support fork, which is required for this test helper.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rollbar&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=rollbar&package-manager=bundler&version-scheme=semver&new-version=latest)
 
 
-> WARNING: Ruby 2.6.0 introduced a new bug bug ([#15472 -
-Invalid JSON data being sent from Net::HTTP in some cases with Ruby 2.6.0](https://bugs.ruby-lang.org/issues/15472)) that may result in the Rollbar API returning an error when an exception is reported.  (See [rollbar-gem issue #797](https://github.com/rollbar/rollbar-gem/issues/797)).
-
-> UPDATE: This bug is fixed in Ruby 2.6.1, and rollbar-gem has a safe workaround in version >= 2.19.0.
-If you need to stay on Ruby 2.6.0 for any reason, make sure you have the latest rollbar-gem.
-
-
-
 [Rollbar](https://rollbar.com) is a real-time exception reporting service for Ruby and other languages. The Rollbar service will alert you of problems with your code and help you understand them in a ways never possible before. We love it and we hope you will too.
 
 Rollbar-gem is the SDK for Ruby apps and includes support for apps using Rails, Sinatra, Rack, plain Ruby, and other frameworks.
@@ -27,9 +19,19 @@ For complete usage instructions and configuration reference, see our [Ruby SDK d
 
 ## Compatibility
 
+Version >= 3.0.0 is compatible with Ruby >= 2.0.0.
+
 Version >= 2.19.0 is compatible with Ruby >= 1.9.3.
 
 Version < 2.19.0 is compatible with Ruby >= 1.8.7.
+
+### Ruby 2.6.0
+
+> WARNING: Ruby 2.6.0 introduced a new bug bug ([#15472 -
+Invalid JSON data being sent from Net::HTTP in some cases with Ruby 2.6.0](https://bugs.ruby-lang.org/issues/15472)) that may result in the Rollbar API returning an error when an exception is reported.  (See [rollbar-gem issue #797](https://github.com/rollbar/rollbar-gem/issues/797)).
+
+> UPDATE: This bug is fixed in Ruby 2.6.1, and rollbar-gem has a safe workaround in version >= 2.19.0.
+If you need to stay on Ruby 2.6.0 for any reason, make sure you have the latest rollbar-gem.
 
 ## Release History & Changelog
 

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -34,17 +34,11 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'shoryuken'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'shoryuken'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'sinatra'
 gem 'delayed_job', :require => false
@@ -54,13 +48,7 @@ gem 'genspec', '>= 0.2.8'
 gem 'girl_friday', '>= 0.11.1'
 gem 'rspec-command'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'public_suffix', '< 1.5'
-  gem 'mime-types', '< 3.0'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'webmock', :require => false
-end
+gem 'webmock', :require => false
 
 gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -33,17 +33,11 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch'
-  gem 'shoryuken'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch'
+gem 'shoryuken'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'sinatra'
 gem 'delayed_job', :require => false
@@ -53,13 +47,7 @@ gem 'girl_friday'
 gem 'generator_spec'
 gem 'rspec-command'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
-  gem 'public_suffix', '< 1.5'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'webmock', :require => false
-end
+gem 'webmock', :require => false
 
 gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -35,17 +35,11 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'shoryuken'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'shoryuken'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'delayed_job', :require => false
 gem 'redis'
@@ -56,13 +50,7 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'rspec-command'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
-  gem 'public_suffix', '< 1.5'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'webmock', :require => false
-end
+gem 'webmock', :require => false
 
 gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -35,19 +35,12 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-  gem 'json', '~> 1.8'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'json', '~> 2.0'
-  gem 'shoryuken'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'json', '~> 2.0'
+gem 'shoryuken'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'delayed_job', :require => false
 gem 'redis'
@@ -59,13 +52,7 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'rspec-command'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
-  gem 'public_suffix', '< 1.5'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'webmock', :require => false
-end
+gem 'webmock', :require => false
 
 gem 'aws-sdk-sqs'
 

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -32,17 +32,11 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'shoryuken'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'shoryuken'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'delayed_job', :require => false
 gem 'redis'
@@ -54,13 +48,7 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'rspec-command'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
-  gem 'public_suffix', '< 1.5'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'webmock', :require => false
-end
+gem 'webmock', :require => false
 
 gem 'resque'
 gem 'aws-sdk-sqs'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -37,13 +37,8 @@ else
   gem 'sidekiq', '>= 2.13.0'
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'shoryuken', '>= 4.0.0', '<= 4.0.2'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'shoryuken'
-end
+gem 'capistrano', :require => false
+gem 'shoryuken'
 
 gem 'database_cleaner', '~> 1.0.0'
 gem 'delayed_job', :require => false
@@ -56,17 +51,10 @@ gem 'sinatra'
 
 gem 'nokogiri', '~> 1.6.0' if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0')
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
-  gem 'public_suffix', '< 1.5'
-  gem 'sucker_punch', '~> 1.0'
-  gem 'webmock', '< 2.3.0', :require => false
-else
-  gem 'sucker_punch', '~> 2.0'
-  gem 'webmock', :require => false
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'sucker_punch', '~> 2.0'
+gem 'webmock', :require => false
+gem 'codacy-coverage'
+gem 'simplecov'
 
 gem 'aws-sdk-sqs'
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -34,15 +34,10 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
   gem 'rack', '2.1.2'
@@ -60,10 +55,6 @@ gem 'resque'
 unless is_jruby
   # JRuby doesn't support fork, which is required for this test helper.
   gem 'rspec-command'
-end
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
 end
 
 gem 'webmock', :require => false

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -34,15 +34,10 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION.start_with?('1.9')
-  gem 'capistrano', '<= 3.4.1', :require => false
-  gem 'sucker_punch', '~> 1.0'
-elsif RUBY_VERSION.start_with?('2')
-  gem 'capistrano', :require => false
-  gem 'sucker_punch', '~> 2.0'
-  gem 'codacy-coverage'
-  gem 'simplecov'
-end
+gem 'capistrano', :require => false
+gem 'sucker_punch', '~> 2.0'
+gem 'codacy-coverage'
+gem 'simplecov'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
   gem 'rack', '2.1.2'
@@ -61,10 +56,6 @@ gem 'resque'
 unless is_jruby
   # JRuby doesn't support fork, which is required for this test helper.
   gem 'rspec-command'
-end
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
-  gem 'mime-types', '< 3.0'
 end
 
 gem 'webmock', :require => false

--- a/lib/rollbar/language_support.rb
+++ b/lib/rollbar/language_support.rb
@@ -10,10 +10,6 @@ module Rollbar
       mod.const_get(target, inherit)
     end
 
-    def ruby_19?
-      version?('1.9')
-    end
-
     def version?(version)
       numbers = version.split('.')
 
@@ -21,8 +17,6 @@ module Rollbar
     end
 
     def timeout_exceptions
-      return [] if ruby_19?
-
       [Net::ReadTimeout, Net::OpenTimeout]
     end
   end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -698,8 +698,6 @@ module Rollbar
     end
 
     def handle_net_retries
-      return yield if skip_retries?
-
       retries = configuration.net_retries - 1
 
       begin
@@ -711,10 +709,6 @@ module Rollbar
 
         retry
       end
-    end
-
-    def skip_retries?
-      Rollbar::LanguageSupport.ruby_19?
     end
 
     def handle_response(response)

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files        += ['spec/support/rollbar_api.rb'] # useful helper for app spec/tests.
   gem.name          = 'rollbar'
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.0.0'
   gem.version = Rollbar::VERSION
 
   if gem.respond_to?(:metadata)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -194,8 +194,7 @@ describe Rollbar do
       context 'with multi-byte characters in the report' do
         extra_data = { :key => "\u3042", :hash => { :inner_key => 'あああ' } }
 
-        it 'should send as multi-byte on ruby != 2.6.0',
-           :if => RUBY_VERSION >= '2.0.0' && RUBY_VERSION != '2.6.0' do
+        it 'should send as multi-byte on ruby != 2.6.0', :if => RUBY_VERSION != '2.6.0' do
           expect_any_instance_of(Net::HTTP::Post).to receive(:body=).with(
             satisfy do |body|
               body.chars.length < body.bytes.length && body.include?('あああ')
@@ -2031,11 +2030,7 @@ describe Rollbar do
     end
   end
 
-  context 'having timeout issues (for ruby > 1.9.3)' do
-    before do
-      skip if Rollbar::LanguageSupport.ruby_19?
-    end
-
+  context 'having timeout issues' do
     let(:exception_class) do
       Rollbar::LanguageSupport.timeout_exceptions.first
     end


### PR DESCRIPTION
## Description of the change
Removes support for Ruby 1.9.3. Change is prompted by Ruby < 2.0.0 relying on an insecure version of JSON.

Ruby 1.9.3 was EOL in 2015.

> Description here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
Fixes:  ch71976

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
