### PR TITLE
Remove skipping CSP nonce on `unsafe-inline`

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -183,7 +183,6 @@ module Rollbar
         req.respond_to?(:content_security_policy) &&
           req.content_security_policy &&
           req.content_security_policy.directives['script-src'] &&
-          !req.content_security_policy.directives['script-src'].include?("'unsafe-inline'") &&
           req.content_security_policy_nonce
       end
 
@@ -224,15 +223,11 @@ module Rollbar
         end
 
         def csp_needs_nonce?(csp)
-          !opt_out?(csp) && !unsafe_inline?(csp)
+          !opt_out?(csp)
         end
 
         def opt_out?(_csp)
           raise NotImplementedError
-        end
-
-        def unsafe_inline?(csp)
-          csp[:script_src].to_a.include?("'unsafe-inline'")
         end
       end
 

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -17,20 +17,6 @@ shared_examples 'secure_headers' do
     expect(new_body).to include(snippet)
   end
 
-  it 'renders the snippet in the response without nonce if SecureHeaders script_src includes \'unsafe-inline\'' do
-    SecureHeadersMocks::CSP.config = {
-      :opt_out? => false,
-      :script_src => %w['unsafe-inline'] # rubocop:disable Lint/PercentStringArray
-    }
-
-    _, _, response = subject.call(env)
-    new_body = response.body.join
-
-    expect(new_body).to include('<script type="text/javascript">')
-    expect(new_body).to include("var _rollbarConfig = #{json_options};")
-    expect(new_body).to include(snippet)
-  end
-
   it 'renders the snippet in the response without nonce if SecureHeaders CSP is OptOut' do
     SecureHeadersMocks::CSP.config = {
       :opt_out? => true

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -31,8 +31,6 @@ describe ApplicationController, :type => 'request' do
         nonce_present
       elsif mode == :script_src_not_present
         script_src_not_present
-      elsif mode == :unsafe_inline
-        unsafe_inline
       else
         raise 'Unknown CSP mode'
       end
@@ -50,14 +48,6 @@ describe ApplicationController, :type => 'request' do
       Rails.application.config.content_security_policy do |policy|
         policy.default_src :self, :https
         policy.script_src nil
-      end
-    end
-
-    def unsafe_inline
-      # Browser behavior is undefined when unsafe_inline and the nonce are both present.
-      # The app should never set both, but if they do, our best behavior is to not use the nonce.
-      Rails.application.config.content_security_policy do |policy|
-        policy.script_src :self, :unsafe_inline
       end
     end
 
@@ -107,20 +97,7 @@ describe ApplicationController, :type => 'request' do
       include_examples 'adds the snippet'
     end
 
-    context 'when unsafe_inline is present' do
-      let(:nonce_mode) { :unsafe_inline }
-
-      it 'renders the snippet and config in the response with nonce in script tag' do
-        get '/test_rollbar_js'
-
-        expect(response.body).to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to include '<script type="text/javascript">'
-      end
-
-      include_examples 'adds the snippet'
-    end
-
-    context 'when scp nonce is present' do
+    context 'when CSP nonce is present' do
       let(:nonce_mode) { :nonce_present }
 
       it 'renders the snippet and config in the response with nonce in script tag' do


### PR DESCRIPTION
# Description of the change
The current implementation for Rails's CSP nonce functionality
intentionally skips adding a nonce to the script tag if the script-src
directive includes `unsafe-inline`. However, using both a nonce and
unsafe-inline at the same time is perfectly valid (and indeed sensible)
behaviour. It allows the app to maintain some level of backwards
compatibility with browsers that support CSP1 but not CSP2, c.f.:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #1009.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
