### PR TITLE
Update for Ruby 3.0 and Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,23 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby-version: [2.2.10, 2.3.0, 2.3.8, 2.4.5, 2.5.3, 2.6.0, 2.7.2]
+        ruby-version: [2.2.10, 2.3.0, 2.3.8, 2.4.5, 2.5.3, 2.6.0, 2.6.6, 2.7.2]
         gemfile:
           - gemfiles/rails42.gemfile
           - gemfiles/rails50.gemfile
           - gemfiles/rails51.gemfile
           - gemfiles/rails52.gemfile
           - gemfiles/rails60.gemfile
+          - gemfiles/rails61.gemfile
         exclude:
           - gemfile: gemfiles/rails42.gemfile
             ruby-version: 2.7.2
           - gemfile: gemfiles/rails42.gemfile
             ruby-version: 2.6.0
+          - gemfile: gemfiles/rails42.gemfile
+            ruby-version: 2.6.6
+          - gemfile: gemfiles/rails42.gemfile
+            ruby-version: 2.7.2
           - gemfile: gemfiles/rails52.gemfile
             ruby-version: 2.2.10
           - gemfile: gemfiles/rails60.gemfile
@@ -32,6 +37,14 @@ jobs:
           - gemfile: gemfiles/rails60.gemfile
             ruby-version: 2.3.8
           - gemfile: gemfiles/rails60.gemfile
+            ruby-version: 2.4.5
+          - gemfile: gemfiles/rails61.gemfile
+            ruby-version: 2.2.10
+          - gemfile: gemfiles/rails61.gemfile
+            ruby-version: 2.3.0
+          - gemfile: gemfiles/rails61.gemfile
+            ruby-version: 2.3.8
+          - gemfile: gemfiles/rails61.gemfile
             ruby-version: 2.4.5
         include:
           - gemfile: gemfiles/rails41.gemfile
@@ -54,6 +67,8 @@ jobs:
             ruby-version: 2.0.0
           - gemfile: gemfiles/rails30.gemfile
             ruby-version: 2.0.0
+          - gemfile: gemfiles/rails61.gemfile
+            ruby-version: 3.0.0
 
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -55,12 +55,12 @@ end
 
 gem 'aws-sdk-sqs'
 
-if GEMFILE_RAILS_VERSION < '5.2'
-  gem 'database_cleaner', '~> 1.8.4'
+if GEMFILE_RAILS_VERSION >= '5.2'
+  gem 'database_cleaner'
+elsif GEMFILE_RAILS_VERSION.between?('5.0', '5.2')
+  gem 'database_cleaner', '~> 1.8.4' # rubocop:disable Bundler/DuplicatedGem
 elsif GEMFILE_RAILS_VERSION < '5.0'
   gem 'database_cleaner', '~> 1.0.0' # rubocop:disable Bundler/DuplicatedGem
-else
-  gem 'database_cleaner' # rubocop:disable Bundler/DuplicatedGem
 end
 
 if GEMFILE_RAILS_VERSION < '6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,15 @@ unless is_jruby
 end
 
 gem 'aws-sdk-sqs'
-gem 'database_cleaner'
+
+if GEMFILE_RAILS_VERSION < '5.2'
+  gem 'database_cleaner', '~> 1.8.4'
+elsif GEMFILE_RAILS_VERSION < '5.0'
+  gem 'database_cleaner', '~> 1.0.0' # rubocop:disable Bundler/DuplicatedGem
+else
+  gem 'database_cleaner' # rubocop:disable Bundler/DuplicatedGem
+end
+
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'delayed_job', :require => false
 else

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
-GEMFILE_RAILS_VERSION = '5.2.2'.freeze
-
+GEMFILE_RAILS_VERSION = '6.1.1'.freeze
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
 gem 'jruby-openssl', :platform => :jruby
@@ -21,8 +20,7 @@ gem 'rake'
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'rspec-rails', '~> 3.4'
 else
-  # TODO: update this when 4.x becomes available on Rubygems
-  gem 'rspec-rails', :git => 'https://github.com/rspec/rspec-rails', :ref => 'v4.0.0.beta2' # rubocop:disable Bundler/DuplicatedGem
+  gem 'rspec-rails', '~> 4.0.2' # rubocop:disable Bundler/DuplicatedGem
 end
 
 if GEMFILE_RAILS_VERSION < '6.0'
@@ -41,7 +39,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
 end
 
 gem 'capistrano', :require => false

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -25,7 +25,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
 end
 
 gem 'capistrano', :require => false

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -39,7 +39,7 @@ end
 
 # We need last sinatra that uses rack 2.1.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
-gem 'database_cleaner'
+gem 'database_cleaner', '~> 1.8.4'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -40,7 +40,7 @@ end
 # We need last sinatra that uses rack 2.1.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 
-gem 'database_cleaner'
+gem 'database_cleaner', '~> 1.8.4'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -25,7 +25,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
 end
 
 gem 'capistrano', :require => false

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -10,12 +10,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'rails', '6.0.2.1'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
-gem 'rspec-core', '~> 3.8.0'
-gem 'rspec-support', '~> 3.8.0'
-gem 'rspec-expectations', '~> 3.8.0'
-gem 'rspec-mocks', '~> 3.8.0'
-# TODO: update this when 4.x becomes available on Rubygems
-gem 'rspec-rails', :git => 'https://github.com/rspec/rspec-rails', :ref => 'v4.0.0.beta2' # rubocop:disable Bundler/DuplicatedGem
+gem 'rspec-rails', '~> 4.0.2'
 
 gem 'rake'
 
@@ -25,7 +20,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
 end
 
 gem 'sucker_punch', '~> 2.0'
@@ -35,7 +30,7 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'database_cleaner'
 gem 'codacy-coverage'
-gem 'delayed_job', '4.1.8.beta1', :require => false
+gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -6,14 +6,10 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '~> 5.2.3'
-gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
+gem 'rails', '6.1.1'
+gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
-gem 'rspec-core', '~> 3.8.0'
-gem 'rspec-rails', '~> 3.8.0'
-gem 'rspec-support', '~> 3.8.0'
-gem 'rspec-expectations', '~> 3.8.0'
-gem 'rspec-mocks', '~> 3.8.0'
+gem 'rspec-rails', '~> 4.0.2'
 
 gem 'rake'
 
@@ -33,12 +29,12 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
 gem 'database_cleaner'
 gem 'codacy-coverage'
-gem 'delayed_job', :require => false
+gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque'
-gem 'simplecov', '<= 0.17.1'
+gem 'simplecov'
 
 unless is_jruby
   # JRuby doesn't support fork, which is required for this test helper.

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -9,12 +9,12 @@ def wrap_process_args(*args)
 end
 
 def send_req(meth, path, args)
-  if args.is_a?(Array)
-    # Rails < 5.x will pass an array, which will splat into separate objects
-    send(meth, path, *args)
-  else
+  if !args.is_a?(Array)
     # Rails 5+ will send a hash, which will splat into keyword arguments
     send(meth, path, **args)
+  else
+    # Rails < 5.x will pass an array, which will splat into separate objects
+    send(meth, path, *args)
   end
 end
 
@@ -339,12 +339,11 @@ describe HomeController do
 
         expect(frames[-1][:locals]).to be_eql(locals[0])
 
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
-          expect(frames[-2][:method]).to be_eql('tap')
-          expect(frames[-2][:locals]).to be_eql(locals[1])
-        else
-          expect(frames[-2][:method]).to be_eql('tap')
+        expect(frames[-2][:method]).to be_eql('tap')
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
           expect(frames[-2][:locals]).to be_nil
+        else
+          expect(frames[-2][:locals]).to be_eql(locals[1])
         end
 
         expect(frames[-3][:locals]).to be_eql(locals[2])

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -338,7 +338,15 @@ describe HomeController do
         frames = Rollbar.last_report[:body][:trace][:frames]
 
         expect(frames[-1][:locals]).to be_eql(locals[0])
-        expect(frames[-2][:locals]).to be_eql(locals[1])
+
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
+          expect(frames[-2][:method]).to be_eql('tap')
+          expect(frames[-2][:locals]).to be_eql(locals[1])
+        else
+          expect(frames[-2][:method]).to be_eql('tap')
+          expect(frames[-2][:locals]).to be_nil
+        end
+
         expect(frames[-3][:locals]).to be_eql(locals[2])
         expect(frames[-4][:locals]).to be_eql(locals[3])
         # Frames: -5, -6 are not app frames, and have different contents in

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,9 +2,19 @@ require 'spec_helper'
 
 def wrap_process_args(*args)
   if ::Gem::Version.new(::Rails.version) >= ::Gem::Version.new('5.0')
-    [{ :params => args[0], :headers => args[1] }]
+    { :params => args[0], :headers => args[1] }
   else
     args
+  end
+end
+
+def send_req(meth, path, args)
+  if args.is_a?(Array)
+    # Rails < 5.x will pass an array, which will splat into separate objects
+    send(meth, path, *args)
+  else
+    # Rails 5+ will send a hash, which will splat into keyword arguments
+    send(meth, path, **args)
   end
 end
 
@@ -200,7 +210,7 @@ describe HomeController do
         :secret_token => 'f6805fea1cae0fb79c5e63bbdcd12bc6'
       }
 
-      post '/report_exception', *wrap_process_args(params)
+      send_req(:post, '/report_exception', wrap_process_args(params))
 
       filtered = Rollbar.last_report[:request][:POST]
 
@@ -223,7 +233,7 @@ describe HomeController do
         :notpass => 'hidden'
       }
 
-      post '/report_exception', *wrap_process_args(params)
+      send_req(:post, '/report_exception', wrap_process_args(params))
 
       filtered = Rollbar.last_report[:request][:POST]
 
@@ -255,7 +265,7 @@ describe HomeController do
     it 'should raise a NameError and have PUT params in the reported exception' do
       logger_mock.should_receive(:info).with('[Rollbar] Success')
 
-      put '/report_exception', *wrap_process_args(:putparam => 'putval')
+      send_req(:put, '/report_exception', wrap_process_args(:putparam => 'putval'))
 
       Rollbar.last_report.should_not be_nil
       Rollbar.last_report[:request][:POST]['putparam'].should == 'putval'
@@ -265,7 +275,7 @@ describe HomeController do
       it 'reports the errors successfully' do
         logger_mock.should_receive(:info).with('[Rollbar] Success')
 
-        put '/deprecated_report_exception', *wrap_process_args(:putparam => 'putval')
+        send_req(:put, '/deprecated_report_exception', wrap_process_args(:putparam => 'putval'))
 
         Rollbar.last_report.should_not be_nil
         Rollbar.last_report[:request][:POST]['putparam'].should == 'putval'
@@ -277,7 +287,7 @@ describe HomeController do
       @request.env['HTTP_ACCEPT'] = 'application/json'
 
       params = { :jsonparam => 'jsonval' }.to_json
-      post '/report_exception', *wrap_process_args(params, 'CONTENT_TYPE' => 'application/json')
+      send_req(:post, '/report_exception', wrap_process_args(params, 'CONTENT_TYPE' => 'application/json'))
 
       Rollbar.last_report.should_not be_nil
       expect(Rollbar.last_report[:request][:body]).to be_eql(params)
@@ -424,7 +434,7 @@ describe HomeController do
         before { cookies[:session_id] = user.id }
 
         subject(:person_data) do
-          put '/report_exception', *wrap_process_args('foo' => 'bar')
+          send_req(:put, '/report_exception', wrap_process_args('foo' => 'bar'))
 
           Rollbar.last_report[:person]
         end
@@ -474,7 +484,9 @@ describe HomeController do
 
   context 'with routing errors', :type => :request do
     it 'raises a RoutingError exception' do
-      expect { get '/foo/bar', *wrap_process_args(:foo => :bar) }.to raise_exception(ActionController::RoutingError)
+      expect do
+        send_req(:get, '/foo/bar', wrap_process_args(:foo => :bar))
+      end.to raise_exception(ActionController::RoutingError)
 
       report = Rollbar.last_report
       expect(report[:request][:GET]['foo']).to be_eql('bar')
@@ -497,7 +509,9 @@ describe HomeController do
 
     context 'with a single upload' do
       it 'saves attachment data' do
-        expect { post '/file_upload', *wrap_process_args(:upload => file1) }.to raise_exception(NameError)
+        expect do
+          send_req(:post, '/file_upload', wrap_process_args(:upload => file1))
+        end.to raise_exception(NameError)
 
         upload_param = Rollbar.last_report[:request][:POST]['upload']
 
@@ -512,7 +526,9 @@ describe HomeController do
 
     context 'with multiple uploads', :type => :request do
       it 'saves attachment data for all uploads' do
-        expect { post '/file_upload', *wrap_process_args(:upload => [file1, file2]) }.to raise_exception(NameError)
+        expect do
+          send_req(:post, '/file_upload', wrap_process_args(:upload => [file1, file2]))
+        end.to raise_exception(NameError)
         sent_params = Rollbar.last_report[:request][:POST]['upload']
 
         expect(sent_params).to be_kind_of(Array)
@@ -544,7 +560,7 @@ describe HomeController do
 
     it 'parses the correct headers' do
       expect do
-        post '/cause_exception', *wrap_process_args(params, 'ACCEPT' => 'application/vnd.github.v3+json')
+        send_req(:post, '/cause_exception', wrap_process_args(params, 'ACCEPT' => 'application/vnd.github.v3+json'))
       end.to raise_exception(NameError)
 
       expect(Rollbar.last_report[:request][:POST]['foo']).to be_eql('bar')
@@ -565,7 +581,9 @@ describe HomeController do
     end
 
     it 'scrubs sensible data from URL' do
-      expect { get '/cause_exception', *wrap_process_args({ :password => 'my-secret-password' }, headers) }.to raise_exception(NameError)
+      expect do
+        send_req(:get, '/cause_exception', wrap_process_args({ :password => 'my-secret-password' }, headers))
+      end.to raise_exception(NameError)
 
       request_data = Rollbar.last_report[:request]
 

--- a/spec/dummyapp/config/storage.yml
+++ b/spec/dummyapp/config/storage.yml
@@ -1,0 +1,4 @@
+# This isn't used, but is expected to be present for Rails 6.x
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -118,12 +118,12 @@ describe Rollbar::Logger do
       logger = notifier.configuration.logger
       logdev = logger.instance_eval { @logdev }
 
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
-        expect(logdev.filename).to be_eql('/dev/null')
-      else
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
         # The Logger class no longer creates a LogDevice when the device is `File::NULL`
-        # https://github.com/ruby/ruby/commit/f3e12caa088cc893a54bc2810ff511e4c89b322b#diff-f19218661d07876c8e4201ff03633b36edfdb4b57dd396f87db7cfd992b3f676
+        # See: ruby/ruby@f3e12caa088cc893a54bc2810ff511e4c89b322b
         expect(logdev).to be_nil
+      else
+        expect(logdev.filename).to be_eql('/dev/null')
       end
     end
   end

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -118,7 +118,13 @@ describe Rollbar::Logger do
       logger = notifier.configuration.logger
       logdev = logger.instance_eval { @logdev }
 
-      expect(logdev.filename).to be_eql('/dev/null')
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
+        expect(logdev.filename).to be_eql('/dev/null')
+      else
+        # The Logger class no longer creates a LogDevice when the device is `File::NULL`
+        # https://github.com/ruby/ruby/commit/f3e12caa088cc893a54bc2810ff511e4c89b322b#diff-f19218661d07876c8e4201ff03633b36edfdb4b57dd396f87db7cfd992b3f676
+        expect(logdev).to be_nil
+      end
     end
   end
 end

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -273,12 +273,11 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
 
           expect(frames[-1][:locals]).to be_eql(locals[0])
 
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
-            expect(frames[-2][:method]).to be_eql('tap')
-            expect(frames[-2][:locals]).to be_eql(locals[1])
-          else
-            expect(frames[-2][:method]).to be_eql('tap')
+          expect(frames[-2][:method]).to be_eql('tap')
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
             expect(frames[-2][:locals]).to be_nil
+          else
+            expect(frames[-2][:locals]).to be_eql(locals[1])
           end
 
           expect(frames[-3][:locals]).to be_eql(locals[2])

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -272,7 +272,15 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
           frames = Rollbar.last_report[:body][:trace][:frames]
 
           expect(frames[-1][:locals]).to be_eql(locals[0])
-          expect(frames[-2][:locals]).to be_eql(locals[1])
+
+          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
+            expect(frames[-2][:method]).to be_eql('tap')
+            expect(frames[-2][:locals]).to be_eql(locals[1])
+          else
+            expect(frames[-2][:method]).to be_eql('tap')
+            expect(frames[-2][:locals]).to be_nil
+          end
+
           expect(frames[-3][:locals]).to be_eql(locals[2])
           expect(frames[-4][:locals]).to be_eql(locals[3])
           # Frames: -5, -6 are not app frames, and have different contents in


### PR DESCRIPTION
## Description of the change

Update RSpec, Gemfiles, and CI for Ruby 3.0 and Rails 6.1.

### Details
* Starting in Rails 5.x, `ActionDispatch::IntegrationTest` methods only accept keyword arguments (not a hash) for their optional parameters. However, Ruby 2.x would generously convert hashes to keyword args. Ruby 3.0 no longer does this, and the args must be passed as keyword args.
* Ruby 3.0 no longer creates a device instance for null loggers, and the test must expect a null device.
* Starting in Rails 6.1, ActiveStorage is enabled by default and will fail if a storage.yml isn't present. This has been added to the test app used by the RSpec tests.
* Ruby 3.0 stack frames are slightly changed from Ruby 2.x, and the tests for locals capture must take this difference into account.
* Some Gemfile dependencies needed updating.
* The test matrix has been expanded to include Ruby 3.0 and Rails 6.1. 

Note:
Ruby 3.0 enforces the new rules for positional arguments and keyword arguments:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Rails 5.x and Rails 6.0 are not compatible with this change. (The first thing that breaks in this CI is ActionDispatch.) Therefore the matrix for Ruby 3.x starts at Rails 6.1. 

Note:
The dependency `database_cleaner` started using the safe navigation operator in its latest version. The version for this gem is now pinned to safe versions for matrix builds that use Ruby < 2.3.0. This is unrelated to Ruby 3.0 or Rails 6.1 and just happened to come up while this PR was in progress.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (CI updates, doc updates, dependencies, etc.)

## Related issues

ch77439

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
