### PR TITLE
Use #prepend over #alias_method for Thread plugin

### DIFF
--- a/lib/rollbar/plugins/thread.rb
+++ b/lib/rollbar/plugins/thread.rb
@@ -1,13 +1,14 @@
 Rollbar.plugins.define('thread') do
-  execute do
-    Thread.class_eval do
-      def initialize_with_rollbar(*args, &block)
+  module Rollbar
+    module ThreadPlugin
+      def initialize(*args)
         self[:_rollbar_notifier] ||= Rollbar.notifier.scope
-        initialize_without_rollbar(*args, &block)
+        super
       end
-
-      alias_method :initialize_without_rollbar, :initialize
-      alias_method :initialize, :initialize_with_rollbar
     end
+  end
+
+  execute do
+    Thread.send(:prepend, Rollbar::ThreadPlugin) # rubocop:disable Lint/SendWithMixinArgument
   end
 end

--- a/spec/rollbar/plugins/thread_spec.rb
+++ b/spec/rollbar/plugins/thread_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+Rollbar.plugins.load!
+
+describe Rollbar::ThreadPlugin do
+  subject(:thread) { Thread.new {} }
+
+  it 'has a Rollbar notifier' do
+    expect(thread[:_rollbar_notifier]).to be_a_kind_of(Rollbar::Notifier)
+  end
+end


### PR DESCRIPTION
## Description of the change

> The `Thread` plugin uses `alias_method` rewrites to patch `Thread` behavior. This is destructive and doesn't play well with other patches (particularly from other libraries.) Instead, use `prepend` which non-destructively patches.

> While `alias_method` was previously necessary for Ruby < 2.0 support, with that version support being dropped, `prepend` should be preferred.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

(None)

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
