### PR TITLE
Restore the option to put the token in the payload if needed

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -75,6 +75,7 @@ module Rollbar
     attr_accessor :files_processed_enabled
     attr_accessor :files_processed_duration # seconds
     attr_accessor :files_processed_size # bytes
+    attr_accessor :use_payload_access_token
 
     attr_reader :project_gem_paths
     attr_accessor :configured_options
@@ -167,6 +168,7 @@ module Rollbar
       @files_processed_enabled = false
       @files_processed_duration = 60
       @files_processed_size = 5 * 1000 * 1000
+      @use_payload_access_token = false
 
       @configured_options = ConfiguredOptions.new(self)
     end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -640,7 +640,11 @@ module Rollbar
       request = Net::HTTP::Post.new(uri.request_uri)
 
       request.body = pack_ruby260_bytes(body)
-      request.add_field('X-Rollbar-Access-Token', access_token)
+
+      # Ensure the payload token will be used if the option is set.
+      unless (configuration.use_payload_access_token)
+        request.add_field('X-Rollbar-Access-Token', access_token)
+      end
 
       handle_net_retries { http.request(request) }
     end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -43,6 +43,21 @@ describe Rollbar::Item do
   describe '#build' do
     let(:payload) { subject.build }
 
+    context 'when use_payload_access_token is set' do
+      let(:configuration) do
+        Rollbar.configure do |c|
+          c.enabled = true
+          c.access_token = 'footoken'
+          c.use_payload_access_token = true
+        end
+        Rollbar.configuration
+      end
+
+      it 'adds token to payload' do
+        payload['access_token'].should == 'footoken'
+      end
+    end
+
     context 'a basic payload' do
       let(:extra) { {:key => 'value', :hash => {:inner_key => 'inner_value'}} }
 


### PR DESCRIPTION
## Description of the change

### Background

In the specific issue report, the access token is changed dynamically in the config in order to send reports to multiple Rollbar projects. An async/delayed sender is used, which doesn't have the dynamically updated config. Therefore all reports are sent using the access token in the delayed sender config.

The above scenario used to work because the token was added to the payload before queuing. Recent versions of rollbar-gem don't add the token to the payload and only add it as an http request header. (See https://github.com/rollbar/rollbar-gem/pull/966) The header is added by the delayed sender process, which uses the access token in its config.

The current interface for async senders only passes the payload and no other arguments, and the sender process doesn't have access to any other context. Even if this could be augmented in a back compatible way for the built-in senders, custom senders would still be affected by this.

### Solution

An option (`config.use_payload_access_token = true`) is added to use the payload instead of the http header for the access token. The http header is specifically omitted in this case, to ensure the Rollbar API uses the intended token when they differ. When the config option is set, the token is sent in the payload regardless of whether the report is async or not.

This can be deprecated and removed on a future major release where an improved interface for async jobs is available. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch74796

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
