### PR TITLE
Don't use logger.error with capistrano 2

### DIFF
--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -30,6 +30,7 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
+gem 'rexml', '<= 3.2.4'
 gem 'sucker_punch', '~> 2.0'
 gem 'shoryuken'
 gem 'codacy-coverage'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -29,6 +29,7 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
+gem 'rexml', '<= 3.2.4'
 gem 'sucker_punch'
 gem 'shoryuken'
 gem 'codacy-coverage'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -31,6 +31,7 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
+gem 'rexml', '<= 3.2.4'
 gem 'sucker_punch', '~> 2.0'
 gem 'shoryuken'
 gem 'codacy-coverage'

--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -16,7 +16,9 @@ module Rollbar
             if result[:success] && (deploy_id = result[:data] && result[:data][:deploy_id])
               capistrano.set :rollbar_deploy_id, deploy_id
             else
-              log_error logger, 'Unable to report deploy to Rollbar' + (result[:message] ? ': ' + result[:message] : '')
+              message = format_message('Unable to report deploy to Rollbar',
+                                       result[:message])
+              log_error(logger, message)
             end
           end
         end
@@ -56,7 +58,9 @@ module Rollbar
               if result[:success]
                 logger.info 'Updated deploy status in Rollbar'
               else
-                log_error logger, 'Unable to update deploy status in Rollbar' + (result[:message] ? ': ' + result[:message] : '')
+                message = format_message('Unable to update deploy status in Rollbar',
+                                         result[:message])
+                log_error(logger, message)
               end
             end
           end
@@ -135,8 +139,13 @@ module Rollbar
         logger.debug result[:response_info] if result[:response_info]
       end
 
+      def format_message(*args)
+        args.compact.join(': ')
+      end
+
       def log_error(logger, message)
-        # Capistrano 2.x doesn't have the #error method, so we use #important if #error isn't present
+        # Capistrano 2.x doesn't have the #error method,
+        # so we use #important if #error isn't present
         if logger.respond_to?(:error)
           logger.error message
         elsif logger.respond_to?(:important)


### PR DESCRIPTION
## Description of the change

The Capistrano 2.x logger doesn't support the `logger.error` method. The best alternative is `logger.important` so this PR will detect and switch when needed.

Note: This incompatibility has been in rollbar-gem for years and not resolved. The inattention is likely due to the declining use of Capistrano 2 (last released 8 years ago) and the fact that this code path is only hit when there's some kind of deploy error. Other deploy notifications aren't affected. 

~Build break is due to needing the rexml dependency fix included in https://github.com/rollbar/rollbar-gem/pull/1041~ - This commit has now been cherry-picked to this PR.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1039
ch70999

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
