### PR TITLE
remove reseting notifier

### DIFF
--- a/lib/rollbar/middleware/rack/builder.rb
+++ b/lib/rollbar/middleware/rack/builder.rb
@@ -9,13 +9,11 @@ module Rollbar
         include RequestDataExtractor
 
         def call_with_rollbar(env)
-          Rollbar.reset_notifier!
-
           Rollbar.scoped(fetch_scope(env)) do
             begin
               call_without_rollbar(env)
-            rescue ::Exception => exception
-              report_exception_to_rollbar(env, exception)
+            rescue ::Exception => e
+              report_exception_to_rollbar(env, e)
               raise
             end
           end


### PR DESCRIPTION
rubocop autofix

## Description of the change
The issue is described here https://github.com/rollbar/rollbar-gem/issues/1033

I am not sure if it does not brake anything else, but since that reset was quite old and also tests are still passing - it should do the job.

> Description here
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
