### PR TITLE
Add test for lambda in exception_level_filters

### DIFF
--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -854,6 +854,20 @@ describe Rollbar do
         Rollbar.error(exception, :use_exception_level_filters => true)
       end
 
+      it 'sets error level using lambda' do
+        Rollbar.configure do |config|
+          config.exception_level_filters = {
+            'NameError' => lambda { |error| 'info' }
+          }
+        end
+
+        logger_mock.should_receive(:info)
+        logger_mock.should_not_receive(:warn)
+        logger_mock.should_not_receive(:error)
+
+        Rollbar.error(exception, :use_exception_level_filters => true)
+      end
+
       context 'using :use_exception_level_filters option as false' do
         it 'sends the correct filtered level' do
           Rollbar.configure do |config|


### PR DESCRIPTION
## Description of the change

I saw no existing tests for setting a new error level using `config.exception_level_filters`, nor any that pass a proc/lambda.

This PR adds a simple test to exercise both cases.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Test

## Related issues

https://github.com/rollbar/rollbar-gem/issues/763

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
