### PR TITLE
Handle request URLs that include non-ASCII characters

### DIFF
--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -112,6 +112,26 @@ describe Rollbar::Scrubbers::URL do
         end
       end
 
+      context 'with non-ASCII UTF-8 encoded URL' do
+        let(:url) { 'http://foo.com/some-path?foo=あああ'.force_encoding(Encoding::UTF_8) }
+        before { reconfigure_notifier }
+
+        it 'returns the URI encoded url' do
+          expected_url = 'http://foo.com/some-path?foo=%E3%81%82%E3%81%82%E3%81%82'
+          expect(subject.call(options)).to match(expected_url)
+        end
+      end
+
+      context 'with non-ASCII ASCII-8BIT encoded URL' do
+        let(:url) { 'http://foo.com/some-path?foo=あああ'.force_encoding(Encoding::ASCII_8BIT) }
+        before { reconfigure_notifier }
+
+        it 'returns the URI encoded url' do
+          expected_url = 'http://foo.com/some-path?foo=%E3%81%82%E3%81%82%E3%81%82'
+          expect(subject.call(options)).to match(expected_url)
+        end
+      end
+
       context 'with URL with spaces and arrays' do
         let(:url) do
           'https://server.com/api/v1/assignments/4430038?user_id=1&assignable_id=2&starts_at=Wed%20Jul%2013%202016%2000%3A00%3A00%20GMT-0700%20(PDT)&ends_at=Fri%20Jul%2029%202016%2000%3A00%3A00%20GMT-0700%20(PDT)&allocation_mode=hours_per_day&percent=&fixed_hours=&hours_per_day=0&auth=REMOVED&___uidh=2228207862&password[]=mypassword'


### PR DESCRIPTION
## Description of the change

In some cases, form data sent as a query string (or converted later) may be unencoded before the request URL is sent to the scrubber. If this data contains non-ASCII characters, `URI.parse()` will fail with `URI::InvalidURIError: URI must be ascii only`.

This PR checks for any non-ASCII characters and URL encodes them.

### Notes

The reported case involves Rails generated forms sent as query params that include the Rails "checkmark", `utf8=✓`. This would be fine if URL encoded, and I'm sure it is encoded over the wire. But in some cases, it gets decoded after received and before the scrubber sees it.

Other than the `utf8=✓`, any other non-ASCII characters will also repro the issue if not encoded. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

fixes: https://github.com/rollbar/rollbar-gem/issues/1017
ch78009

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
