### PR TITLE
Preserve first-added token when using payload tokens

### DIFF
--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -173,7 +173,7 @@ module Rollbar
       # Until the delayed sender interface is changed to allow passing dynamic config options,
       # this workaround allows the main process to set the token by adding it to the payload.
       if (configuration && configuration.use_payload_access_token)
-        payload['access_token'] = configuration.access_token
+        payload['access_token'] ||= configuration.access_token
       end
 
       payload

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -713,6 +713,43 @@ describe Rollbar::Item do
 
   end # end #build
 
+  describe '#build_with' do
+    context 'when use_payload_access_token is set' do
+      let(:configuration) do
+        Rollbar.configure do |c|
+          c.enabled = true
+          c.access_token = 'new-token'
+          c.use_payload_access_token = true
+        end
+        Rollbar.configuration
+      end
+
+      context 'when no token is in payload' do
+        it 'adds token to payload' do
+          item = described_class.build_with(
+            { 'foo' => 'bar' },
+            { :configuration => configuration }
+          )
+          payload = item.payload
+
+          expect(payload['access_token']).to be_eql('new-token')
+        end
+      end
+
+      context 'when token is in payload' do
+        it 'preserves original token' do
+          item = described_class.build_with(
+            { 'foo' => 'bar', 'access_token' => 'original-token' },
+            { :configuration => configuration }
+          )
+          payload = item.payload
+
+          expect(payload['access_token']).to be_eql('original-token')
+        end
+      end
+    end
+  end
+
   describe '#dump' do
     context 'with recursing instance in payload and ActiveSupport is enabled' do
       class Recurse


### PR DESCRIPTION
## Description of the change

When adding the access_token to the payload (via `config.use_payload_access_token`), the item constructor should honor the first token added and not allow it to be overwritten when the payload is later passed to `Item.build_with()`.

Related: https://github.com/rollbar/rollbar-gem/pull/1004

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: ch76024

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
