### PR TITLE
Rubocop: Bump version and apply safe autocorrect updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/vendor/**/*'
+  TargetRubyVersion: 2.5 # This is the minimum allowed for current rubocop
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
@@ -26,6 +27,10 @@ Style/Lambda:
   Enabled: false
 
 Style/EachWithObject:
+  Enabled: false
+
+Style/RedundantBegin:
+  # Ruby < 2.5 needs begin/end inside blocks when using rescue
   Enabled: false
 
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,8 +13,8 @@ Style/HashSyntax:
 Style/SymbolArray:
   Enabled: false # %i[] syntax isn't 1.9.x compatible
 
-Metrics/LineLength:
-  Max: 1000
+Layout/LineLength:
+  Max: 90
 
 Metrics/MethodLength:
   Max: 15 # Relax slightly from the default of 10

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,10 @@ Layout/HeredocIndentation:
   # or external packages that we don't want as dependencies.
   Enabled: false
 
+Lint/SendWithMixinArgument:
+  # Object#include is still a private method in Ruby 2.0.
+  Enabled: false
+
 Metrics/MethodLength:
   Max: 15 # Relax slightly from the default of 10
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ Style/SymbolArray:
 Layout/LineLength:
   Max: 90
 
+Layout/HeredocIndentation:
+  # When enabled, forces either squiggly syntax (not available until 2.3),
+  # or external packages that we don't want as dependencies.
+  Enabled: false
+
 Metrics/MethodLength:
   Max: 15 # Relax slightly from the default of 10
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,26 +20,26 @@ gem 'rake'
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'rspec-rails', '~> 3.4'
 else
-  gem 'rspec-rails', '~> 4.0.2' # rubocop:disable Bundler/DuplicatedGem
+  gem 'rspec-rails', '~> 4.0.2'
 end
 
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 else
-  gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw] # rubocop:disable Bundler/DuplicatedGem
+  gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 end
 
 if RUBY_VERSION < '2.2.2'
   gem 'sidekiq', '~> 2.13.0'
 else
-  gem 'sidekiq', '>= 2.13.0' # rubocop:disable Bundler/DuplicatedGem
+  gem 'sidekiq', '>= 2.13.0'
 end
 
 platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'capistrano', :require => false
@@ -66,7 +66,7 @@ end
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'delayed_job', :require => false
 else
-  gem 'delayed_job', '~> 4.1', :require => false # rubocop:disable Bundler/DuplicatedGem
+  gem 'delayed_job', '~> 4.1', :require => false
 end
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/Gemfile
+++ b/Gemfile
@@ -58,9 +58,9 @@ gem 'aws-sdk-sqs'
 if GEMFILE_RAILS_VERSION >= '5.2'
   gem 'database_cleaner'
 elsif GEMFILE_RAILS_VERSION.between?('5.0', '5.2')
-  gem 'database_cleaner', '~> 1.8.4' # rubocop:disable Bundler/DuplicatedGem
+  gem 'database_cleaner', '~> 1.8.4'
 elsif GEMFILE_RAILS_VERSION < '5.0'
-  gem 'database_cleaner', '~> 1.0.0' # rubocop:disable Bundler/DuplicatedGem
+  gem 'database_cleaner', '~> 1.0.0'
 end
 
 if GEMFILE_RAILS_VERSION < '6.0'
@@ -72,7 +72,7 @@ gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
 gem 'redis'
 gem 'resque', '< 2.0.0'
-gem 'rubocop', '~> 0.93.0', :require => false
+gem 'rubocop', '1.15.0', :require => false # pin specific version, update manually
 gem 'rubocop-performance', :require => false
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'sinatra'

--- a/gemfiles/rails30.gemfile
+++ b/gemfiles/rails30.gemfile
@@ -4,16 +4,16 @@ source 'https://rubygems.org'
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
-gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
-gem 'jruby-openssl', :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
-gem 'rails', '~> 3.0.20'
 gem 'hitimes', '< 1.2.2'
+gem 'jruby-openssl', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
+gem 'rails', '~> 3.0.20'
 gem 'rake', '< 11'
 gem 'rspec-rails', '>= 2.14.0'
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 if RUBY_VERSION < '2.2.2'
   gem 'sidekiq', '~> 2.13.0'
@@ -30,24 +30,24 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
-gem 'rexml', '<= 3.2.4'
-gem 'sucker_punch', '~> 2.0'
-gem 'shoryuken'
 gem 'codacy-coverage'
+gem 'rexml', '<= 3.2.4'
+gem 'shoryuken'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
-gem 'sinatra'
-gem 'delayed_job', :require => false
-gem 'redis', '<= 3.3.5'
-gem 'redis-namespace', '<= 1.5.0'
 gem 'database_cleaner', '~> 1.0.0'
+gem 'delayed_job', :require => false
 gem 'genspec', '>= 0.2.8'
 gem 'girl_friday', '>= 0.11.1'
+gem 'redis', '<= 3.3.5'
+gem 'redis-namespace', '<= 1.5.0'
 gem 'rspec-command'
+gem 'sinatra'
 
 gem 'webmock', :require => false
 
-gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
+gem 'resque', '< 2.0.0'
 
 gemspec :path => '../'

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -4,15 +4,15 @@ source 'https://rubygems.org'
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && 'jruby' == RUBY_ENGINE)
 
-gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
-gem 'jruby-openssl', :platform => :jruby
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
+gem 'jruby-openssl', :platform => :jruby
 gem 'mixlib-shellout', '<= 2.0.0'
 gem 'net-ssh', '<= 3.1.1'
 gem 'public_suffix', '<= 2.0.5'
 gem 'rails', '~> 3.1.12'
-gem 'rspec-rails', '~> 3.4'
 gem 'rake', '< 11'
+gem 'rspec-rails', '~> 3.4'
+gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 if RUBY_VERSION < '2.2.2'
   gem 'sidekiq', '~> 2.13.0'
@@ -29,25 +29,25 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
-gem 'rexml', '<= 3.2.4'
-gem 'sucker_punch'
-gem 'shoryuken'
 gem 'codacy-coverage'
+gem 'rexml', '<= 3.2.4'
+gem 'shoryuken'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch'
 
-gem 'sinatra'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
+gem 'generator_spec'
+gem 'girl_friday'
 gem 'rack-cache', '<= 1.9.0'
 gem 'redis', '<= 3.3.5'
 gem 'redis-namespace', '<= 1.5.0'
-gem 'database_cleaner'
-gem 'girl_friday'
-gem 'generator_spec'
 gem 'rspec-command'
+gem 'sinatra'
 
 gem 'webmock', :require => false
 
-gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
+gem 'resque', '< 2.0.0'
 
 gemspec :path => '../'

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -31,11 +31,11 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
-gem 'rexml', '<= 3.2.4'
-gem 'sucker_punch', '~> 2.0'
-gem 'shoryuken'
 gem 'codacy-coverage'
+gem 'rexml', '<= 3.2.4'
+gem 'shoryuken'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
 gem 'delayed_job', :require => false
 gem 'redis', '<= 3.3.5'
@@ -49,7 +49,7 @@ gem 'rspec-command'
 
 gem 'webmock', :require => false
 
-gem 'resque', '< 2.0.0'
 gem 'aws-sdk-sqs'
+gem 'resque', '< 2.0.0'
 
 gemspec :path => '../'

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -31,11 +31,11 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
-gem 'sucker_punch', '~> 2.0'
+gem 'codacy-coverage'
 gem 'json', '~> 2.0'
 gem 'shoryuken'
-gem 'codacy-coverage'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
 gem 'delayed_job', :require => false
 gem 'redis', '<= 3.3.5'

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -28,10 +28,10 @@ platforms :rbx do
 end
 
 gem 'capistrano', :require => false
-gem 'sucker_punch', '~> 2.0'
-gem 'shoryuken'
 gem 'codacy-coverage'
+gem 'shoryuken'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
 gem 'delayed_job', :require => false
 gem 'redis', '<= 3.3.5'
@@ -46,7 +46,7 @@ gem 'rspec-command'
 
 gem 'webmock', :require => false
 
-gem 'resque'
 gem 'aws-sdk-sqs'
+gem 'resque'
 
 gemspec :path => '../'

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -21,9 +21,7 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0' unless RUBY_VERSION.start_with?('1')
 end
 
-if RUBY_VERSION < '2.0.0'
-  gem 'json', '1.8.6'
-end
+gem 'json', '1.8.6' if RUBY_VERSION < '2.0.0'
 
 if RUBY_VERSION < '2.2.2'
   gem 'sidekiq', '~> 2.13.0'
@@ -38,17 +36,17 @@ gem 'database_cleaner', '~> 1.0.0'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'
-gem 'rspec-command'
 gem 'redis', '<= 3.3.5'
 gem 'resque'
+gem 'rspec-command'
 gem 'sinatra'
 
 gem 'nokogiri', '~> 1.6.0' if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0')
 
-gem 'sucker_punch', '~> 2.0'
-gem 'webmock', :require => false
 gem 'codacy-coverage'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
+gem 'webmock', :require => false
 
 gem 'aws-sdk-sqs'
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -12,10 +12,10 @@ gem 'rails', '~> 5.0.7'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.5.0.beta3'
-gem 'rspec-rails', '~> 3.5.0.beta3'
-gem 'rspec-support', '~> 3.5.0.beta3'
 gem 'rspec-expectations', '~> 3.5.0.beta3'
 gem 'rspec-mocks', '~> 3.5.0.beta3'
+gem 'rspec-rails', '~> 3.5.0.beta3'
+gem 'rspec-support', '~> 3.5.0.beta3'
 
 gem 'rake'
 
@@ -25,20 +25,17 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'capistrano', :require => false
-gem 'sucker_punch', '~> 2.0'
 gem 'codacy-coverage'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-  gem 'rack', '2.1.2'
-end
+gem 'rack', '2.1.2' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 
 # We need last sinatra that uses rack 2.1.x
-gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 gem 'database_cleaner', '~> 1.8.4'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
@@ -46,6 +43,7 @@ gem 'girl_friday', '>= 0.11.1'
 gem 'redis', '<= 3.3.5'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
+gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 
 unless is_jruby
   # JRuby doesn't support fork, which is required for this test helper.

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -12,10 +12,10 @@ gem 'rails', '~> 5.1.7'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.5.0.beta3'
-gem 'rspec-rails', '~> 3.5.0.beta3'
-gem 'rspec-support', '~> 3.5.0.beta3'
 gem 'rspec-expectations', '~> 3.5.0.beta3'
 gem 'rspec-mocks', '~> 3.5.0.beta3'
+gem 'rspec-rails', '~> 3.5.0.beta3'
+gem 'rspec-support', '~> 3.5.0.beta3'
 
 gem 'rake'
 
@@ -25,17 +25,15 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'capistrano', :require => false
-gem 'sucker_punch', '~> 2.0'
 gem 'codacy-coverage'
 gem 'simplecov', '<= 0.17.1'
+gem 'sucker_punch', '~> 2.0'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
-  gem 'rack', '2.1.2'
-end
+gem 'rack', '2.1.2' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 
 # We need last sinatra that uses rack 2.1.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -10,10 +10,10 @@ gem 'rails', '~> 5.2.3'
 gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-core', '~> 3.8.0'
-gem 'rspec-rails', '~> 3.8.0'
-gem 'rspec-support', '~> 3.8.0'
 gem 'rspec-expectations', '~> 3.8.0'
 gem 'rspec-mocks', '~> 3.8.0'
+gem 'rspec-rails', '~> 3.8.0'
+gem 'rspec-support', '~> 3.8.0'
 
 gem 'rake'
 
@@ -23,7 +23,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'sucker_punch', '~> 2.0'
@@ -31,8 +31,8 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
-gem 'database_cleaner'
 gem 'codacy-coverage'
+gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -1,4 +1,3 @@
-
 require 'rubygems/version'
 
 source 'https://rubygems.org'
@@ -20,7 +19,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'sucker_punch', '~> 2.0'
@@ -28,8 +27,8 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
-gem 'database_cleaner'
 gem 'codacy-coverage'
+gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -19,7 +19,7 @@ platforms :rbx do
   gem 'minitest'
   gem 'racc'
   gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2') # rubysl doesn't yet support Ruby 3.x
+  gem 'rubysl', '~> 2.0' if RUBY_VERSION.start_with?('2')
 end
 
 gem 'sucker_punch', '~> 2.0'
@@ -27,8 +27,8 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra'
 
-gem 'database_cleaner'
 gem 'codacy-coverage'
+gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
 gem 'girl_friday', '>= 0.11.1'

--- a/lib/generators/rollbar/rollbar_generator.rb
+++ b/lib/generators/rollbar/rollbar_generator.rb
@@ -5,7 +5,8 @@ require 'generators/rollbar/rollbar_generator'
 module Rollbar
   module Generators
     class RollbarGenerator < ::Rails::Generators::Base
-      argument :access_token, :type => :string, :banner => 'access_token', :default => :use_env_sentinel
+      argument :access_token, :type => :string, :banner => 'access_token',
+                              :default => :use_env_sentinel
 
       source_root File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
 
@@ -24,21 +25,20 @@ module Rollbar
 
         if defined? EY::Config
           say 'Access token will be read from Engine Yard configuration'
+        elsif access_token === :use_env_sentinel
+          say 'Generator run without an access token; assuming you want to configure using an environment variable.'
+          say "You'll need to add an environment variable ROLLBAR_ACCESS_TOKEN with your access token:"
+          say "\n$ export ROLLBAR_ACCESS_TOKEN=yourtokenhere"
+          say "\nIf that's not what you wanted to do:"
+          say "\n$ rm config/initializers/rollbar.rb"
+          say '$ rails generate rollbar yourtokenhere'
+          say "\n"
         else
-          if access_token === :use_env_sentinel
-            say 'Generator run without an access token; assuming you want to configure using an environment variable.'
-            say "You'll need to add an environment variable ROLLBAR_ACCESS_TOKEN with your access token:"
-            say "\n$ export ROLLBAR_ACCESS_TOKEN=yourtokenhere"
-            say "\nIf that's not what you wanted to do:"
-            say "\n$ rm config/initializers/rollbar.rb"
-            say '$ rails generate rollbar yourtokenhere'
-            say "\n"
-          else
-            say 'access token: ' << access_token
-          end
+          say 'access token: ' << access_token
         end
 
-        template 'initializer.rb', 'config/initializers/rollbar.rb', :assigns => { :access_token => access_token_expr }
+        template 'initializer.rb', 'config/initializers/rollbar.rb',
+                 :assigns => { :access_token => access_token_expr }
 
         # TODO: run rake test task
       end

--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -49,7 +49,7 @@ module Rails
     def legacy_runner
       string_to_eval = File.read(runner_path)
 
-      ::Rails.module_eval(<<-EOL, __FILE__, __LINE__ + 2)
+      ::Rails.module_eval(<<-EOL, __FILE__, __LINE__ + 1)
           #{string_to_eval}
       EOL
     end

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -31,8 +31,7 @@ module Rollbar
 
     def_delegators :notifier, *PUBLIC_NOTIFIER_METHODS
 
-    attr_writer :plugins
-    attr_writer :root_notifier
+    attr_writer :plugins, :root_notifier
 
     def notifier
       # Use the global instance @root_notifier so we don't fall

--- a/lib/rollbar/capistrano.rb
+++ b/lib/rollbar/capistrano.rb
@@ -34,7 +34,9 @@ module Rollbar
           _cset(:rollbar_role)  { :app }
           _cset(:rollbar_user)  { ENV['USER'] || ENV['USERNAME'] }
           _cset(:rollbar_env)   { fetch(:rails_env, 'production') }
-          _cset(:rollbar_token) { abort("Please specify the Rollbar access token, set :rollbar_token, 'your token'") }
+          _cset(:rollbar_token) do
+            abort("Please specify the Rollbar access token, set :rollbar_token, 'your token'")
+          end
           _cset(:rollbar_revision) { real_revision }
           _cset(:rollbar_comment) { nil }
         end
@@ -51,7 +53,8 @@ module Rollbar
           :task => :deploy_started,
           :configuration => configuration
         ) do
-          ::Rollbar::CapistranoTasks.deploy_started(configuration, configuration.logger, configuration.dry_run)
+          ::Rollbar::CapistranoTasks.deploy_started(configuration, configuration.logger,
+                                                    configuration.dry_run)
         end
       end
 
@@ -61,17 +64,16 @@ module Rollbar
           :task => :deploy_succeeded,
           :configuration => configuration
         ) do
-          ::Rollbar::CapistranoTasks.deploy_succeeded(configuration, configuration.logger, configuration.dry_run)
+          ::Rollbar::CapistranoTasks.deploy_succeeded(configuration,
+                                                      configuration.logger, configuration.dry_run)
         end
       end
 
-      def load_task(configuration:, desc:, task:)
+      def load_task(configuration:, desc:, task:, &block)
         configuration.load do
           namespace :rollbar do
             desc(desc)
-            task(task) do
-              yield
-            end
+            task(task, &block)
           end
         end
       end
@@ -79,4 +81,6 @@ module Rollbar
   end
 end
 
-Rollbar::Capistrano2.load_into(Capistrano::Configuration.instance) if Capistrano::Configuration.instance
+if Capistrano::Configuration.instance
+  Rollbar::Capistrano2.load_into(Capistrano::Configuration.instance)
+end

--- a/lib/rollbar/capistrano3.rb
+++ b/lib/rollbar/capistrano3.rb
@@ -8,7 +8,9 @@ require 'rollbar/capistrano_tasks'
 
 namespace :rollbar do
   # dry_run? wasn't introduced till Capistrano 3.5.0; use the old fetch(:sshkit_backed)
-  set :dry_run, (proc { ::Capistrano::Configuration.env.fetch(:sshkit_backend) == ::SSHKit::Backend::Printer })
+  set :dry_run, (proc {
+                   ::Capistrano::Configuration.env.fetch(:sshkit_backend) == ::SSHKit::Backend::Printer
+                 })
 
   desc 'Send deployment started notification to Rollbar.'
   task :deploy_started do
@@ -49,7 +51,9 @@ namespace :load do
   task :defaults do
     set :rollbar_user,      (proc { fetch :local_user, ENV['USER'] || ENV['USERNAME'] })
     set :rollbar_env,       (proc { fetch :rails_env, 'production' })
-    set :rollbar_token,     (proc { abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'" })
+    set :rollbar_token,     (proc {
+                               abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'"
+                             })
     set :rollbar_role,      (proc { :app })
     set :rollbar_revision,  (proc { fetch :current_revision })
   end

--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -25,13 +25,15 @@ module Rollbar
       end
 
       def deploy_succeeded(capistrano, logger, dry_run)
-        deploy_update(capistrano, logger, dry_run, :desc => 'Setting deployment status to `succeeded` in Rollbar') do
+        deploy_update(capistrano, logger, dry_run,
+                      :desc => 'Setting deployment status to `succeeded` in Rollbar') do
           report_deploy_succeeded(capistrano, dry_run)
         end
       end
 
       def deploy_failed(capistrano, logger, dry_run)
-        deploy_update(capistrano, logger, dry_run, :desc => 'Setting deployment status to `failed` in Rollbar') do
+        deploy_update(capistrano, logger, dry_run,
+                      :desc => 'Setting deployment status to `failed` in Rollbar') do
           report_deploy_failed(capistrano, dry_run)
         end
       end
@@ -42,7 +44,6 @@ module Rollbar
         capistrano_300_warning(logger)
         logger.info opts[:desc] if opts[:desc]
         yield
-
       rescue StandardError => e
         log_error logger, "Error reporting to Rollbar: #{e.inspect}"
       end
@@ -68,7 +69,9 @@ module Rollbar
       end
 
       def capistrano_300_warning(logger)
-        return unless ::Capistrano.const_defined?('VERSION') && ::Capistrano::VERSION =~ /^3\.0/
+        unless ::Capistrano.const_defined?('VERSION') && ::Capistrano::VERSION =~ /^3\.0/
+          return
+        end
 
         logger.warn('You need to upgrade capistrano to >= 3.1 version in order'\
           'to correctly report deploys to Rollbar. (On 3.0, the reported revision'\
@@ -121,7 +124,8 @@ module Rollbar
         if capistrano.fetch(:rollbar_deploy_id)
           yield
         else
-          log_error logger, 'Failed to update the deploy in Rollbar. No deploy id available.'
+          log_error logger,
+                    'Failed to update the deploy in Rollbar. No deploy id available.'
         end
       end
 

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -4,82 +4,11 @@ module Rollbar
   class Configuration
     SEND_EXTRA_FRAME_DATA_OPTIONS = [:none, :app, :all].freeze
 
-    attr_accessor :access_token
-    attr_accessor :async_handler
-    attr_accessor :branch
-    attr_reader :before_process
-    attr_accessor :capture_uncaught
-    attr_accessor :code_version
-    attr_accessor :custom_data_method
-    attr_accessor :delayed_job_enabled
-    attr_accessor :default_logger
-    attr_reader :logger_level
-    attr_accessor :disable_monkey_patch
-    attr_accessor :disable_rack_monkey_patch
-    attr_accessor :disable_core_monkey_patch
-    attr_accessor :enable_error_context
-    attr_accessor :dj_threshold
-    attr_accessor :async_skip_report_handler
-    attr_accessor :enabled
-    attr_accessor :endpoint
-    attr_accessor :environment
-    attr_accessor :exception_level_filters
-    attr_accessor :failover_handlers
-    attr_accessor :framework
-    attr_accessor :ignored_person_ids
-    attr_accessor :host
-    attr_accessor :locals
-    attr_writer :logger
-    attr_accessor :payload_options
-    attr_accessor :person_method
-    attr_accessor :person_id_method
-    attr_accessor :person_username_method
-    attr_accessor :person_email_method
-    attr_accessor :populate_empty_backtraces
-    attr_accessor :report_dj_data
-    attr_accessor :open_timeout
-    attr_accessor :request_timeout
-    attr_accessor :net_retries
-    attr_accessor :root
-    attr_accessor :js_options
-    attr_accessor :js_enabled
-    attr_accessor :safely
-    attr_accessor :scrub_fields
-    attr_accessor :scrub_user
-    attr_accessor :scrub_password
-    attr_accessor :scrub_whitelist
-    attr_accessor :collect_user_ip
-    attr_accessor :anonymize_user_ip
-    attr_accessor :user_ip_obfuscator_secret
-    attr_accessor :randomize_scrub_length
-    attr_accessor :uncaught_exception_level
-    attr_accessor :scrub_headers
-    attr_accessor :sidekiq_threshold
-    attr_accessor :sidekiq_use_scoped_block
-    attr_reader :transform
-    attr_accessor :verify_ssl_peer
-    attr_accessor :use_async
-    attr_accessor :async_json_payload
-    attr_reader :use_eventmachine
-    attr_accessor :web_base
-    attr_reader :send_extra_frame_data
-    attr_accessor :use_exception_level_filters_default
-    attr_accessor :proxy
-    attr_accessor :raise_on_error
-    attr_accessor :transmit
-    attr_accessor :log_payload
-    attr_accessor :backtrace_cleaner
-
-    attr_accessor :write_to_file
-    attr_accessor :filepath
-    attr_accessor :files_with_pid_name_enabled
-    attr_accessor :files_processed_enabled
-    attr_accessor :files_processed_duration # seconds
-    attr_accessor :files_processed_size # bytes
-    attr_accessor :use_payload_access_token
-
-    attr_reader :project_gem_paths
-    attr_accessor :configured_options
+    attr_accessor :access_token, :async_handler, :branch, :capture_uncaught,
+                  :code_version, :custom_data_method, :delayed_job_enabled, :default_logger, :disable_monkey_patch, :disable_rack_monkey_patch, :disable_core_monkey_patch, :enable_error_context, :dj_threshold, :async_skip_report_handler, :enabled, :endpoint, :environment, :exception_level_filters, :failover_handlers, :framework, :ignored_person_ids, :host, :locals, :payload_options, :person_method, :person_id_method, :person_username_method, :person_email_method, :populate_empty_backtraces, :report_dj_data, :open_timeout, :request_timeout, :net_retries, :root, :js_options, :js_enabled, :safely, :scrub_fields, :scrub_user, :scrub_password, :scrub_whitelist, :collect_user_ip, :anonymize_user_ip, :user_ip_obfuscator_secret, :randomize_scrub_length, :uncaught_exception_level, :scrub_headers, :sidekiq_threshold, :sidekiq_use_scoped_block, :verify_ssl_peer, :use_async, :async_json_payload, :web_base, :use_exception_level_filters_default, :proxy, :raise_on_error, :transmit, :log_payload, :backtrace_cleaner, :write_to_file, :filepath, :files_with_pid_name_enabled, :files_processed_enabled, :files_processed_duration, :files_processed_size, :use_payload_access_token, :configured_options
+    attr_reader :before_process, :logger_level, :transform, :use_eventmachine,
+                :send_extra_frame_data, :project_gem_paths
+    attr_writer :logger # seconds # bytes
 
     alias safely? safely
 
@@ -360,7 +289,10 @@ module Rollbar
       return super unless configuration.respond_to?(method)
 
       method_string = method.to_s
-      configured[method_string.chomp('=').to_sym] = args.first if method_string.end_with?('=')
+      if method_string.end_with?('=')
+        configured[method_string.chomp('=').to_sym] =
+          args.first
+      end
 
       configuration.send(method, *args, &block)
     end

--- a/lib/rollbar/delay/sidekiq.rb
+++ b/lib/rollbar/delay/sidekiq.rb
@@ -10,7 +10,10 @@ module Rollbar
       end
 
       def call(payload)
-        raise StandardError, 'Unable to push the job to Sidekiq' if ::Sidekiq::Client.push(@options.merge('args' => [payload])).nil?
+        if ::Sidekiq::Client.push(@options.merge('args' => [payload])).nil?
+          raise StandardError,
+                'Unable to push the job to Sidekiq'
+        end
       end
 
       include ::Sidekiq::Worker

--- a/lib/rollbar/delay/sucker_punch.rb
+++ b/lib/rollbar/delay/sucker_punch.rb
@@ -7,8 +7,7 @@ module Rollbar
       include ::SuckerPunch::Job
 
       class << self
-        attr_accessor :perform_proc
-        attr_accessor :ready
+        attr_accessor :perform_proc, :ready
       end
 
       self.ready = false

--- a/lib/rollbar/delay/thread.rb
+++ b/lib/rollbar/delay/thread.rb
@@ -62,11 +62,12 @@ module Rollbar
                 reaper.join
               end
             rescue Timeout::Error
-              raise TimeoutError, "unable to reap all threads within #{EXIT_TIMEOUT} seconds"
+              raise TimeoutError,
+                    "unable to reap all threads within #{EXIT_TIMEOUT} seconds"
             end
           end
         end
-      end # class << self
+      end
 
       def priority
         self.class.options[:priority] || DEFAULT_PRIORITY

--- a/lib/rollbar/encoding/encoder.rb
+++ b/lib/rollbar/encoding/encoder.rb
@@ -1,8 +1,10 @@
 module Rollbar
   module Encoding
     class Encoder
-      ALL_ENCODINGS = [::Encoding::UTF_8, ::Encoding::ISO_8859_1, ::Encoding::ASCII_8BIT, ::Encoding::US_ASCII].freeze
-      ASCII_ENCODINGS = [::Encoding::US_ASCII, ::Encoding::ASCII_8BIT, ::Encoding::ISO_8859_1].freeze
+      ALL_ENCODINGS = [::Encoding::UTF_8, ::Encoding::ISO_8859_1, ::Encoding::ASCII_8BIT,
+                       ::Encoding::US_ASCII].freeze
+      ASCII_ENCODINGS = [::Encoding::US_ASCII, ::Encoding::ASCII_8BIT,
+                         ::Encoding::ISO_8859_1].freeze
       UTF8 = 'UTF-8'.freeze
       BINARY = 'binary'.freeze
 
@@ -40,7 +42,9 @@ module Rollbar
       def force_encoding(value)
         return value if value.frozen?
 
-        value.force_encoding(detect_encoding(value)) if value.encoding == ::Encoding::UTF_8
+        if value.encoding == ::Encoding::UTF_8
+          value.force_encoding(detect_encoding(value))
+        end
 
         value
       end

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -29,7 +29,8 @@ module Rollbar
     end
 
     def exception_data(exception)
-      Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception, :use_exception_level_filters => true)
+      Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception,
+                  :use_exception_level_filters => true)
     end
   end
 end

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -23,17 +23,8 @@ module Rollbar
 
     attr_writer :payload
 
-    attr_reader :level
-    attr_reader :message
-    attr_reader :exception
-    attr_reader :extra
-
-    attr_reader :configuration
-    attr_reader :scope
-    attr_reader :logger
-    attr_reader :notifier
-
-    attr_reader :context
+    attr_reader :level, :message, :exception, :extra, :configuration, :scope, :logger,
+                :notifier, :context
 
     def_delegators :payload, :[]
 
@@ -64,7 +55,7 @@ module Rollbar
 
     def build
       data = build_data
-      self.payload = add_access_token_to_payload({'data' => data})
+      self.payload = add_access_token_to_payload({ 'data' => data })
 
       enforce_valid_utf8
       transform
@@ -86,9 +77,15 @@ module Rollbar
         },
         :body => build_body
       }
-      data[:project_package_paths] = configuration.project_gem_paths if configuration.project_gem_paths.any?
+      if configuration.project_gem_paths.any?
+        data[:project_package_paths] =
+          configuration.project_gem_paths
+      end
       data[:code_version] = configuration.code_version if configuration.code_version
-      data[:uuid] = SecureRandom.uuid if defined?(SecureRandom) && SecureRandom.respond_to?(:uuid)
+      if defined?(SecureRandom) && SecureRandom.respond_to?(:uuid)
+        data[:uuid] =
+          SecureRandom.uuid
+      end
 
       Util.deep_merge(data, configuration.payload_options)
       Util.deep_merge(data, scope)
@@ -130,7 +127,7 @@ module Rollbar
       nil
     end
 
-    def handle_too_large_payload(stringified_payload, final_payload, attempts)
+    def handle_too_large_payload(stringified_payload, _final_payload, attempts)
       uuid = stringified_payload['data']['uuid']
       host = stringified_payload['data'].fetch('server', {})['host']
 
@@ -172,7 +169,7 @@ module Rollbar
       #
       # Until the delayed sender interface is changed to allow passing dynamic config options,
       # this workaround allows the main process to set the token by adding it to the payload.
-      if (configuration && configuration.use_payload_access_token)
+      if configuration && configuration.use_payload_access_token
         payload['access_token'] ||= configuration.access_token
       end
 

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -3,11 +3,7 @@ require 'rollbar/item/frame'
 module Rollbar
   class Item
     class Backtrace
-      attr_reader :exception
-      attr_reader :message
-      attr_reader :extra
-      attr_reader :configuration
-      attr_reader :files
+      attr_reader :exception, :message, :extra, :configuration, :files
 
       private :files
 
@@ -100,7 +96,9 @@ module Rollbar
       # are those from the user's Rollbar.error line until this method. We want
       # to remove those lines.
       def exception_backtrace(current_exception)
-        return current_exception.backtrace if current_exception.backtrace.respond_to?(:map)
+        if current_exception.backtrace.respond_to?(:map)
+          return current_exception.backtrace
+        end
         return [] unless configuration.populate_empty_backtraces
 
         caller_backtrace = caller

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -6,9 +6,7 @@ module Rollbar
   class Item
     # Representation of the trace data per frame in the payload
     class Frame
-      attr_reader :backtrace
-      attr_reader :frame
-      attr_reader :configuration
+      attr_reader :backtrace, :frame, :configuration
 
       MAX_CONTEXT_LENGTH = 4
 
@@ -104,7 +102,8 @@ module Rollbar
 
       def post_data(file_lines, lineno)
         from_line = lineno
-        number_of_lines = [from_line + MAX_CONTEXT_LENGTH, file_lines.size].min - from_line
+        number_of_lines = [from_line + MAX_CONTEXT_LENGTH,
+                           file_lines.size].min - from_line
 
         file_lines[from_line, number_of_lines]
       end
@@ -113,7 +112,9 @@ module Rollbar
         to_line = lineno - 2
         from_line = [to_line - MAX_CONTEXT_LENGTH + 1, 0].max
 
-        file_lines[from_line, (to_line - from_line + 1)].select { |line| line && !line.empty? }
+        file_lines[from_line, (to_line - from_line + 1)].select do |line|
+          line && !line.empty?
+        end
       end
     end
   end

--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -58,7 +58,9 @@ module Rollbar
         # truncation strategy for large payloads.
         #
         def prepare_value(value)
-          return simple_value?(value) ? value : value.inspect unless value.is_a?(Hash) || value.is_a?(Array)
+          unless value.is_a?(Hash) || value.is_a?(Array)
+            return simple_value?(value) ? value : value.inspect
+          end
 
           cloned_value = ::Rollbar::Util.deep_copy(value)
           ::Rollbar::Util.iterate_and_update_with_block(cloned_value) do |v|

--- a/lib/rollbar/lazy_store.rb
+++ b/lib/rollbar/lazy_store.rb
@@ -1,9 +1,7 @@
 module Rollbar
   class LazyStore
-    attr_reader :loaded_data
+    attr_reader :loaded_data, :raw
     private :loaded_data
-
-    attr_reader :raw
 
     def initialize(initial_data)
       initial_data ||= {}

--- a/lib/rollbar/logger.rb
+++ b/lib/rollbar/logger.rb
@@ -16,7 +16,9 @@ module Rollbar
   # Rails.logger.extend(ActiveSupport::Logger.broadcast(Rollbar::Logger.new))
   class Logger < ::Logger
     class Error < RuntimeError; end
+
     class DatetimeFormatNotSupported < Error; end
+
     class FormatterNotSupported < Error; end
 
     def initialize

--- a/lib/rollbar/logger_proxy.rb
+++ b/lib/rollbar/logger_proxy.rb
@@ -23,7 +23,9 @@ module Rollbar
     end
 
     def log(level, message)
-      return unless Rollbar.configuration.enabled && acceptable_levels.include?(level.to_sym)
+      unless Rollbar.configuration.enabled && acceptable_levels.include?(level.to_sym)
+        return
+      end
 
       @object.send(level, message)
     rescue StandardError

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -10,11 +10,11 @@ module Rollbar
     class Js
       include Rollbar::RequestDataExtractor
 
-      attr_reader :app
-      attr_reader :config
+      attr_reader :app, :config
 
       JS_IS_INJECTED_KEY = 'rollbar.js_is_injected'.freeze
-      SNIPPET = File.read(File.expand_path('../../../../data/rollbar.snippet.js', __FILE__))
+      SNIPPET = File.read(File.expand_path('../../../../data/rollbar.snippet.js',
+                                           __FILE__))
 
       def initialize(app, config)
         @app = app
@@ -82,7 +82,10 @@ module Rollbar
         env[JS_IS_INJECTED_KEY] = true
 
         status, headers, = app_result
-        headers['Content-Length'] = response_string.bytesize.to_s if headers.key?('Content-Length')
+        if headers.key?('Content-Length')
+          headers['Content-Length'] =
+            response_string.bytesize.to_s
+        end
 
         response = ::Rack::Response.new(response_string, status, headers)
 

--- a/lib/rollbar/middleware/rack/builder.rb
+++ b/lib/rollbar/middleware/rack/builder.rb
@@ -14,8 +14,8 @@ module Rollbar
           Rollbar.scoped(fetch_scope(env)) do
             begin
               call_without_rollbar(env)
-            rescue ::Exception => exception
-              report_exception_to_rollbar(env, exception)
+            rescue ::Exception => e
+              report_exception_to_rollbar(env, e)
               raise
             end
           end

--- a/lib/rollbar/middleware/rack/test_session.rb
+++ b/lib/rollbar/middleware/rack/test_session.rb
@@ -6,9 +6,9 @@ module Rollbar
 
         def env_for_with_rollbar(path, env)
           env_for_without_rollbar(path, env)
-        rescue Exception => exception
-          report_exception_to_rollbar(env, exception)
-          raise exception
+        rescue Exception => e
+          report_exception_to_rollbar(env, e)
+          raise e
         end
 
         def self.included(base)

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -29,8 +29,8 @@ module Rollbar
               end
 
               response
-            rescue Exception => exception
-              report_exception_to_rollbar(env, exception)
+            rescue Exception => e
+              report_exception_to_rollbar(env, e)
               raise
             ensure
               Rollbar.notifier.disable_locals
@@ -63,7 +63,9 @@ module Rollbar
 
         def person_data_proc(env)
           block = proc { extract_person_data_from_controller(env) }
-          return block unless defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?
+          unless defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?
+            return block
+          end
 
           proc do
             begin
@@ -79,7 +81,9 @@ module Rollbar
 
           route_params = request_data[:params]
           # make sure route is a hash built by RequestDataExtractor
-          return route_params[:controller].to_s + '#' + route_params[:action].to_s if route_params.is_a?(Hash) && !route_params.empty?
+          if route_params.is_a?(Hash) && !route_params.empty?
+            route_params[:controller].to_s + '#' + route_params[:action].to_s
+          end
         end
       end
     end

--- a/lib/rollbar/middleware/rails/show_exceptions.rb
+++ b/lib/rollbar/middleware/rails/show_exceptions.rb
@@ -20,20 +20,22 @@ module Rollbar
 
         def call_with_rollbar(env)
           call_without_rollbar(env)
-        rescue ActionController::RoutingError => exception
+        rescue ActionController::RoutingError => e
           # won't reach here if show_detailed_exceptions is true
           scope = extract_scope_from(env)
 
           Rollbar.scoped(scope) do
-            report_exception_to_rollbar(env, exception)
+            report_exception_to_rollbar(env, e)
           end
 
-          raise exception
+          raise e
         end
 
         def extract_scope_from(env)
           scope = env['rollbar.scope']
-          Rollbar.log_warn('[Rollbar] rollbar.scope key has been removed from Rack env.') unless scope
+          unless scope
+            Rollbar.log_warn('[Rollbar] rollbar.scope key has been removed from Rack env.')
+          end
 
           scope || {}
         end

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -36,7 +36,8 @@ module Rollbar
       def trace_point
         return unless defined?(TracePoint)
 
-        @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call, :c_return, :raise) do |tp|
+        @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call,
+                                        :c_return, :raise) do |tp|
           case tp.event
           when :call, :b_call, :c_call, :class
             frames.push frame(tp)

--- a/lib/rollbar/plugin.rb
+++ b/lib/rollbar/plugin.rb
@@ -4,12 +4,8 @@ module Rollbar
   # On Rollbar initialization, all plugins will be saved in memory and those that
   # satisfy the dependencies will be loaded
   class Plugin
-    attr_reader :name
-    attr_reader :dependencies
-    attr_reader :callables
-    attr_reader :revert_callables
-    attr_accessor :on_demand
-    attr_accessor :loaded
+    attr_reader :name, :dependencies, :callables, :revert_callables
+    attr_accessor :on_demand, :loaded
 
     private :loaded=
 

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -17,6 +17,9 @@ end
 if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
   ActiveSupport.on_load(:action_mailer) do
     # Automatically add to ActionMailer::DeliveryJob
-    ActionMailer::DeliveryJob.send(:include, Rollbar::ActiveJob) if defined?(ActionMailer::DeliveryJob)
+    if defined?(ActionMailer::DeliveryJob)
+      ActionMailer::DeliveryJob.send(:include,
+                                     Rollbar::ActiveJob)
+    end
   end
 end

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -15,9 +15,14 @@ module Rollbar
 
           # DelayedJob < 4.1 doesn't provide job#error
           if job.class.method_defined? :error
-            ::Rollbar.scope(:request => data).error(job.error, :use_exception_level_filters => true) if job.error
+            if job.error
+              ::Rollbar.scope(:request => data).error(job.error,
+                                                      :use_exception_level_filters => true)
+            end
           elsif job.last_error
-            ::Rollbar.scope(:request => data).error("Job has failed and won't be retried anymore: " + job.last_error, :use_exception_level_filters => true)
+            ::Rollbar.scope(:request => data).error(
+              "Job has failed and won't be retried anymore: " + job.last_error, :use_exception_level_filters => true
+            )
           end
         end
       end

--- a/lib/rollbar/plugins/goalie.rb
+++ b/lib/rollbar/plugins/goalie.rb
@@ -11,16 +11,18 @@ Rollbar.plugins.define('goalie') do
           begin
             controller = env['action_controller.instance']
             request_data = begin
-                             controller.rollbar_request_data
-                           rescue StandardError
-                             nil
-                           end
+              controller.rollbar_request_data
+            rescue StandardError
+              nil
+            end
             person_data = begin
-                            controller.rollbar_person_data
-                          rescue StandardError
-                            nil
-                          end
-            exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(exception, :use_exception_level_filters => true)
+              controller.rollbar_person_data
+            rescue StandardError
+              nil
+            end
+            exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(
+              exception, :use_exception_level_filters => true
+            )
           rescue StandardError => e
             Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
           end

--- a/lib/rollbar/plugins/rails.rb
+++ b/lib/rollbar/plugins/rails.rb
@@ -39,7 +39,8 @@ Rollbar.plugins.define('rails-rollbar.js') do
             end
 
             def after_secure_headers(&block)
-              Rollbar::Railtie.initializer('rollbar.js.frameworks.rails', :after => 'secure_headers.middleware', &block)
+              Rollbar::Railtie.initializer('rollbar.js.frameworks.rails',
+                                           :after => 'secure_headers.middleware', &block)
             end
 
             def plugin_execute_proc_body(plugin)
@@ -52,7 +53,8 @@ Rollbar.plugins.define('rails-rollbar.js') do
                       :options => Rollbar.configuration.js_options,
                       :enabled => Rollbar.configuration.js_enabled
                     }
-                    ::Rails.configuration.middleware.use(::Rollbar::Middleware::Js, config)
+                    ::Rails.configuration.middleware.use(::Rollbar::Middleware::Js,
+                                                         config)
                   end
                 end
               end

--- a/lib/rollbar/plugins/rails/controller_methods.rb
+++ b/lib/rollbar/plugins/rails/controller_methods.rb
@@ -7,25 +7,27 @@ module Rollbar
       include RequestDataExtractor
 
       def rollbar_person_data
-        (user = send(Rollbar.configuration.person_method)) unless Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
+        (user = send(Rollbar.configuration.person_method)) unless Rollbar::Util.method_in_stack_twice(
+          :rollbar_person_data, __FILE__
+        )
         # include id, username, email if non-empty
         if user
           {
             :id => (begin
-                      user.send(Rollbar.configuration.person_id_method)
-                    rescue StandardError
-                      nil
-                    end),
+              user.send(Rollbar.configuration.person_id_method)
+            rescue StandardError
+              nil
+            end),
             :username => (begin
-                            user.send(Rollbar.configuration.person_username_method)
-                          rescue StandardError
-                            nil
-                          end),
+              user.send(Rollbar.configuration.person_username_method)
+            rescue StandardError
+              nil
+            end),
             :email => (begin
-                         user.send(Rollbar.configuration.person_email_method)
-                       rescue StandardError
-                         nil
-                       end)
+              user.send(Rollbar.configuration.person_email_method)
+            rescue StandardError
+              nil
+            end)
           }
         else
           {}

--- a/lib/rollbar/plugins/rails/railtie30.rb
+++ b/lib/rollbar/plugins/rails/railtie30.rb
@@ -11,7 +11,8 @@ module Rollbar
 
       app.config.middleware.insert_after ActionDispatch::ShowExceptions,
                                          Rollbar::Middleware::Rails::RollbarMiddleware
-      ActionDispatch::ShowExceptions.send(:include, Rollbar::Middleware::Rails::ShowExceptions)
+      ActionDispatch::ShowExceptions.send(:include,
+                                          Rollbar::Middleware::Rails::ShowExceptions)
     end
   end
 end

--- a/lib/rollbar/plugins/rails/railtie32.rb
+++ b/lib/rollbar/plugins/rails/railtie32.rb
@@ -11,7 +11,8 @@ module Rollbar
 
       app.config.middleware.insert_after ActionDispatch::DebugExceptions,
                                          Rollbar::Middleware::Rails::RollbarMiddleware
-      ActionDispatch::DebugExceptions.send(:include, Rollbar::Middleware::Rails::ShowExceptions)
+      ActionDispatch::DebugExceptions.send(:include,
+                                           Rollbar::Middleware::Rails::ShowExceptions)
     end
   end
 end

--- a/lib/rollbar/plugins/sidekiq/plugin.rb
+++ b/lib/rollbar/plugins/sidekiq/plugin.rb
@@ -5,12 +5,12 @@ module Rollbar
     PARAM_BLACKLIST = %w[backtrace error_backtrace error_message error_class].freeze
 
     class ResetScope
-      def call(_worker, msg, _queue)
+      def call(_worker, msg, _queue, &block)
         Rollbar.reset_notifier! # clears scope
 
         return yield unless Rollbar.configuration.sidekiq_use_scoped_block
 
-        Rollbar.scoped(Rollbar::Sidekiq.job_scope(msg)) { yield }
+        Rollbar.scoped(Rollbar::Sidekiq.job_scope(msg), &block)
       end
     end
 
@@ -57,12 +57,12 @@ module Rollbar
     end
 
     # see https://github.com/mperham/sidekiq/wiki/Middleware#server-middleware
-    def call(_worker, msg, _queue)
+    def call(_worker, msg, _queue, &block)
       Rollbar.reset_notifier! # clears scope
 
       return yield unless Rollbar.configuration.sidekiq_use_scoped_block
 
-      Rollbar.scoped(Rollbar::Sidekiq.job_scope(msg)) { yield }
+      Rollbar.scoped(Rollbar::Sidekiq.job_scope(msg), &block)
     rescue Exception => e
       Rollbar::Sidekiq.handle_exception(msg, e)
       raise

--- a/lib/rollbar/plugins/thread.rb
+++ b/lib/rollbar/plugins/thread.rb
@@ -9,6 +9,6 @@ Rollbar.plugins.define('thread') do
   end
 
   execute do
-    Thread.send(:prepend, Rollbar::ThreadPlugin) # rubocop:disable Lint/SendWithMixinArgument
+    Thread.send(:prepend, Rollbar::ThreadPlugin)
   end
 end

--- a/lib/rollbar/rake_tasks.rb
+++ b/lib/rollbar/rake_tasks.rb
@@ -1,4 +1,3 @@
-
 namespace :rollbar do
   desc 'Verify your gem installation by sending a test message to Rollbar'
   task :test => [:environment] do

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -19,10 +19,10 @@ module Rollbar
       else
         controller = env['action_controller.instance']
         person_data = begin
-                        controller.rollbar_person_data
-                      rescue StandardError
-                        {}
-                      end
+          controller.rollbar_person_data
+        rescue StandardError
+          {}
+        end
       end
 
       person_data
@@ -34,7 +34,8 @@ module Rollbar
 
       get_params = scrub_params(rollbar_get_params(rack_req), sensitive_params)
       post_params = scrub_params(rollbar_post_params(rack_req), sensitive_params)
-      raw_body_params = scrub_params(mergeable_raw_body_params(rack_req), sensitive_params)
+      raw_body_params = scrub_params(mergeable_raw_body_params(rack_req),
+                                     sensitive_params)
       cookies = scrub_params(rollbar_request_cookies(rack_req), sensitive_params)
       session = scrub_params(rollbar_request_session(env), sensitive_params)
       route_params = scrub_params(rollbar_route_params(env), sensitive_params)
@@ -54,7 +55,10 @@ module Rollbar
         :method => rollbar_request_method(env)
       }
 
-      data[:request_id] = env['action_dispatch.request_id'] if env['action_dispatch.request_id']
+      if env['action_dispatch.request_id']
+        data[:request_id] =
+          env['action_dispatch.request_id']
+      end
 
       data
     end
@@ -131,9 +135,11 @@ module Rollbar
       host = host.split(',').first.strip unless host.empty?
 
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
-      path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{"?#{env['QUERY_STRING']}" unless env['QUERY_STRING'].to_s.empty?}"
-      unless path.nil? || path.empty?
-        path = '/' + path.to_s if path.to_s.slice(0, 1) != '/'
+      path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{unless env['QUERY_STRING'].to_s.empty?
+                                                            "?#{env['QUERY_STRING']}"
+                                                          end}"
+      if !(path.nil? || path.empty?) && (path.to_s.slice(0, 1) != '/')
+        path = '/' + path.to_s
       end
 
       port = env['HTTP_X_FORWARDED_PORT']
@@ -248,7 +254,9 @@ module Rollbar
     end
 
     def sensitive_headers_list
-      return [] unless Rollbar.configuration.scrub_headers && Rollbar.configuration.scrub_headers.is_a?(Array)
+      unless Rollbar.configuration.scrub_headers && Rollbar.configuration.scrub_headers.is_a?(Array)
+        return []
+      end
 
       # Normalize into the expected matching format
       Rollbar.configuration.scrub_headers.map do |header|

--- a/lib/rollbar/scrubbers.rb
+++ b/lib/rollbar/scrubbers.rb
@@ -2,7 +2,7 @@ module Rollbar
   module Scrubbers
     module_function
 
-    def scrub_value(value)
+    def scrub_value(_value)
       if Rollbar.configuration.randomize_scrub_length
         random_filtered_value
       else

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -10,7 +10,8 @@ module Rollbar
     # configuration array even if :scrub_all is true.
     class Params
       SKIPPED_CLASSES = [::Tempfile].freeze
-      ATTACHMENT_CLASSES = %w[ActionDispatch::Http::UploadedFile Rack::Multipart::UploadedFile].freeze
+      ATTACHMENT_CLASSES = %w[ActionDispatch::Http::UploadedFile
+                              Rack::Multipart::UploadedFile].freeze
       SCRUB_ALL = :scrub_all
 
       def self.call(*args)
@@ -52,10 +53,14 @@ module Rollbar
       end
 
       def build_whitelist_regex(whitelist)
-        fields = whitelist.find_all { |f| f.is_a?(String) || f.is_a?(Symbol) || f.is_a?(Regexp) }
+        fields = whitelist.find_all do |f|
+          f.is_a?(String) || f.is_a?(Symbol) || f.is_a?(Regexp)
+        end
         return unless fields.any?
 
-        Regexp.new(fields.map { |val| val.is_a?(Regexp) ? val : /\A#{Regexp.escape(val.to_s)}\z/ }.join('|'))
+        Regexp.new(fields.map do |val|
+                     val.is_a?(Regexp) ? val : /\A#{Regexp.escape(val.to_s)}\z/
+                   end.join('|'))
       end
 
       def scrub(params, options)

--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -54,8 +54,10 @@ module Rollbar
         uri = URI.parse(url)
 
         uri.user = filter_user(uri.user, scrub_user, randomize_scrub_length)
-        uri.password = filter_password(uri.password, scrub_password, randomize_scrub_length)
-        uri.query = filter_query(uri.query, regex, randomize_scrub_length, scrub_all, whitelist)
+        uri.password = filter_password(uri.password, scrub_password,
+                                       randomize_scrub_length)
+        uri.query = filter_query(uri.query, regex, randomize_scrub_length, scrub_all,
+                                 whitelist)
 
         uri.to_s
       end
@@ -73,7 +75,12 @@ module Rollbar
       end
 
       def filter_password(password, scrub_password, randomize_scrub_length)
-        scrub_password && password ? filtered_value(password, randomize_scrub_length) : password
+        if scrub_password && password
+          filtered_value(password,
+                         randomize_scrub_length)
+        else
+          password
+        end
       end
 
       def filter_query(query, regex, randomize_scrub_length, scrub_all, whitelist)
@@ -81,7 +88,8 @@ module Rollbar
 
         params = decode_www_form(query)
 
-        encode_www_form(filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist))
+        encode_www_form(filter_query_params(params, regex, randomize_scrub_length,
+                                            scrub_all, whitelist))
       end
 
       def decode_www_form(query)
@@ -102,7 +110,13 @@ module Rollbar
 
       def filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist)
         params.map do |key, value|
-          [key, filter_key?(key, regex, scrub_all, whitelist) ? filtered_value(value, randomize_scrub_length) : value]
+          [key,
+           if filter_key?(key, regex, scrub_all,
+                          whitelist)
+             filtered_value(value, randomize_scrub_length)
+           else
+             value
+           end]
         end
       end
 
@@ -115,10 +129,10 @@ module Rollbar
           random_filtered_value
         else
           '*' * (begin
-                   value.length
-                 rescue StandardError
-                   8
-                 end)
+            value.length
+          rescue StandardError
+            8
+          end)
         end
       end
 

--- a/lib/rollbar/truncation/remove_any_key_strategy.rb
+++ b/lib/rollbar/truncation/remove_any_key_strategy.rb
@@ -91,7 +91,10 @@ module Rollbar
       def extract_title(body)
         return body['message']['body'] if body['message'] && body['message']['body']
         return extract_title_from_trace(body['trace']) if body['trace']
-        return extract_title_from_trace(body['trace_chain'][0]) if body['trace_chain'] && body['trace_chain'][0]
+
+        if body['trace_chain'] && body['trace_chain'][0]
+          extract_title_from_trace(body['trace_chain'][0])
+        end
       end
 
       def extract_title_from_trace(trace)

--- a/lib/rollbar/truncation/remove_extra_strategy.rb
+++ b/lib/rollbar/truncation/remove_extra_strategy.rb
@@ -24,7 +24,9 @@ module Rollbar
       end
 
       def delete_trace_chain_extra(body)
-        body['trace_chain'][0].delete('extra') if body['trace_chain'] && body['trace_chain'][0]['extra']
+        if body['trace_chain'] && body['trace_chain'][0]['extra']
+          body['trace_chain'][0].delete('extra')
+        end
       end
 
       def delete_trace_extra(body)

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -80,7 +80,9 @@ module Rollbar
       hash2 ||= {}
 
       # If we've already merged these two objects, return hash1 now.
-      return hash1 if merged[hash1.object_id] && merged[hash1.object_id].include?(hash2.object_id)
+      if merged[hash1.object_id] && merged[hash1.object_id].include?(hash2.object_id)
+        return hash1
+      end
 
       merged[hash1.object_id] ||= []
       merged[hash1.object_id] << hash2.object_id
@@ -121,7 +123,7 @@ module Rollbar
     end
 
     def self.count_method_in_stack(method_symbol, file_path = '')
-      caller.grep(/#{file_path}.*#{method_symbol.to_s}/).count
+      caller.grep(/#{file_path}.*#{method_symbol}/).count
     end
 
     def self.method_in_stack(method_symbol, file_path = '')

--- a/lib/rollbar/util/hash.rb
+++ b/lib/rollbar/util/hash.rb
@@ -35,11 +35,17 @@ module Rollbar
         case thing
         when ::Hash
           thing.keys.each do |key|
-            thing[key] = "removed circular reference: #{thing[key]}" if seen[thing[key].object_id]
+            if seen[thing[key].object_id]
+              thing[key] =
+                "removed circular reference: #{thing[key]}"
+            end
           end
         when Array
           thing.each_with_index do |_, i|
-            thing[i] = "removed circular reference: #{thing[i]}" if seen[thing[i].object_id]
+            if seen[thing[i].object_id]
+              thing[i] =
+                "removed circular reference: #{thing[i]}"
+            end
           end
         end
       end

--- a/lib/tasks/benchmark.rake
+++ b/lib/tasks/benchmark.rake
@@ -77,7 +77,8 @@ class BenchmarkTraceWithBindings # :nodoc:
   def trace_point # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return unless defined?(TracePoint)
 
-    @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call, :c_return, :raise) do |tp|
+    @trace_point ||= TracePoint.new(:call, :return, :b_call, :b_return, :c_call,
+                                    :c_return, :raise) do |tp|
       next if options['hook_only']
 
       case tp.event

--- a/rollbar.gemspec
+++ b/rollbar.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Reports exceptions to Rollbar'
   gem.homepage      = 'https://rollbar.com'
   gem.license       = 'MIT'
-  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  gem.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
   gem.files        += ['spec/support/rollbar_api.rb'] # useful helper for app spec/tests.
   gem.name          = 'rollbar'
   gem.require_paths = ['lib']

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -62,7 +62,8 @@ describe HomeController do
     end
   end
 
-  context format('rollbar controller methods with %s requests', (local? ? 'local' : 'non-local')) do
+  context format('rollbar controller methods with %s requests',
+                 (local? ? 'local' : 'non-local')) do
     # TODO: run these for a a more-real request
     it 'should build valid request data' do
       data = @controller.rollbar_request_data
@@ -275,7 +276,8 @@ describe HomeController do
       it 'reports the errors successfully' do
         logger_mock.should_receive(:info).with('[Rollbar] Success')
 
-        send_req(:put, '/deprecated_report_exception', wrap_process_args(:putparam => 'putval'))
+        send_req(:put, '/deprecated_report_exception',
+                 wrap_process_args(:putparam => 'putval'))
 
         Rollbar.last_report.should_not be_nil
         Rollbar.last_report[:request][:POST]['putparam'].should == 'putval'
@@ -287,7 +289,8 @@ describe HomeController do
       @request.env['HTTP_ACCEPT'] = 'application/json'
 
       params = { :jsonparam => 'jsonval' }.to_json
-      send_req(:post, '/report_exception', wrap_process_args(params, 'CONTENT_TYPE' => 'application/json'))
+      send_req(:post, '/report_exception',
+               wrap_process_args(params, 'CONTENT_TYPE' => 'application/json'))
 
       Rollbar.last_report.should_not be_nil
       expect(Rollbar.last_report[:request][:body]).to be_eql(params)
@@ -311,7 +314,7 @@ describe HomeController do
           {
             :obj => 'Post',
             :password => '******',
-            :hash => {:foo => 'Post', :bar => 'bar'},
+            :hash => { :foo => 'Post', :bar => 'bar' },
             :foo => 'Post',
             :_index => 0
           },
@@ -465,7 +468,11 @@ describe HomeController do
             end
 
             context 'configured to send email addresses and username' do
-              before { Rollbar.configure { |config| config.person_username_method = 'username' } }
+              before do
+                Rollbar.configure do |config|
+                  config.person_username_method = 'username'
+                end
+              end
 
               it 'sends the current user data including email address and username' do
                 expect(person_data).to eq(:id => user.id,
@@ -567,7 +574,8 @@ describe HomeController do
 
     it 'parses the correct headers' do
       expect do
-        send_req(:post, '/cause_exception', wrap_process_args(params, 'ACCEPT' => 'application/vnd.github.v3+json'))
+        send_req(:post, '/cause_exception',
+                 wrap_process_args(params, 'ACCEPT' => 'application/vnd.github.v3+json'))
       end.to raise_exception(NameError)
 
       expect(Rollbar.last_report[:request][:POST]['foo']).to be_eql('bar')
@@ -589,7 +597,8 @@ describe HomeController do
 
     it 'scrubs sensible data from URL' do
       expect do
-        send_req(:get, '/cause_exception', wrap_process_args({ :password => 'my-secret-password' }, headers))
+        send_req(:get, '/cause_exception',
+                 wrap_process_args({ :password => 'my-secret-password' }, headers))
       end.to raise_exception(NameError)
 
       request_data = Rollbar.last_report[:request]

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -25,16 +25,8 @@ module Delayed
       end
 
       class Job
-        attr_accessor :id
-        attr_accessor :priority
-        attr_accessor :attempts
-        attr_accessor :handler
-        attr_accessor :last_error
-        attr_accessor :run_at
-        attr_accessor :locked_at
-        attr_accessor :locked_by
-        attr_accessor :failed_at
-        attr_accessor :queue
+        attr_accessor :id, :priority, :attempts, :handler, :last_error, :run_at,
+                      :locked_at, :locked_by, :failed_at, :queue
 
         include Delayed::Backend::Base
 
@@ -76,7 +68,7 @@ module Delayed
         end
 
         # Find a few candidate jobs to run (in case some immediately get locked by others).
-        def self.find_available(worker_name, limit = 5, max_run_time = Worker.max_run_time) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
+        def self.find_available(worker_name, limit = 5, max_run_time = Worker.max_run_time) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           jobs = all.select do |j|
             j.run_at <= db_time_now &&
               (j.locked_at.nil? || j.locked_at < db_time_now - max_run_time || j.locked_by == worker_name) &&

--- a/spec/dummyapp/app/models/user.rb
+++ b/spec/dummyapp/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ActiveRecord::Base
-  attr_accessible :username, :email, :password, :password_confirmation, :remember_me if Rails::VERSION::MAJOR < 4
+  if Rails::VERSION::MAJOR < 4
+    attr_accessible :username, :email, :password, :password_confirmation,
+                    :remember_me
+  end
 
   validates_presence_of :email
   after_validation :report_validation_errors_to_rollbar

--- a/spec/dummyapp/config/application.rb
+++ b/spec/dummyapp/config/application.rb
@@ -55,6 +55,8 @@ module Dummy
     # Version of your assets, change this if you want to expire all your assets
     # config.assets.version = '1.0'
 
-    config.active_job.queue_adapter = :inline if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
+      config.active_job.queue_adapter = :inline
+    end
   end
 end

--- a/spec/dummyapp/db/schema.rb
+++ b/spec/dummyapp/db/schema.rb
@@ -36,5 +36,6 @@ ActiveRecord::Schema.define(:version => 20_161_219_185_529) do
   end
 
   add_index 'users', ['email'], :name => 'index_users_on_email', :unique => true
-  add_index 'users', ['reset_password_token'], :name => 'index_users_on_reset_password_token', :unique => true
+  add_index 'users', ['reset_password_token'],
+            :name => 'index_users_on_reset_password_token', :unique => true
 end

--- a/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
+++ b/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 begin
   require 'genspec'
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError
 end
 
 require 'generators/rollbar/rollbar_generator'

--- a/spec/generators/rollbar/rollbar_generator_spec.rb
+++ b/spec/generators/rollbar/rollbar_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 begin
   require 'generator_spec'
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError
 end
 
 require 'generators/rollbar/rollbar_generator'

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -25,15 +25,19 @@ describe HomeController do
 
   context 'with error hiding deep inside' do
     let!(:cookie_method_name) { :[] }
-    let!(:original_cookie_method) { ActionDispatch::Cookies::CookieJar.instance_method(cookie_method_name) }
+    let!(:original_cookie_method) do
+      ActionDispatch::Cookies::CookieJar.instance_method(cookie_method_name)
+    end
     let!(:broken_cookie_method) { proc { |_name| '1' - 1 } }
 
     before(:each) do
-      ActionDispatch::Cookies::CookieJar.send(:define_method, cookie_method_name, broken_cookie_method)
+      ActionDispatch::Cookies::CookieJar.send(:define_method, cookie_method_name,
+                                              broken_cookie_method)
     end
 
     after do
-      ActionDispatch::Cookies::CookieJar.send(:define_method, cookie_method_name, original_cookie_method)
+      ActionDispatch::Cookies::CookieJar.send(:define_method, cookie_method_name,
+                                              original_cookie_method)
     end
 
     it 'should report uncaught exceptions' do

--- a/spec/rollbar/capistrano_tasks_spec.rb
+++ b/spec/rollbar/capistrano_tasks_spec.rb
@@ -5,7 +5,9 @@ require 'sshkit'
 
 describe ::Rollbar::CapistranoTasks do
   let(:capistrano) { ::Capistrano::Configuration.new }
-  let(:logger) { instance_double(::SSHKit::Backend::Printer) } # this needs to be different for Capistrano 2.x
+  let(:logger) do
+    instance_double(::SSHKit::Backend::Printer)
+  end
 
   let(:rollbar_user) { 'foo' }
   let(:rollbar_comment) { 'bar' }
@@ -15,9 +17,11 @@ describe ::Rollbar::CapistranoTasks do
   let(:dry_run) { false }
 
   class Capistrano2LoggerStub
-    def important(message, line_prefix=nil) end
-    def info(message, line_prefix=nil) end
-    def debug(message, line_prefix=nil) end
+    def important(message, line_prefix = nil) end
+
+    def info(message, line_prefix = nil) end
+
+    def debug(message, line_prefix = nil) end
   end
 
   before do
@@ -86,7 +90,7 @@ describe ::Rollbar::CapistranoTasks do
     end
 
     context 'when an an exception is raised' do
-      it "logs the error to the logger" do
+      it 'logs the error to the logger' do
         expect(::Rollbar::Deploy).to receive(:report)
           .and_raise('an API exception')
 
@@ -98,7 +102,7 @@ describe ::Rollbar::CapistranoTasks do
       context 'when using Capistrano 2.x logger' do
         let(:logger2) { Capistrano2LoggerStub.new }
 
-        it "logs the error to the logger" do
+        it 'logs the error to the logger' do
           expect(::Rollbar::Deploy).to receive(:report)
             .and_raise('an API exception')
 
@@ -185,7 +189,7 @@ describe ::Rollbar::CapistranoTasks do
       end
 
       context 'when an an exception is raised' do
-        it "logs the error to the logger" do
+        it 'logs the error to the logger' do
           expect(::Rollbar::Deploy).to receive(:update)
             .and_raise('an API exception')
 
@@ -197,7 +201,7 @@ describe ::Rollbar::CapistranoTasks do
         context 'when using Capistrano 2.x logger' do
           let(:logger2) { Capistrano2LoggerStub.new }
 
-          it "logs the error to the logger" do
+          it 'logs the error to the logger' do
             expect(::Rollbar::Deploy).to receive(:update)
               .and_raise('an API exception')
 
@@ -306,7 +310,7 @@ describe ::Rollbar::CapistranoTasks do
       end
 
       context 'when an an exception is raised' do
-        it "logs the error to the logger" do
+        it 'logs the error to the logger' do
           expect(::Rollbar::Deploy).to receive(:update)
             .and_raise('an API exception')
 
@@ -318,7 +322,7 @@ describe ::Rollbar::CapistranoTasks do
         context 'when using Capistrano 2.x logger' do
           let(:logger2) { Capistrano2LoggerStub.new }
 
-          it "logs the error to the logger" do
+          it 'logs the error to the logger' do
             expect(::Rollbar::Deploy).to receive(:update)
               .and_raise('an API exception')
 

--- a/spec/rollbar/delay/active_job_spec.rb
+++ b/spec/rollbar/delay/active_job_spec.rb
@@ -5,7 +5,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
     require 'rollbar/delay/active_job'
 
     describe Rollbar::Delay::ActiveJob do
-      include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper) # rubocop:disable Style/MixinUsage
+      include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
 
       describe '.call' do
         let(:payload) { {} }

--- a/spec/rollbar/deploy_spec.rb
+++ b/spec/rollbar/deploy_spec.rb
@@ -149,7 +149,8 @@ describe ::Rollbar::Deploy do
     end
 
     context 'with valid request data' do
-      it_behaves_like 'valid deploy API request', /^200; OK; {"data":{"deploy_id":[0-9]+}}/
+      it_behaves_like 'valid deploy API request',
+                      /^200; OK; {"data":{"deploy_id":[0-9]+}}/
 
       it 'adds deploy id to the result' do
         expect(@result[:data][:deploy_id].to_s).to match(/[0-9]+/)
@@ -199,7 +200,7 @@ describe ::Rollbar::Deploy do
     end
 
     context 'with valid request data' do
-      it_behaves_like 'valid deploy API request', /^200; OK; {.*\"id\":[0-9]+.*/
+      it_behaves_like 'valid deploy API request', /^200; OK; {.*"id":[0-9]+.*/
     end
 
     context 'with invalid request data' do

--- a/spec/rollbar/item/backtrace_spec.rb
+++ b/spec/rollbar/item/backtrace_spec.rb
@@ -25,7 +25,8 @@ describe Rollbar::Item::Backtrace do
   end
 
   describe '#map_frames' do
-    context 'when using backtrace_cleaner', :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3.0') do
+    context 'when using backtrace_cleaner',
+            :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('3.0') do
       subject { described_class.new(exception, { :configuration => config }) }
 
       let(:config) do

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -59,7 +59,7 @@ describe Rollbar::Item do
     end
 
     context 'a basic payload' do
-      let(:extra) { {:key => 'value', :hash => {:inner_key => 'inner_value'}} }
+      let(:extra) { { :key => 'value', :hash => { :inner_key => 'inner_value' } } }
 
       it 'calls Rollbar::Util.enforce_valid_utf8' do
         expect(Rollbar::Util).to receive(:enforce_valid_utf8).with(kind_of(Hash))
@@ -133,14 +133,15 @@ describe Rollbar::Item do
     end
 
     it 'should have custom message data when custom_data_method is configured' do
-      configuration.custom_data_method = lambda { {:a => 1, :b => [2, 3, 4]} }
+      configuration.custom_data_method = lambda { { :a => 1, :b => [2, 3, 4] } }
 
       payload['data'][:body][:message][:extra].should_not be_nil
       payload['data'][:body][:message][:extra][:a].should == 1
       payload['data'][:body][:message][:extra][:b][2].should == 4
     end
 
-    context 'ActiveSupport >= 4.1', :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
+    context 'ActiveSupport >= 4.1',
+            :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
       it 'should have correct configured_options object' do
         payload['data'][:notifier][:configured_options][:access_token].should == '******'
         payload['data'][:notifier][:configured_options][:root].should == '/foo/'
@@ -148,22 +149,23 @@ describe Rollbar::Item do
       end
     end
 
-    context 'ActiveSupport < 4.1', :if => Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1') do
+    context 'ActiveSupport < 4.1',
+            :if => Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1') do
       it 'should have configured_options message' do
-        payload['data'][:notifier][:configured_options].class == 'String'
+        payload['data'][:notifier][:configured_options].instance_of?('String')
       end
     end
 
     context do
-      let(:context) { { :controller => "ExampleController" } }
+      let(:context) { { :controller => 'ExampleController' } }
 
       it 'should have access to the context in custom_data_method' do
-        configuration.custom_data_method = lambda do |message, exception, context|
-          { :result => "MyApp#" + context[:controller] }
+        configuration.custom_data_method = lambda do |_message, _exception, context|
+          { :result => 'MyApp#' + context[:controller] }
         end
 
         payload['data'][:body][:message][:extra].should_not be_nil
-        payload['data'][:body][:message][:extra][:result].should == "MyApp#"+context[:controller]
+        payload['data'][:body][:message][:extra][:result].should == 'MyApp#' + context[:controller]
       end
 
       it 'should not include data passed in :context if there is no custom_data_method configured' do
@@ -173,31 +175,31 @@ describe Rollbar::Item do
       end
 
       it 'should have access to the message in custom_data_method' do
-        configuration.custom_data_method = lambda do |message, exception, context|
-          { :result => "Transformed in custom_data_method: " + message }
+        configuration.custom_data_method = lambda do |message, _exception, _context|
+          { :result => 'Transformed in custom_data_method: ' + message }
         end
 
         payload['data'][:body][:message][:extra].should_not be_nil
-        payload['data'][:body][:message][:extra][:result].should == "Transformed in custom_data_method: " + message
+        payload['data'][:body][:message][:extra][:result].should == 'Transformed in custom_data_method: ' + message
       end
 
       context do
-        let(:exception) { Exception.new "Exception to test custom_data_method" }
+        let(:exception) { Exception.new 'Exception to test custom_data_method' }
 
         it 'should have access to the current exception in custom_data_method' do
-          configuration.custom_data_method = lambda do |message, exception, context|
-            { :result => "Transformed in custom_data_method: " + exception.message }
+          configuration.custom_data_method = lambda do |_message, exception, _context|
+            { :result => 'Transformed in custom_data_method: ' + exception.message }
           end
 
           payload['data'][:body][:trace][:extra].should_not be_nil
-          payload['data'][:body][:trace][:extra][:result].should == "Transformed in custom_data_method: " + exception.message
+          payload['data'][:body][:trace][:extra][:result].should == 'Transformed in custom_data_method: ' + exception.message
         end
       end
     end
 
     context do
       let(:extra) do
-        { :c => {:e => 'g' }, :f => 'f' }
+        { :c => { :e => 'g' }, :f => 'f' }
       end
 
       it 'should merge extra data into custom message data' do
@@ -205,8 +207,7 @@ describe Rollbar::Item do
           { :a => 1,
             :b => [2, 3, 4],
             :c => { :d => 'd', :e => 'e' },
-            :f => ['1', '2']
-          }
+            :f => %w[1 2] }
         end
         configuration.custom_data_method = custom_method
 
@@ -282,7 +283,7 @@ describe Rollbar::Item do
       let(:exception) do
         begin
           foo = bar
-        rescue => e
+        rescue StandardError => e
           e
         end
       end
@@ -298,12 +299,12 @@ describe Rollbar::Item do
 
         context 'and extra data' do
           let(:extra) do
-            {:a => 'b'}
+            { :a => 'b' }
           end
 
           it 'should build a message body when no exception and extra data is passed in' do
             payload['data'][:body][:message][:body].should == 'message'
-            payload['data'][:body][:message][:extra].should == {:a => 'b'}
+            payload['data'][:body][:message][:extra].should == { :a => 'b' }
             payload['data'][:body][:trace].should be_nil
           end
         end
@@ -323,7 +324,7 @@ describe Rollbar::Item do
 
       context 'with extra data' do
         let(:extra) do
-          {:a => 'b'}
+          { :a => 'b' }
         end
 
         it 'should build an exception body when one is passed in along with extra data' do
@@ -335,7 +336,7 @@ describe Rollbar::Item do
 
           trace[:exception][:class].should_not be_nil
           trace[:exception][:message].should_not be_nil
-          trace[:extra].should == {:a => 'b'}
+          trace[:extra].should == { :a => 'b' }
         end
       end
     end
@@ -344,7 +345,7 @@ describe Rollbar::Item do
       let(:exception) do
         begin
           foo = bar
-        rescue => e
+        rescue StandardError => e
           e
         end
       end
@@ -359,10 +360,8 @@ describe Rollbar::Item do
         frames.should be_a_kind_of(Array)
         frames.each do |frame|
           frame[:filename].should be_a_kind_of(String)
-          frame[:lineno].should be_a_kind_of(Fixnum)
-          if frame[:method]
-            frame[:method].should be_a_kind_of(String)
-          end
+          frame[:lineno].should be_a_kind_of(Integer)
+          frame[:method].should be_a_kind_of(String) if frame[:method]
         end
 
         # should be NameError, but can be NoMethodError sometimes on rubinius 1.8
@@ -385,7 +384,7 @@ describe Rollbar::Item do
 
         context 'and extra data' do
           let(:extra) do
-            {:key => 'value', :hash => {:inner_key => 'inner_value'}}
+            { :key => 'value', :hash => { :inner_key => 'inner_value' } }
           end
 
           it 'should build exception data with a description and extra data' do
@@ -395,14 +394,14 @@ describe Rollbar::Item do
             trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
             trace[:exception][:description].should == 'exception description'
             trace[:extra][:key].should == 'value'
-            trace[:extra][:hash].should == {:inner_key => 'inner_value'}
+            trace[:extra][:hash].should == { :inner_key => 'inner_value' }
           end
         end
       end
 
       context 'with extra data' do
         let(:extra) do
-          {:key => 'value', :hash => {:inner_key => 'inner_value'}}
+          { :key => 'value', :hash => { :inner_key => 'inner_value' } }
         end
         it 'should build exception data with a extra data' do
           body = payload['data'][:body]
@@ -410,13 +409,13 @@ describe Rollbar::Item do
 
           trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
           trace[:extra][:key].should == 'value'
-          trace[:extra][:hash].should == {:inner_key => 'inner_value'}
+          trace[:extra][:hash].should == { :inner_key => 'inner_value' }
         end
       end
 
       context 'with error context' do
         let(:context) do
-          {:key => 'value', :hash => {:inner_key => 'inner_value'}}
+          { :key => 'value', :hash => { :inner_key => 'inner_value' } }
         end
         it 'should build exception data with a extra data' do
           exception.rollbar_context = context
@@ -426,7 +425,7 @@ describe Rollbar::Item do
 
           trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
           trace[:extra][:key].should == 'value'
-          trace[:extra][:hash].should == {:inner_key => 'inner_value'}
+          trace[:extra][:hash].should == { :inner_key => 'inner_value' }
         end
       end
 
@@ -435,11 +434,11 @@ describe Rollbar::Item do
           proc do
             begin
               begin
-                fail CauseException.new('the cause')
-              rescue
-                fail StandardError.new('the error')
+                raise CauseException, 'the cause'
+              rescue StandardError
+                raise StandardError, 'the error'
               end
-            rescue => e
+            rescue StandardError => e
               e
             end
           end
@@ -470,7 +469,7 @@ describe Rollbar::Item do
             let(:exception) { Exception.new('custom cause') }
 
             it 'ignores the cause when it is not an Exception' do
-              allow(exception).to receive(:cause) { "Foo" }
+              allow(exception).to receive(:cause) { 'Foo' }
 
               payload['data'][:body][:trace].should_not be_nil
             end
@@ -519,26 +518,26 @@ describe Rollbar::Item do
 
       context 'with extra data' do
         let(:extra) do
-          {:key => 'value', :hash => {:inner_key => 'inner_value'}}
+          { :key => 'value', :hash => { :inner_key => 'inner_value' } }
         end
 
         it 'should build a message with extra data' do
           payload['data'][:body][:message][:body].should == 'message'
           payload['data'][:body][:message][:extra][:key].should == 'value'
-          payload['data'][:body][:message][:extra][:hash].should == {:inner_key => 'inner_value'}
+          payload['data'][:body][:message][:extra][:hash].should == { :inner_key => 'inner_value' }
         end
       end
 
       context 'with empty message and extra data' do
         let(:message) { nil }
         let(:extra) do
-          {:key => 'value', :hash => {:inner_key => 'inner_value'}}
+          { :key => 'value', :hash => { :inner_key => 'inner_value' } }
         end
 
         it 'should build an empty message with extra data' do
           payload['data'][:body][:message][:body].should == 'Empty message'
           payload['data'][:body][:message][:extra][:key].should == 'value'
-          payload['data'][:body][:message][:extra][:hash].should == {:inner_key => 'inner_value'}
+          payload['data'][:body][:message][:extra][:hash].should == { :inner_key => 'inner_value' }
         end
       end
     end
@@ -553,7 +552,6 @@ describe Rollbar::Item do
       context 'without mutation in payload' do
         let(:handler) do
           proc do |options|
-
           end
         end
 
@@ -611,8 +609,8 @@ describe Rollbar::Item do
       end
 
       context 'with two handlers' do
-        let(:handler1) { proc { |options|} }
-        let(:handler2) { proc { |options|} }
+        let(:handler1) { proc { |options| } }
+        let(:handler2) { proc { |options| } }
 
         before do
           configuration.transform << handler1
@@ -622,7 +620,7 @@ describe Rollbar::Item do
         context 'and the first one fails' do
           let(:exception) { StandardError.new('foo') }
           let(:handler1) do
-            proc { |options|  raise exception }
+            proc { |_options| raise exception }
           end
 
           it 'doesnt call the second handler and logs the error' do
@@ -643,10 +641,12 @@ describe Rollbar::Item do
       end
 
       context 'with uuid in reported data' do
-        next unless defined?(SecureRandom) and SecureRandom.respond_to?(:uuid)
+        next unless defined?(SecureRandom) && SecureRandom.respond_to?(:uuid)
 
         let(:report_data) { { :uuid => SecureRandom.uuid } }
-        let(:expected_url) { "https://rollbar.com/instance/uuid?uuid=#{report_data[:uuid]}" }
+        let(:expected_url) do
+          "https://rollbar.com/instance/uuid?uuid=#{report_data[:uuid]}"
+        end
 
         it 'returns the uuid in :_error_in_custom_data_method' do
           expect(payload['data'][:body][:message][:extra]).to be_eql(:_error_in_custom_data_method => expected_url)
@@ -689,13 +689,12 @@ describe Rollbar::Item do
     end
 
     context 'with ignored person ids' do
-      let(:ignored_ids) { [1,2,4] }
+      let(:ignored_ids) { [1, 2, 4] }
       let(:person_data) do
         { :person => {
-            :id => 2,
-            :username => 'foo'
-          }
-        }
+          :id => 2,
+          :username => 'foo'
+        } }
       end
       let(:scope) { Rollbar::LazyStore.new(person_data) }
 
@@ -710,8 +709,7 @@ describe Rollbar::Item do
         expect(subject).to be_ignored
       end
     end
-
-  end # end #build
+  end
 
   describe '#build_with' do
     context 'when use_payload_access_token is set' do
@@ -851,14 +849,16 @@ describe Rollbar::Item do
       it 'calls Notifier#send_failsafe and logs the error' do
         original_size = Rollbar::JSON.dump(payload).bytesize
         attempts = []
-        final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload), attempts).bytesize
+        final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload),
+                                                  attempts).bytesize
         # final_size = original_size
         rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
         uuid = payload['data']['uuid']
         host = payload['data']['server']['host']
         log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
 
-        expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil, hash_including(:uuid => uuid, :host => host))
+        expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil,
+                                                         hash_including(:uuid => uuid, :host => host))
         expect(logger).to receive(:error).with(log_message)
 
         item.dump
@@ -869,13 +869,15 @@ describe Rollbar::Item do
           payload['data'].delete('server')
           original_size = Rollbar::JSON.dump(payload).bytesize
           attempts = []
-          final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload), attempts).bytesize
+          final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload),
+                                                    attempts).bytesize
           # final_size = original_size
           rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
           uuid = payload['data']['uuid']
           log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
 
-          expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil, hash_including(:uuid => uuid))
+          expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil,
+                                                           hash_including(:uuid => uuid))
           expect(logger).to receive(:error).with(log_message)
 
           item.dump

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -152,7 +152,7 @@ describe Rollbar::Item do
     context 'ActiveSupport < 4.1',
             :if => Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1') do
       it 'should have configured_options message' do
-        payload['data'][:notifier][:configured_options].instance_of?('String')
+        payload['data'][:notifier][:configured_options].instance_of?(String)
       end
     end
 

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -33,7 +33,8 @@ describe Rollbar::Logger do
       let(:message) { 'foo' }
 
       it 'calls Rollbar to send the message with critical level' do
-        expect_any_instance_of(Rollbar::Notifier).to receive(:log).with(:critical, message)
+        expect_any_instance_of(Rollbar::Notifier).to receive(:log).with(:critical,
+                                                                        message)
 
         subject.add(Logger::FATAL, message)
       end
@@ -60,7 +61,11 @@ describe Rollbar::Logger do
     end
 
     context 'without active_support/core_ext/object/blank' do
-      let(:message) { 'foo'.tap { |message| message.instance_eval('undef :blank?') } }
+      let(:message) do
+        'foo'.tap do |message|
+          message.instance_eval('undef :blank?', __FILE__, __LINE__)
+        end
+      end
 
       it 'calls Rollbar to send the message' do
         expect_any_instance_of(Rollbar::Notifier).to receive(:log).with(:error, message)

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -265,7 +265,8 @@ describe Rollbar::Middleware::Js do
         end
       end
 
-      context 'having a html 200 response without head but with an header tag', :add_js => false do
+      context 'having a html 200 response without head but with an header tag',
+              :add_js => false do
         let(:body) { ['<header>foobar</header>'] }
         let(:status) { 200 }
         let(:headers) do

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -245,7 +245,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
             {
               :obj => 'Post',
               :bar => 'bar',
-              :hash => {:foo => 'Post', :bar => 'bar'},
+              :hash => { :foo => 'Post', :bar => 'bar' },
               :foo => 'Post',
               :_index => 0
             },

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -74,7 +74,7 @@ describe Rollbar::Notifier do
         notifier.configuration.files_processed_enabled = true
       end
 
-      let(:dummy_file) { double(File, birthtime: Time.now, size: 0).as_null_object }
+      let(:dummy_file) { double(File, :birthtime => Time.now, :size => 0).as_null_object }
 
       it 'writes to the file' do
         allow(File).to receive(:open).with(nil, 'a').and_return(dummy_file)
@@ -96,7 +96,7 @@ describe Rollbar::Notifier do
 
       let(:dummy_file) do
         double(
-          File, birthtime: Time.now - (notifier.configuration.files_processed_duration + 1).seconds, size: 0
+          File, :birthtime => Time.now - (notifier.configuration.files_processed_duration + 1).seconds, :size => 0
         ).as_null_object
       end
 
@@ -119,7 +119,8 @@ describe Rollbar::Notifier do
       end
 
       let(:dummy_file) do
-        double(File, birthtime: Time.now, size: notifier.configuration.files_processed_size + 1).as_null_object
+        double(File, :birthtime => Time.now,
+                     :size => notifier.configuration.files_processed_size + 1).as_null_object
       end
 
       it 'writes to the file and rename' do
@@ -161,7 +162,7 @@ describe Rollbar::Notifier do
         before { allow(dummy_http).to receive(:request).and_raise(SocketError) }
 
         it 'passes the message on' do
-          expect {process_item}.to raise_error(SocketError)
+          expect { process_item }.to raise_error(SocketError)
         end
 
         context 'the item has come via failsafe' do
@@ -233,11 +234,11 @@ describe Rollbar::Notifier do
         before { allow(dummy_http).to receive(:request).and_raise(SocketError) }
 
         it 'passes the message on' do
-          expect {process_from_async_handler}.to raise_error(SocketError)
+          expect { process_from_async_handler }.to raise_error(SocketError)
         end
 
         context 'the item has come via failsafe' do
-          let(:payload) { { "data" => { "failsafe" => true } } }
+          let(:payload) { { 'data' => { 'failsafe' => true } } }
 
           it 'does not pass the message on' do
             expect(notifier).to receive(:log_error).with("[Rollbar] Error processing the item: SocketError, SocketError. Item: #{payload.inspect}")
@@ -268,7 +269,8 @@ describe Rollbar::Notifier do
         begin
           raise java.lang.Exception, 'Hello'
         rescue StandardError => e
-          _message, exception, _extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
+          _message, exception, _extra = Rollbar::Notifier.new.send(:extract_arguments,
+                                                                   [e])
           expect(exception).to eq(e)
         end
       end
@@ -277,7 +279,8 @@ describe Rollbar::Notifier do
         begin
           raise java.lang.AssertionError.new('Hello') # rubocop:disable Style/RaiseArgs
         rescue java.lang.Error => e
-          _message, exception, _extra = Rollbar::Notifier.new.send(:extract_arguments, [e])
+          _message, exception, _extra = Rollbar::Notifier.new.send(:extract_arguments,
+                                                                   [e])
           expect(exception).to eq(e)
         end
       end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -44,7 +44,7 @@ describe Rollbar::ActiveJob do
   end
 
   context 'using ActionMailer::DeliveryJob', :if => defined?(ActionMailer::DeliveryJob) do
-    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper) # rubocop:disable Style/MixinUsage
+    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
 
     class TestMailer < ActionMailer::Base
       attr_accessor :arguments
@@ -68,7 +68,8 @@ describe Rollbar::ActiveJob do
         :use_exception_level_filters => true,
         :arguments => ['TestMailer', 'test_email', 'deliver_now', 12]
       }
-      expect(Rollbar).to receive(:error).with(kind_of(StandardError), hash_including(expected_params))
+      expect(Rollbar).to receive(:error).with(kind_of(StandardError),
+                                              hash_including(expected_params))
       perform_enqueued_jobs do
         TestMailer.test_email(argument).deliver_later rescue nil # rubocop:disable Style/RescueModifier
       end

--- a/spec/rollbar/plugins/basic_socket_spec.rb
+++ b/spec/rollbar/plugins/basic_socket_spec.rb
@@ -37,9 +37,9 @@ describe 'basic_socket plugin' do
       if Gem::Version.new(ActiveSupport::VERSION::STRING) < Gem::Version.new('4.1.0')
         context 'using active_support < 4.1' do
           it 'changes implementation of ::BasicSocket#as_json temporarily' do
-            original_implementation = BasicSocket.
-              public_instance_method(:as_json).
-              source_location
+            original_implementation = BasicSocket
+                                      .public_instance_method(:as_json)
+                                      .source_location
 
             subject.load_scoped! do
               expect(subject.loaded).to eq(true)
@@ -49,8 +49,8 @@ describe 'basic_socket plugin' do
             end
 
             expect(subject.loaded).to eq(false)
-            expect(BasicSocket.public_instance_method(:as_json).source_location).
-              to(eq(original_implementation))
+            expect(BasicSocket.public_instance_method(:as_json).source_location)
+              .to(eq(original_implementation))
           end
         end
       else

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -43,7 +43,8 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
 
-      expect(payload['data'][:request]["handler"]).to include({:args=>[:foo, :bar], :method_name=>:do_job_please!})
+      expect(payload['data'][:request]['handler']).to include({ :args => [:foo, :bar],
+                                                                :method_name => :do_job_please! })
     end
   end
 
@@ -52,9 +53,9 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
       [/Delayed::DeserializationError/, { :use_exception_level_filters => true }]
     end
     let(:new_expected_args) do
-      [instance_of(Delayed::DeserializationError), { :use_exception_level_filters => true }]
+      [instance_of(Delayed::DeserializationError),
+       { :use_exception_level_filters => true }]
     end
-
 
     it 'sends the exception' do
       expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original

--- a/spec/rollbar/plugins/rack_spec.rb
+++ b/spec/rollbar/plugins/rack_spec.rb
@@ -27,7 +27,8 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
   let(:uncaught_level) { Rollbar.configuration.uncaught_exception_level }
 
   it 'reports the error to Rollbar' do
-    expect(Rollbar).to receive(:log).with(uncaught_level, exception, :use_exception_level_filters => true)
+    expect(Rollbar).to receive(:log).with(uncaught_level, exception,
+                                          :use_exception_level_filters => true)
     expect { request.get('/will_crash') }.to raise_error(exception)
   end
 
@@ -66,7 +67,8 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
 
     it 'sends them to Rollbar' do
       expect do
-        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+        request.post('/will_crash', :input => params.to_json,
+                                    'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
       expect(Rollbar.last_report[:request][:body]).to be_eql(params.to_json)
@@ -80,10 +82,11 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
 
     it 'scrubs the body' do
       expect do
-        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+        request.post('/will_crash', :input => params.to_json,
+                                    'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
-      expect(Rollbar.last_report[:request][:body]).to be_eql("{\"password\":\"******\"}")
+      expect(Rollbar.last_report[:request][:body]).to be_eql('{"password":"******"}')
     end
   end
 
@@ -94,11 +97,13 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
 
     it 'sends a body.multi key in params' do
       expect do
-        request.post('/will_crash', :input => params.to_json, 'CONTENT_TYPE' => 'application/json')
+        request.post('/will_crash', :input => params.to_json,
+                                    'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
       reported_body = Rollbar.last_report[:request][:body]
-      expect(reported_body).to be_eql({ 'body.multi' => [{ 'key' => 'value' }, 'string', 10] }.to_json)
+      expect(reported_body).to be_eql({ 'body.multi' => [{ 'key' => 'value' }, 'string',
+                                                         10] }.to_json)
     end
   end
 
@@ -107,7 +112,8 @@ describe Rollbar::Middleware::Rack::Builder, :reconfigure_notifier => true do
 
     it 'sends a body.multi key in params' do
       expect do
-        request.post('/will_crash', :input => params, 'CONTENT_TYPE' => 'application/json')
+        request.post('/will_crash', :input => params,
+                                    'CONTENT_TYPE' => 'application/json')
       end.to raise_error(exception)
 
       reported_body = Rollbar.last_report[:request][:body]

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -20,7 +20,9 @@ describe ApplicationController, :type => 'request' do
     it 'renders the snippet and config in the response', :type => 'request' do
       get '/test_rollbar_js'
 
-      snippet_from_submodule = File.read(File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
+      snippet_from_submodule = File.read(File.expand_path(
+                                           '../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__
+                                         ))
 
       expect(response.body).to include("var _rollbarConfig = #{Rollbar.configuration.js_options.to_json};")
       expect(response.body).to include(snippet_from_submodule)
@@ -60,7 +62,9 @@ describe ApplicationController, :type => 'request' do
 
     def nonce_present
       # Rails will add the nonce to script_src when the generator is set.
-      Rails.application.config.content_security_policy_nonce_generator = lambda { |_| SecureRandom.base64(16) }
+      Rails.application.config.content_security_policy_nonce_generator = lambda { |_|
+        SecureRandom.base64(16)
+      }
 
       Rails.application.config.content_security_policy do |policy|
         policy.script_src :self, :https
@@ -76,7 +80,9 @@ describe ApplicationController, :type => 'request' do
     end
 
     def script_src_not_present
-      Rails.application.config.content_security_policy_nonce_generator = lambda { |_| SecureRandom.base64(16) }
+      Rails.application.config.content_security_policy_nonce_generator = lambda { |_|
+        SecureRandom.base64(16)
+      }
 
       # This is a valid policy, but Rails will not apply the nonce to script_src.
       Rails.application.config.content_security_policy do |policy|
@@ -87,7 +93,9 @@ describe ApplicationController, :type => 'request' do
 
     def unsafe_inline_present
       # Rails will add the nonce to script_src when the generator is set.
-      Rails.application.config.content_security_policy_nonce_generator = lambda { |_| SecureRandom.base64(16) }
+      Rails.application.config.content_security_policy_nonce_generator = lambda { |_|
+        SecureRandom.base64(16)
+      }
 
       Rails.application.config.content_security_policy do |policy|
         policy.script_src :unsafe_inline
@@ -186,7 +194,6 @@ describe ApplicationController, :type => 'request' do
 
   context 'using secure_headers',
           :if => (Gem::Version.new(Rails.version) >= Gem::Version.new('5.0.0')) do
-
     before do
       configure_csp(nonce_mode)
     end
@@ -197,6 +204,7 @@ describe ApplicationController, :type => 'request' do
 
     def configure_csp(mode)
       return unless defined?(::SecureHeaders)
+
       if mode == :nonce_present
         nonce_present
       elsif mode == :nonce_not_present
@@ -211,8 +219,8 @@ describe ApplicationController, :type => 'request' do
     def nonce_present
       config = ::SecureHeaders::Configuration.new do |config|
         config.csp = {
-          :default_src => %w('none'),
-          :script_src => %w('self')
+          :default_src => %w['none'],
+          :script_src => %w['self']
         }
       end
       ::SecureHeaders::Configuration.instance_variable_set(:@default_config, config)
@@ -221,8 +229,8 @@ describe ApplicationController, :type => 'request' do
     def nonce_not_present
       config = ::SecureHeaders::Configuration.new do |config|
         config.csp = {
-          :default_src => %w('none'),
-          :script_src => %w('self')
+          :default_src => %w['none'],
+          :script_src => %w['self']
         }
       end
       ::SecureHeaders::Configuration.instance_variable_set(:@default_config, config)
@@ -231,8 +239,8 @@ describe ApplicationController, :type => 'request' do
     def unsafe_inline_present
       config = ::SecureHeaders::Configuration.new do |config|
         config.csp = {
-          :default_src => %w('none'),
-          :script_src => %w('unsafe-inline')
+          :default_src => %w['none'],
+          :script_src => %w['unsafe-inline']
         }
       end
       ::SecureHeaders::Configuration.instance_variable_set(:@default_config, config)

--- a/spec/rollbar/plugins/rake_spec.rb
+++ b/spec/rollbar/plugins/rake_spec.rb
@@ -12,7 +12,8 @@ describe Rollbar::Rake do
     end
 
     it 'reports error to Rollbar' do
-      expect(Rollbar).to receive(:error).with(exception, :use_exception_level_filters => true)
+      expect(Rollbar).to receive(:error).with(exception,
+                                              :use_exception_level_filters => true)
       expect(application).to receive(:orig_display_error_message).with(exception)
 
       Rollbar::Rake.patch! # Really here Rake is already patched

--- a/spec/rollbar/plugins/resque/failure_spec.rb
+++ b/spec/rollbar/plugins/resque/failure_spec.rb
@@ -16,7 +16,8 @@ describe Resque::Failure::Rollbar do
     end
 
     it 'should be notified of an error' do
-      expect_any_instance_of(Rollbar::Notifier).to receive(:log).with('error', exception, payload)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:log).with('error', exception,
+                                                                      payload)
       backend.save
     end
   end
@@ -29,7 +30,8 @@ describe Resque::Failure::Rollbar do
     end
 
     it 'sends the :use_exception_level_filters option' do
-      expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(exception, payload_with_options)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(exception,
+                                                                        payload_with_options)
       backend.save
     end
   end

--- a/spec/rollbar/plugins/sidekiq_spec.rb
+++ b/spec/rollbar/plugins/sidekiq_spec.rb
@@ -73,7 +73,8 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
 
     it 'sends the passed-in error to rollbar' do
       allow(Rollbar).to receive(:scope).and_return(rollbar)
-      expect(rollbar).to receive(:error).with(exception, :use_exception_level_filters => true)
+      expect(rollbar).to receive(:error).with(exception,
+                                              :use_exception_level_filters => true)
 
       described_class.handle_exception(msg, exception)
     end

--- a/spec/rollbar/rake_tasks_spec.rb
+++ b/spec/rollbar/rake_tasks_spec.rb
@@ -17,7 +17,9 @@ describe RollbarTest do
 
     context 'when rollbar is not configured' do
       it 'exits with token error message' do
-        expect { subject.run }.to output(Regexp.new(subject.token_error_message)).to_stdout
+        expect do
+          subject.run
+        end.to output(Regexp.new(subject.token_error_message)).to_stdout
       end
     end
 

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -11,7 +11,8 @@ describe Rollbar::RequestDataExtractor do
   subject { ExtractorDummy.new }
 
   let(:env) do
-    Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'localhost:81', 'HTTP_X_FORWARDED_HOST' => 'example.org:9292')
+    Rack::MockRequest.env_for('/', 'HTTP_HOST' => 'localhost:81',
+                                   'HTTP_X_FORWARDED_HOST' => 'example.org:9292')
   end
 
   describe '#scrub_url' do
@@ -85,7 +86,9 @@ describe Rollbar::RequestDataExtractor do
     end
 
     context 'with scrub headers set' do
-      let(:scrub_headers) { ['HTTP_UPPER_CASE_HEADER', 'http-lower-case-header', 'Mixed-CASE-header'] }
+      let(:scrub_headers) do
+        %w[HTTP_UPPER_CASE_HEADER http-lower-case-header Mixed-CASE-header]
+      end
 
       let(:env) do
         env = Rack::MockRequest.env_for('/',
@@ -110,7 +113,8 @@ describe Rollbar::RequestDataExtractor do
 
     context 'with invalid utf8 sequence in key' do
       let(:data) do
-        File.read(File.expand_path('../../support/encodings/iso_8859_9', __FILE__)).force_encoding(Encoding::ISO_8859_9)
+        File.read(File.expand_path('../../support/encodings/iso_8859_9',
+                                   __FILE__)).force_encoding(Encoding::ISO_8859_9)
       end
       let(:env) do
         env = Rack::MockRequest.env_for('/',
@@ -294,8 +298,6 @@ describe Rollbar::RequestDataExtractor do
         result = subject.extract_request_data_from_rack(env)
         expect(result[:body]).to be_eql(body)
       end
-
-
     end
 
     context 'with JSON DELETE body' do

--- a/spec/rollbar/scrubbers/params_spec.rb
+++ b/spec/rollbar/scrubbers/params_spec.rb
@@ -599,7 +599,8 @@ end
 
 describe Rollbar::Scrubbers::Params::ATTACHMENT_CLASSES do
   it 'has the correct values' do
-    expect(described_class).to be_eql(%w[ActionDispatch::Http::UploadedFile Rack::Multipart::UploadedFile].freeze)
+    expect(described_class).to be_eql(%w[ActionDispatch::Http::UploadedFile
+                                         Rack::Multipart::UploadedFile].freeze)
   end
 end
 

--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -35,7 +35,9 @@ describe Rollbar::Scrubbers::URL do
         end
 
         context 'with arrays in params' do
-          let(:url) { 'http://user:password@foo.com/some-interesting-path?foo[]=1&foo[]=2' }
+          let(:url) do
+            'http://user:password@foo.com/some-interesting-path?foo[]=1&foo[]=2'
+          end
 
           it 'returns the URL without any change' do
             expect(subject.call(options)).to be_eql(url)
@@ -56,14 +58,16 @@ describe Rollbar::Scrubbers::URL do
         let(:url) { 'http://user:password@foo.com/some-interesting-path#fragment' }
 
         it 'returns the URL without any change' do
-          expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/some-interesting\-path#fragment}
+          expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/some-interesting-path#fragment}
 
           expect(subject.call(options)).to match(expected_url)
         end
       end
 
       context 'with params to be filtered' do
-        let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue#fragment' }
+        let(:url) do
+          'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue#fragment'
+        end
 
         it 'returns the URL with some params filtered' do
           expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password=\*{3,8}&secret=\*{3,8}#fragment}
@@ -72,7 +76,9 @@ describe Rollbar::Scrubbers::URL do
         end
 
         context 'having array params' do
-          let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue#fragment' }
+          let(:url) do
+            'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue#fragment'
+          end
 
           it 'returns the URL with some params filtered' do
             expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=\*{3,8}#fragment}
@@ -93,7 +99,9 @@ describe Rollbar::Scrubbers::URL do
           }
         end
         let(:password) { 'longpasswordishere' }
-        let(:url) { "http://foo.com/some-interesting-path?foo=bar&password=#{password}#fragment" }
+        let(:url) do
+          "http://foo.com/some-interesting-path?foo=bar&password=#{password}#fragment"
+        end
 
         it 'scrubs with same length than the scrubbed param' do
           expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password=\*{#{password.length}}#fragment}
@@ -123,7 +131,9 @@ describe Rollbar::Scrubbers::URL do
       end
 
       context 'with non-ASCII ASCII-8BIT encoded URL' do
-        let(:url) { 'http://foo.com/some-path?foo=あああ'.force_encoding(Encoding::ASCII_8BIT) }
+        let(:url) do
+          'http://foo.com/some-path?foo=あああ'.force_encoding(Encoding::ASCII_8BIT)
+        end
         before { reconfigure_notifier }
 
         it 'returns the URI encoded url' do
@@ -139,7 +149,8 @@ describe Rollbar::Scrubbers::URL do
         let(:options) do
           {
             :url => url,
-            :scrub_fields => [:passwd, :password, :password_confirmation, :secret, :confirm_password, :secret_token, :api_key, :access_token, :auth, :SAMLResponse, :password, :auth],
+            :scrub_fields => [:passwd, :password, :password_confirmation, :secret,
+                              :confirm_password, :secret_token, :api_key, :access_token, :auth, :SAMLResponse, :password, :auth],
             :scrub_user => true,
             :scrub_password => true,
             :randomize_scrub_length => true
@@ -179,7 +190,7 @@ describe Rollbar::Scrubbers::URL do
           let(:url) { 'http://user:password@foo.com/some-interesting-path#fragment' }
 
           it 'returns the URL without any change' do
-            expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/some-interesting\-path#fragment}
+            expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/some-interesting-path#fragment}
 
             expect(subject.call(options)).to match(expected_url)
           end
@@ -195,7 +206,9 @@ describe Rollbar::Scrubbers::URL do
               :whitelist => whitelist
             }
           end
-          let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment' }
+          let(:url) do
+            'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment'
+          end
 
           it 'returns the URL with some params filtered' do
             expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
@@ -204,7 +217,9 @@ describe Rollbar::Scrubbers::URL do
           end
 
           context 'having array params' do
-            let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment' }
+            let(:url) do
+              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
+            end
 
             it 'returns the URL with some params filtered' do
               expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
@@ -225,7 +240,9 @@ describe Rollbar::Scrubbers::URL do
             }
           end
 
-          let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment' }
+          let(:url) do
+            'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment'
+          end
 
           it 'returns the URL with some params filtered' do
             expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
@@ -234,7 +251,9 @@ describe Rollbar::Scrubbers::URL do
           end
 
           context 'having array params' do
-            let(:url) { 'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment' }
+            let(:url) do
+              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
+            end
 
             it 'returns the URL with some params filtered' do
               expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}

--- a/spec/rollbar/truncation/remove_any_key_strategy_spec.rb
+++ b/spec/rollbar/truncation/remove_any_key_strategy_spec.rb
@@ -55,7 +55,8 @@ describe Rollbar::Truncation::RemoveAnyKeyStrategy do
 
       expect(result['data']['body']).to be_eql(truncation_message)
       expect(result['data']['request']).to be_eql(request)
-      expect(result['data']['title']).to be_eql([exception_class, exception_message].join(': '))
+      expect(result['data']['title']).to be_eql([exception_class,
+                                                 exception_message].join(': '))
       expect(result['unknown_root_key']).to be_nil
       expect(result['data']['notifier']).to be_eql(diagnostic)
 

--- a/spec/rollbar/util_spec.rb
+++ b/spec/rollbar/util_spec.rb
@@ -101,7 +101,7 @@ describe Rollbar::Util do
     context 'with frozen data' do
       let(:data) do
         {
-          :foo => ['bar', 'baz', 'buzz'].freeze,
+          :foo => %w[bar baz buzz].freeze,
           :baz => 'buzz'.freeze
         }
       end

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -87,7 +87,10 @@ describe Rollbar do
     end
 
     let(:logger_mock) { double('Rails.logger').as_null_object }
-    let(:user) { User.create(:email => 'email@example.com', :encrypted_password => '', :created_at => Time.now, :updated_at => Time.now) }
+    let(:user) do
+      User.create(:email => 'email@example.com', :encrypted_password => '',
+                  :created_at => Time.now, :updated_at => Time.now)
+    end
 
     it 'should report simple messages' do
       allow(Rollbar).to receive(:notifier).and_return(notifier)
@@ -118,7 +121,8 @@ describe Rollbar do
         :extra_foo => 'extra_bar'
       }
 
-      Rollbar.report_message_with_request('Test message', 'info', request_data, person_data, extra_data)
+      Rollbar.report_message_with_request('Test message', 'info', request_data,
+                                          person_data, extra_data)
 
       Rollbar.last_report[:request].should eq(request_data)
       Rollbar.last_report[:person].should eq(person_data)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -15,18 +15,18 @@ require 'spec_helper'
 begin
   require 'rollbar/delay/sidekiq'
   require 'rollbar/delay/sucker_punch'
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError
 end
 
 begin
   require 'sucker_punch'
   require 'sucker_punch/testing/inline'
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError
 end
 
 begin
   require 'rollbar/delay/shoryuken'
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError
 end
 
 describe Rollbar do
@@ -162,7 +162,8 @@ describe Rollbar do
       it 'should report a simple message with extra data' do
         extra_data = { :key => 'value', :hash => { :inner_key => 'inner_value' } }
 
-        expect(notifier).to receive(:report).with('error', 'test message', nil, extra_data, nil)
+        expect(notifier).to receive(:report).with('error', 'test message', nil,
+                                                  extra_data, nil)
         notifier.log('error', 'test message', extra_data)
       end
 
@@ -174,19 +175,22 @@ describe Rollbar do
       it 'should report an exception with extra data' do
         extra_data = { :key => 'value', :hash => { :inner_key => 'inner_value' } }
 
-        expect(notifier).to receive(:report).with('error', nil, exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('error', nil, exception, extra_data,
+                                                  nil)
         notifier.log('error', exception, extra_data)
       end
 
       it 'should report an exception with a description' do
-        expect(notifier).to receive(:report).with('error', 'exception description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('error', 'exception description',
+                                                  exception, nil, nil)
         notifier.log('error', exception, 'exception description')
       end
 
       it 'should report an exception with a description and extra data' do
         extra_data = { :key => 'value', :hash => { :inner_key => 'inner_value' } }
 
-        expect(notifier).to receive(:report).with('error', 'exception description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('error', 'exception description',
+                                                  exception, extra_data, nil)
         notifier.log('error', exception, extra_data, 'exception description')
       end
 
@@ -203,7 +207,8 @@ describe Rollbar do
           notifier.log('error', 'test message', extra_data)
         end
 
-        it 'should unpack multi-byte and send as single byte on ruby == 2.6.0', :if => RUBY_VERSION == '2.6.0' do
+        it 'should unpack multi-byte and send as single byte on ruby == 2.6.0',
+           :if => RUBY_VERSION == '2.6.0' do
           expect_any_instance_of(Net::HTTP::Post).to receive(:body=).with(
             satisfy do |body|
               body.chars.length == body.bytes.length && body.force_encoding('utf-8').include?('あああ')
@@ -231,12 +236,15 @@ describe Rollbar do
 
         before do
           notifier.configuration = configuration
-          allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(:code => 500, :body => 'Error'))
+          allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(
+                                                                             :code => 500, :body => 'Error'
+                                                                           ))
           @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
         end
 
         it 'calls the :on_error_response hook if response status is not 200' do
-          expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil, nil).and_call_original
+          expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil,
+                                                  nil).and_call_original
           expect(notifier.configuration.hook(:on_error_response)).to receive(:call)
 
           notifier.log(level, message)
@@ -285,7 +293,8 @@ describe Rollbar do
           end
 
           it 'should have access to the context data through configuration.custom_data_method' do
-            result = notifier.log('error', 'Custom message', :custom_data_method_context => context)
+            result = notifier.log('error', 'Custom message',
+                                  :custom_data_method_context => context)
 
             result[:body][:message][:extra].should_not be_nil
             result[:body][:message][:extra][:result].should eq('MyApp#' + context[:controller])
@@ -556,10 +565,12 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('debug', nil, exception, nil, nil)
         notifier.debug(exception)
 
-        expect(notifier).to receive(:report).with('debug', 'description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('debug', 'description', exception, nil,
+                                                  nil)
         notifier.debug(exception, 'description')
 
-        expect(notifier).to receive(:report).with('debug', 'description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('debug', 'description', exception,
+                                                  extra_data, nil)
         notifier.debug(exception, 'description', extra_data)
       end
 
@@ -567,10 +578,12 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('info', nil, exception, nil, nil)
         notifier.info(exception)
 
-        expect(notifier).to receive(:report).with('info', 'description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('info', 'description', exception, nil,
+                                                  nil)
         notifier.info(exception, 'description')
 
-        expect(notifier).to receive(:report).with('info', 'description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('info', 'description', exception,
+                                                  extra_data, nil)
         notifier.info(exception, 'description', extra_data)
       end
 
@@ -578,10 +591,12 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('warning', nil, exception, nil, nil)
         notifier.warning(exception)
 
-        expect(notifier).to receive(:report).with('warning', 'description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('warning', 'description', exception,
+                                                  nil, nil)
         notifier.warning(exception, 'description')
 
-        expect(notifier).to receive(:report).with('warning', 'description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('warning', 'description', exception,
+                                                  extra_data, nil)
         notifier.warning(exception, 'description', extra_data)
       end
 
@@ -589,10 +604,12 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('error', nil, exception, nil, nil)
         notifier.error(exception)
 
-        expect(notifier).to receive(:report).with('error', 'description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('error', 'description', exception, nil,
+                                                  nil)
         notifier.error(exception, 'description')
 
-        expect(notifier).to receive(:report).with('error', 'description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('error', 'description', exception,
+                                                  extra_data, nil)
         notifier.error(exception, 'description', extra_data)
       end
 
@@ -600,10 +617,12 @@ describe Rollbar do
         expect(notifier).to receive(:report).with('critical', nil, exception, nil, nil)
         notifier.critical(exception)
 
-        expect(notifier).to receive(:report).with('critical', 'description', exception, nil, nil)
+        expect(notifier).to receive(:report).with('critical', 'description', exception,
+                                                  nil, nil)
         notifier.critical(exception, 'description')
 
-        expect(notifier).to receive(:report).with('critical', 'description', exception, extra_data, nil)
+        expect(notifier).to receive(:report).with('critical', 'description', exception,
+                                                  extra_data, nil)
         notifier.critical(exception, 'description', extra_data)
       end
     end
@@ -735,7 +754,10 @@ describe Rollbar do
     end
 
     let(:logger_mock) { double('Rails.logger').as_null_object }
-    let(:user) { User.create(:email => 'email@example.com', :encrypted_password => '', :created_at => Time.now, :updated_at => Time.now) }
+    let(:user) do
+      User.create(:email => 'email@example.com', :encrypted_password => '',
+                  :created_at => Time.now, :updated_at => Time.now)
+    end
 
     before do
       Rollbar.unconfigure
@@ -857,7 +879,7 @@ describe Rollbar do
       it 'sets error level using lambda' do
         Rollbar.configure do |config|
           config.exception_level_filters = {
-            'NameError' => lambda { |error| 'info' }
+            'NameError' => lambda { |_error| 'info' }
           }
         end
 
@@ -1054,7 +1076,9 @@ describe Rollbar do
       gem_lib_dir = gem_dir + '/lib'
       last_report = Rollbar.last_report
 
-      filepaths = last_report[:body][:trace][:frames].map { |frame| frame[:filename] }.reverse
+      filepaths = last_report[:body][:trace][:frames].map do |frame|
+        frame[:filename]
+      end.reverse
 
       expect(filepaths[0]).not_to include(gem_lib_dir)
       expect(filepaths.any? { |filepath| filepath.include?(gem_dir) }).to eq true
@@ -1133,7 +1157,7 @@ describe Rollbar do
         exc_with_stack = nil
         begin
           raise exception
-        rescue => e
+        rescue StandardError => e
           exc_with_stack = e
         end
         Rollbar.error(exc_with_stack)
@@ -1161,7 +1185,10 @@ describe Rollbar do
     end
 
     let(:logger_mock) { double('Rails.logger').as_null_object }
-    let(:user) { User.create(:email => 'email@example.com', :encrypted_password => '', :created_at => Time.now, :updated_at => Time.now) }
+    let(:user) do
+      User.create(:email => 'email@example.com', :encrypted_password => '',
+                  :created_at => Time.now, :updated_at => Time.now)
+    end
 
     it 'should report simple messages' do
       logger_mock.should_receive(:info).with('[Rollbar] Scheduling item')
@@ -1333,7 +1360,8 @@ describe Rollbar do
         config.write_to_file = true
         config.files_with_pid_name_enabled = true
 
-        filepath = config.filepath.gsub(Rollbar::Notifier::EXTENSION_REGEXP, "_#{Process.pid}\\0")
+        filepath = config.filepath.gsub(Rollbar::Notifier::EXTENSION_REGEXP,
+                                        "_#{Process.pid}\\0")
       end
 
       Rollbar.error(exception)
@@ -1350,7 +1378,9 @@ describe Rollbar do
 
   context 'using a proxy server' do
     before do
-      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(:code => 200, :body => 'Success'))
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(OpenStruct.new(
+                                                                         :code => 200, :body => 'Success'
+                                                                       ))
       @env_vars = clear_proxy_env_vars
     end
 
@@ -1367,12 +1397,14 @@ describe Rollbar do
         ENV['http_proxy']  = 'http://user:pass@example.com:80'
         ENV['https_proxy'] = 'http://user:pass@example.com:80'
 
-        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'example.com', 80, 'user', 'pass').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'example.com', 80,
+                                                'user', 'pass').and_call_original
         Rollbar.info('proxy this')
       end
 
       it 'does not use a proxy if no proxy settings in environemnt' do
-        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil, nil).and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, nil, nil, nil,
+                                                nil).and_call_original
         Rollbar.info('proxy this')
       end
     end
@@ -1392,7 +1424,8 @@ describe Rollbar do
       end
 
       it 'honors proxy settings in the config file' do
-        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080,
+                                                'foo', 'bar').and_call_original
         Rollbar.info('proxy this')
       end
 
@@ -1400,7 +1433,8 @@ describe Rollbar do
         ENV['http_proxy']  = 'http://user:pass@example.com:80'
         ENV['https_proxy'] = 'http://user:pass@example.com:80'
 
-        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'bar').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080,
+                                                'foo', 'bar').and_call_original
         Rollbar.info('proxy this')
       end
 
@@ -1409,7 +1443,8 @@ describe Rollbar do
           config.proxy[:password] = 'manh@tan'
         end
 
-        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080, 'foo', 'manh@tan').and_call_original
+        expect(Net::HTTP).to receive(:new).with(@uri.host, @uri.port, 'config.com', 8080,
+                                                'foo', 'manh@tan').and_call_original
         Rollbar.info('proxy this')
       end
     end
@@ -1497,8 +1532,7 @@ describe Rollbar do
     end
 
     it 'should send without configured_options in payload when async_json_payload is not set',
-      :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
-
+       :if => Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1') do
       # Verify no configured_options
       logger_mock.should_receive(:info).with('not serialized when async_json_payload is not set')
 
@@ -1738,7 +1772,7 @@ describe Rollbar do
 
   context 'project_gems' do
     it 'should include gem paths for specified project gems in the payload' do
-      gems = ['rack', 'rspec-rails']
+      gems = %w[rack rspec-rails]
       gem_paths = []
 
       Rollbar.configure do |config|
@@ -1767,7 +1801,7 @@ describe Rollbar do
       end
 
       gem_paths = gems.map do |name|
-        Gem::Specification.each.select { |spec| name === spec.name } # rubocop:disable CaseEquality
+        Gem::Specification.each.select { |spec| name === spec.name }
       end.flatten.uniq.map(&:gem_dir)
 
       gem_paths.length.should be > 1
@@ -2058,7 +2092,8 @@ describe Rollbar do
 
     it 'retries the request' do
       expect_any_instance_of(Net::HTTP).to receive(:request).exactly(3)
-      expect(Rollbar.notifier).to receive(:report_internal_error).with(net_exception, anything)
+      expect(Rollbar.notifier).to receive(:report_internal_error).with(net_exception,
+                                                                       anything)
 
       Rollbar.info('foo')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,15 +79,23 @@ RSpec.configure do |config|
     Rollbar.clear_notifier!
 
     stub_request(:any, /api.rollbar.com/).to_rack(RollbarAPI.new) if defined?(WebMock)
-    stub_request(:post, %r{api.rollbar.com/api/[0-9]/deploy/$}).to_rack(DeployAPI::Report.new) if defined?(WebMock)
-    stub_request(:patch, %r{api.rollbar.com/api/[0-9]/deploy/[0-9]+}).to_rack(DeployAPI::Update.new) if defined?(WebMock)
+    if defined?(WebMock)
+      stub_request(:post,
+                   %r{api.rollbar.com/api/[0-9]/deploy/$}).to_rack(DeployAPI::Report.new)
+    end
+    if defined?(WebMock)
+      stub_request(:patch,
+                   %r{api.rollbar.com/api/[0-9]/deploy/[0-9]+}).to_rack(DeployAPI::Update.new)
+    end
   end
 
   config.after do
     DatabaseCleaner.clean
   end
 
-  config.infer_spec_type_from_file_location! if config.respond_to?(:infer_spec_type_from_file_location!)
+  if config.respond_to?(:infer_spec_type_from_file_location!)
+    config.infer_spec_type_from_file_location!
+  end
   config.backtrace_exclusion_patterns = [%r{gems/rspec-.*}]
 
   config.include RSpecCommand if defined?(RSpecCommand)

--- a/spec/support/deploy_api/update.rb
+++ b/spec/support/deploy_api/update.rb
@@ -30,7 +30,9 @@ module DeployAPI
     end
 
     def access_token(request)
-      CGI.parse(request.env['QUERY_STRING'])['access_token'][0] unless CGI.parse(request.env['QUERY_STRING'])['access_token'].empty?
+      unless CGI.parse(request.env['QUERY_STRING'])['access_token'].empty?
+        CGI.parse(request.env['QUERY_STRING'])['access_token'][0]
+      end
     end
 
     def success_body(json, request)


### PR DESCRIPTION
## Description of the change

Rubocop has been pinned at version 0.93 for a long time, and also fell out of CI when Codacy was disabled for all SDKs. Most of the changes in this current round of PRs can be attributed to three factors:
* Rule changes introduced since 0.93
* Enforcing line length, which had never been enforced before
* Rollbar-gem was never fully green in the past, though nearly green except for method complexity.

Bringing rubocop up to date will be done in a series of PRs to help ease the code review burden, but also to get the changes that touch the most files (this PR) merged as soon as possible. Since this PR is limited to autocorrect fixes, review should be mostly mechanical and there hopefully shouldn't be a high cognitive load.

As usual, separate commits are used to help the reviewer.

* Updates rubocop from 0.93.0 to 1.15.0.
* TargetRubyVersion: 2.5 (This is the minimum allowed for current rubocop.)
* enable Layout/LineLength (max length 90)
* disable Style/RedundantBegin (Ruby < 2.5 needs begin/end inside blocks.)
* disable Layout/HeredocIndentation (For Ruby < 2.3. See below.)
* disable Lint/SendWithMixinArgument (Ruby 2.0 still has private `Object.include`)
* rubocop -a,  apply safe autocorrect changes

### TargetRubyVersion
Current rubocop only allows a minimum of 2.5 here, but we need to support 2.0 and up. We set this to the lowest allowed, and will need to modify specific rules as needed for differences in lower versions.

### Disable Style/RedundantBegin
The options for Layout/HeredocIndentation include modern squiggly syntax, and polyfill kinds of solutions, but not reliably the old syntax. Therefore we disable this rule for as long as we support < 2.3.

### Line length
The previous settings didn't only allow long lines. Frequently it _forced_ long lines because rubocop often prefers single line syntax for things if the line length limit allows it. Therefore many of the refactored long lines existed to prevent rubocop violations.

Upcoming PRs will address the following:
* Fix remaining rubocop issues.
* Reorganize cops in rubocop.yml. (for example, use lexicographic order of rules.)
* Remove obsolete Ruby 1.9 requirements
* Enable CI workflow
* Review performance cops, and update as needed

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style refactor

## Related issues

ch85855

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
