### PR TITLE
Remove deprecated URI.escape

### DIFF
--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -67,10 +67,7 @@ module Rollbar
 
         params = decode_www_form(query)
 
-        encoded_query = encode_www_form(filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist))
-
-        # We want this to rebuild array params like foo[]=1&foo[]=2
-        URI.escape(CGI.unescape(encoded_query))
+        encode_www_form(filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist))
       end
 
       def decode_www_form(query)
@@ -78,7 +75,15 @@ module Rollbar
       end
 
       def encode_www_form(params)
-        URI.encode_www_form(params)
+        restore_square_brackets(URI.encode_www_form(params))
+      end
+
+      def restore_square_brackets(query)
+        # We want this to rebuild array params like foo[]=1&foo[]=2
+        #
+        # URI.encode_www_form follows the spec at https://url.spec.whatwg.org/#concept-urlencoded-serializer
+        # and percent encodes square brackets. Here we change them back.
+        query.gsub('%5B', '[').gsub('%5D', ']')
       end
 
       def filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist)


### PR DESCRIPTION
## Description of the change

Removes the deprecated `URI.escape`, which has been deprecated for a long time, but the warnings are now more visible in Ruby 2.7.

The previous code had ended up performing several transforms in order to unencode square brackets while keeping everything else correctly encoded. Condensed, it was effectively like this:
`URI.escape(CGI.unescape(URI.encode_www_form(params)))`

This is all necessary because `URI.encode_www_form` percent encodes square brackets, but we want them unencoded.

This PR refactors and takes a simpler approach. As a side note, the debate about whether unencoded brackets should be allowed in URLs is not as relevant here since these are only used as debugging data in Rollbar payloads. They aren't being used to perform actual http requests.

The original URL may or may not have been percent encoded. The previous code didn't preserve the original state, and neither does this PR. The unencoded brackets are more readable, and is what everyone has been expecting and getting in their Rollbar dashboard, so we keep it that way.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/989
ch71576

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
