### PR TITLE
Don't rely on return value of ::GirlFriday::WorkQueue.immediate

### DIFF
--- a/spec/rollbar/delay/girl_friday_spec.rb
+++ b/spec/rollbar/delay/girl_friday_spec.rb
@@ -7,8 +7,7 @@ require 'rollbar/delay/girl_friday'
 
 describe Rollbar::Delay::GirlFriday do
   before do
-    queue_class = ::GirlFriday::WorkQueue.immediate!
-    allow(::Rollbar::Delay::GirlFriday).to receive(:queue_class).and_return(queue_class)
+    ::GirlFriday::WorkQueue.immediate!
   end
 
   describe '.call' do


### PR DESCRIPTION
## Description of the change

Note: The bug and the fix here are related to Ruby's implicit return. A Ruby method always returns whatever its last line evaluates to.

The CI break happens on Ruby 3.0.0 builds, and as will be explained, is caused by a change in `Module#alias_method`.
In Ruby < 3.x, `alias_method` returns the class object.
https://ruby-doc.org/core-2.7.1/Module.html#method-i-alias_method

Starting in Ruby 3.x, `alias_method` returns its first argument.
https://ruby-doc.org/core-3.0.0/Module.html#method-i-alias_method

So in Ruby 3.x:
```ruby
alias_method :orig_exit, :exit #=> :orig_exit
```

Our code doesn't directly use `alias_method`. It uses `GirlFriday::WorkQueue.immediate!` which does use `alias_method`.
```ruby
def self.immediate!
  alias_method :push, :push_immediately
  alias_method :<<, :push_immediately
end
```
https://github.com/mperham/girl_friday/blob/01c9e725bbba4d338d8dbda90f31ca40a83d3581/lib/girl_friday/work_queue.rb#L28-L31


Because of implicit return, this returned `GirlFriday::WorkQueue` until Ruby 3.0 where it now returns `:<<`.

### The fix

The original code used the return value to mock the code under test so it would use the modified class. This is unnecessary because `immediate!` modifies the global class object itself, not an instance of the class. The modified class will be used without needing the mock. (If the mock _were_ needed, you would use `GirlFriday::WorkQueue` directly, rather than taking the return from `immediate!`.)

### Notes

This error reproduces with some seed values for rspec and not with others. I was able to reproduce locally by using the seed value from the failing CI build. It also reproduces by isolating the girl_friday tests: `bundle exec rspec spec/rollbar/delay/girl_friday_spec.rb`

So we know that when the specs ran in some order the error was masked, but I don't have insight into what specifically masked the error. 


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

ch80862

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
