### PR TITLE
Avoid warning by not requiring 'rollbar/notifier' from 'item/locals'

### DIFF
--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -1,4 +1,3 @@
-require 'rollbar/notifier'
 require 'rollbar/scrubbers/params'
 require 'rollbar/util'
 


### PR DESCRIPTION
## Description of the change

Ruby shows messages like: "warning: loading in progress, circular
require considered harmful" when using the gem.

The problem appears because of the following requiring call chain:

1. lib/rollbar.rb#L19: `require 'rollbar/notifier'`
2. lib/rollbar/notifier.rb#L10: `require 'rollbar/item'`
3. lib/rollbar/item.rb#L10: `require 'rollbar/item/backtrace'`
4. lib/rollbar/item/backtrace.rb#L1: `require 'rollbar/item/frame'`
5. lib/rollbar/item/frame.rb#L3: `require 'rollbar/item/locals'`
6. lib/rollbar/item/locals.rb#L1: `require 'rollbar/notifier'`

As you can see, the circular dependency is happening between notifier
<> item/locals.

By removing `require 'rollbar/notifier'` the messages go away.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix #946  

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
