### PR TITLE
Rubocop set version, and rename Naming/MethodParameterName

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,7 +51,7 @@ Style/Documentation:
   # As is, we currently add :nodoc: if anything at all.
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   # It's possible to configure this cop to allow just about anything, but what's the point.
   # The default min length of a param name is 3, but the the default whitelist includes things
   # like `db` and `io`. So, short names really can be useful.

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque', '< 2.0.0'
-gem 'rubocop', :require => false
+gem 'rubocop', '~> 0.93.0', :require => false
 gem 'rubocop-performance', :require => false
 gem 'sinatra'
 gem 'webmock', :require => false


### PR DESCRIPTION
## Description of the change

Updates a Rubocop rule name that changed recently and locks Rubocop's minor version in development builds.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/pull/998

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
