### PR TITLE
Properly handle method_missing in `Rollbar::LazyStore`

### DIFF
--- a/lib/rollbar/lazy_store.rb
+++ b/lib/rollbar/lazy_store.rb
@@ -41,8 +41,6 @@ module Rollbar
       raw[key] = value
 
       loaded_data.delete(key)
-
-      value
     end
 
     def data
@@ -76,8 +74,8 @@ module Rollbar
       super
     end
 
-    def respond_to?(method_sym)
-      super || raw.respond_to?(method_sym)
+    def respond_to_missing?(method_sym, include_all)
+      raw.respond_to?(method_sym, include_all)
     end
   end
 end

--- a/spec/rollbar/lazy_store_spec.rb
+++ b/spec/rollbar/lazy_store_spec.rb
@@ -95,4 +95,19 @@ describe Rollbar::LazyStore do
       expect(new_scope.raw).to be_eql(subject.raw)
     end
   end
+
+  describe '#respond_to_missing?' do
+    it 'forwards methods existing on :raw to :raw' do
+      expect(subject.respond_to?(:store)).to be(true)
+      expect { subject.method(:store) }.not_to raise_error
+
+      expect(data).to receive(:store).with(:foo, :bar)
+      subject.store(:foo, :bar)
+    end
+
+    it 'does not have methods that do not exist on raw' do
+      expect(subject.respond_to?(:baz)).to be(false)
+      expect { subject.baz }.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
## Description of the change

Right now we have 
>pry(main)> options.dig(:scope, :request)
>(pry):23: warning: #<Rollbar::LazyStore:0x0000000010b13ba8>.respond_to?(:dig) uses the deprecated method signature, which takes one parameter
>pry(main)> options.fetch(:scope).method(:dig)
>NameError: undefined method `dig' for class `#<Class:#<Rollbar::LazyStore:0x0000000010b13ba8>>'

in `suppress_exception?`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
