### PR TITLE
Define/init all configuration accessors

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -85,8 +85,10 @@ module Rollbar
     DEFAULT_WEB_BASE = 'https://rollbar.com'.freeze
 
     def initialize
+      @access_token = nil
       @async_handler = nil
       @before_process = []
+      @branch = nil
       @capture_uncaught = nil
       @code_version = nil
       @custom_data_method = nil
@@ -110,6 +112,7 @@ module Rollbar
       @failover_handlers = []
       @framework = 'Plain'
       @ignored_person_ids = []
+      @host = nil
       @payload_options = {}
       @person_method = 'current_user'
       @person_id_method = 'id'
@@ -121,6 +124,7 @@ module Rollbar
       @open_timeout = 3
       @request_timeout = 3
       @net_retries = 3
+      @root = nil
       @js_enabled = false
       @js_options = {}
       @locals = {}
@@ -150,6 +154,7 @@ module Rollbar
       @log_payload = false
       @collect_user_ip = true
       @anonymize_user_ip = false
+      @user_ip_obfuscator_secret = nil
       @backtrace_cleaner = nil
       @hooks = {
         :on_error_response => nil, # params: response
@@ -157,6 +162,7 @@ module Rollbar
       }
 
       @write_to_file = false
+      @filepath = nil
       @files_with_pid_name_enabled = false
       @files_processed_enabled = false
       @files_processed_duration = 60

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -8,14 +8,16 @@ describe Rollbar::Notifier do
       { 'foo' => 'bar' }
     end
     let(:new_config) do
-      { 'environment' => 'foo' }
+      { 'access_token' => 'abc', 'environment' => 'foo' }
     end
 
     it 'creates a new notifier with merged scope and configuration' do
       new_notifier = subject.scope(new_scope, new_config)
 
       expect(new_notifier).not_to be(subject)
+      expect(subject.configuration.access_token).to be_eql(nil)
       expect(subject.configuration.environment).to be_eql(nil)
+      expect(new_notifier.configuration.access_token).to be_eql('abc')
       expect(new_notifier.configuration.environment).to be_eql('foo')
       expect(new_notifier.scope_object['foo']).to be_eql('bar')
       expect(new_notifier.configuration).not_to be(subject.configuration)


### PR DESCRIPTION
## Description of the change

This PR adds instance variable initialization for `access_token` as well as for several other accessor properties.

The original report noted that:
```
config = { access_token: 'token' }

Rollbar.scoped(options, config) do
  Rollbar.log()
end
```
fails to pick up the new access_token value.

Root cause is that the merge operation on the Configuration class instantiates a new instance, and _only copies to currently defined instance variables in the new instance_. https://github.com/rollbar/rollbar-gem/blob/v3.0.0/lib/rollbar/configuration.rb#L186-L202

The `access_token` property is defined using `attr_accessor` but is not assigned a default value in the constructor. `attr_accessor` properties do not create an instance variable until the first time they are written or set. Because `access_token` was not set with a default value in the constructor, it is skipped during the merge operation.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

fixes ch74091

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
