### PR TITLE
Track latest rails dot releases for each minor version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
-GEMFILE_RAILS_VERSION = '6.1.1'.freeze
+GEMFILE_RAILS_VERSION = '~> 6.1.3'.freeze
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
 gem 'jruby-openssl', :platform => :jruby

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -7,7 +7,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 gem 'jruby-openssl', :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-gem 'rails', '3.0.20'
+gem 'rails', '~> 3.0.20'
 gem 'hitimes', '< 1.2.2'
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -10,7 +10,7 @@ gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
-gem 'rails', '3.1.12'
+gem 'rails', '~> 3.1.12'
 gem 'rspec-rails', '~> 3.4'
 gem 'rake', '< 11'
 

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -9,7 +9,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
-gem 'rails', '3.2.22'
+gem 'rails', '~> 3.2.22'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -9,7 +9,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
-gem 'rails', '4.0.13'
+gem 'rails', '~> 4.0.13'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -9,7 +9,7 @@ gem 'jruby-openssl', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
-gem 'rails', '4.1.12'
+gem 'rails', '~> 4.1.16'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -9,7 +9,7 @@ gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
-gem 'rails', '4.2.8'
+gem 'rails', '~> 4.2.11'
 gem 'rake'
 gem 'rspec-rails', '~> 3.4'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -7,7 +7,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '6.0.2.1'
+gem 'rails', '~> 6.0.2'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-rails', '~> 4.0.2'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -6,7 +6,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '6.1.1'
+gem 'rails', '~> 6.1.3'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-rails', '~> 4.0.2'


### PR DESCRIPTION
## Description of the change

This was motivated by the need to update to the Rails versions with the mimemagic update: https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/

However, these are just dot releases, and could have been picked up automatically if the CI gemfiles picked up the latest Rails dot release. 

This PR does exactly that by consistently using the `~>` specifier, allowing the latest dot release to be used for each minor version in the matrix. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore: CI

## Related issues

ch82293

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
