### PR TITLE
Fix line length offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/vendor/**/*'
+    - 'spec/dummyapp/**/*'
+    - 'spec/tmp/**/*'
   TargetRubyVersion: 2.5 # This is the minimum allowed for current rubocop
 
 Gemspec/RequiredRubyVersion:

--- a/lib/generators/rollbar/rollbar_generator.rb
+++ b/lib/generators/rollbar/rollbar_generator.rb
@@ -14,7 +14,8 @@ module Rollbar
         say 'creating initializer...'
         if access_token_configured?
           say "It looks like you've already configured Rollbar."
-          say 'To re-create the config file, remove it first: config/initializers/rollbar.rb'
+          say 'To re-create the config file, remove it first: ' \
+            'config/initializers/rollbar.rb'
           exit
         end
 
@@ -26,8 +27,10 @@ module Rollbar
         if defined? EY::Config
           say 'Access token will be read from Engine Yard configuration'
         elsif access_token === :use_env_sentinel
-          say 'Generator run without an access token; assuming you want to configure using an environment variable.'
-          say "You'll need to add an environment variable ROLLBAR_ACCESS_TOKEN with your access token:"
+          say 'Generator run without an access token; assuming you want to ' \
+            'configure using an environment variable.'
+          say "You'll need to add an environment variable ROLLBAR_ACCESS_TOKEN " \
+            'with your access token:'
           say "\n$ export ROLLBAR_ACCESS_TOKEN=yourtokenhere"
           say "\nIf that's not what you wanted to do:"
           say "\n$ rm config/initializers/rollbar.rb"

--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -4,7 +4,10 @@ require 'rollbar'
 # Rails.root is not present here.
 # RSpec needs ENV['DUMMYAPP_PATH'] in order to have a valid path.
 # Dir.pwd is used in normal operation.
-APP_PATH = File.expand_path('config/application', (ENV['DUMMYAPP_PATH'] || Dir.pwd))
+APP_PATH = File.expand_path(
+  'config/application',
+  (ENV['DUMMYAPP_PATH'] || Dir.pwd)
+)
 
 module Rails
   class RollbarRunner
@@ -72,7 +75,11 @@ module Rails
     end
 
     def railties_gem
-      resolver_class = Gem::Specification.respond_to?(:find_by_name) ? GemResolver : LegacyGemResolver
+      resolver_class = if Gem::Specification.respond_to?(:find_by_name)
+                         GemResolver
+                       else
+                         LegacyGemResolver
+                       end
       gem = resolver_class.new.railties_gem
 
       abort 'railties gem not found' unless gem

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -159,8 +159,10 @@ module Rollbar
 
     # Backwards compatibility methods
 
-    def report_exception(exception, request_data = nil, person_data = nil, level = 'error')
-      Kernel.warn('[DEPRECATION] Rollbar.report_exception has been deprecated, please use log() or one of the level functions')
+    def report_exception(exception, request_data = nil, person_data = nil,
+                         level = 'error')
+      Kernel.warn('[DEPRECATION] Rollbar.report_exception has been deprecated, ' \
+        'please use log() or one of the level functions')
 
       scope = {}
       scope[:request] = request_data if request_data
@@ -172,13 +174,16 @@ module Rollbar
     end
 
     def report_message(message, level = 'info', extra_data = nil)
-      Kernel.warn('[DEPRECATION] Rollbar.report_message has been deprecated, please use log() or one of the level functions')
+      Kernel.warn('[DEPRECATION] Rollbar.report_message has been deprecated, ' \
+        'please use log() or one of the level functions')
 
       Rollbar.notifier.log(level, message, extra_data)
     end
 
-    def report_message_with_request(message, level = 'info', request_data = nil, person_data = nil, extra_data = nil)
-      Kernel.warn('[DEPRECATION] Rollbar.report_message_with_request has been deprecated, please use log() or one of the level functions')
+    def report_message_with_request(message, level = 'info', request_data = nil,
+                                    person_data = nil, extra_data = nil)
+      Kernel.warn('[DEPRECATION] Rollbar.report_message_with_request has been ' \
+        'deprecated, please use log() or one of the level functions')
 
       scope = {}
       scope[:request] = request_data if request_data

--- a/lib/rollbar/capistrano.rb
+++ b/lib/rollbar/capistrano.rb
@@ -35,7 +35,9 @@ module Rollbar
           _cset(:rollbar_user)  { ENV['USER'] || ENV['USERNAME'] }
           _cset(:rollbar_env)   { fetch(:rails_env, 'production') }
           _cset(:rollbar_token) do
-            abort("Please specify the Rollbar access token, set :rollbar_token, 'your token'")
+            abort(
+              "Please specify the Rollbar access token, set :rollbar_token, 'your token'"
+            )
           end
           _cset(:rollbar_revision) { real_revision }
           _cset(:rollbar_comment) { nil }
@@ -53,8 +55,9 @@ module Rollbar
           :task => :deploy_started,
           :configuration => configuration
         ) do
-          ::Rollbar::CapistranoTasks.deploy_started(configuration, configuration.logger,
-                                                    configuration.dry_run)
+          ::Rollbar::CapistranoTasks.deploy_started(
+            configuration, configuration.logger, configuration.dry_run
+          )
         end
       end
 
@@ -64,8 +67,9 @@ module Rollbar
           :task => :deploy_succeeded,
           :configuration => configuration
         ) do
-          ::Rollbar::CapistranoTasks.deploy_succeeded(configuration,
-                                                      configuration.logger, configuration.dry_run)
+          ::Rollbar::CapistranoTasks.deploy_succeeded(
+            configuration, configuration.logger, configuration.dry_run
+          )
         end
       end
 

--- a/lib/rollbar/capistrano3.rb
+++ b/lib/rollbar/capistrano3.rb
@@ -9,7 +9,8 @@ require 'rollbar/capistrano_tasks'
 namespace :rollbar do
   # dry_run? wasn't introduced till Capistrano 3.5.0; use the old fetch(:sshkit_backed)
   set :dry_run, (proc {
-                   ::Capistrano::Configuration.env.fetch(:sshkit_backend) == ::SSHKit::Backend::Printer
+                   ::Capistrano::Configuration.env.fetch(:sshkit_backend) ==
+                     ::SSHKit::Backend::Printer
                  })
 
   desc 'Send deployment started notification to Rollbar.'
@@ -52,7 +53,8 @@ namespace :load do
     set :rollbar_user,      (proc { fetch :local_user, ENV['USER'] || ENV['USERNAME'] })
     set :rollbar_env,       (proc { fetch :rails_env, 'production' })
     set :rollbar_token,     (proc {
-                               abort "Please specify the Rollbar access token, set :rollbar_token, 'your token'"
+                               abort 'Please specify the Rollbar access token, ' \
+                                     "set :rollbar_token, 'your token'"
                              })
     set :rollbar_role,      (proc { :app })
     set :rollbar_revision,  (proc { fetch :current_revision })

--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -13,7 +13,9 @@ module Rollbar
           capistrano.set(:rollbar_deploy_id, 123) if dry_run
 
           skip_in_dry_run(logger, dry_run) do
-            if result[:success] && (deploy_id = result[:data] && result[:data][:deploy_id])
+            if result[:success] &&
+               (deploy_id = result[:data] &&
+               result[:data][:deploy_id])
               capistrano.set :rollbar_deploy_id, deploy_id
             else
               message = format_message('Unable to report deploy to Rollbar',
@@ -25,8 +27,9 @@ module Rollbar
       end
 
       def deploy_succeeded(capistrano, logger, dry_run)
-        deploy_update(capistrano, logger, dry_run,
-                      :desc => 'Setting deployment status to `succeeded` in Rollbar') do
+        deploy_update(
+          capistrano, logger, dry_run,
+          :desc => 'Setting deployment status to `succeeded` in Rollbar') do
           report_deploy_succeeded(capistrano, dry_run)
         end
       end
@@ -138,7 +141,8 @@ module Rollbar
       end
 
       def debug_request_response(logger, result)
-        # NOTE: in Capistrano debug messages go to log/capistrano.log but not to stdout even if log_level == :debug
+        # NOTE: in Capistrano debug messages go to log/capistrano.log but not to
+        # stdout even if log_level == :debug
         logger.debug result[:request_info]
         logger.debug result[:response_info] if result[:response_info]
       end

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -4,10 +4,79 @@ module Rollbar
   class Configuration
     SEND_EXTRA_FRAME_DATA_OPTIONS = [:none, :app, :all].freeze
 
-    attr_accessor :access_token, :async_handler, :branch, :capture_uncaught,
-                  :code_version, :custom_data_method, :delayed_job_enabled, :default_logger, :disable_monkey_patch, :disable_rack_monkey_patch, :disable_core_monkey_patch, :enable_error_context, :dj_threshold, :async_skip_report_handler, :enabled, :endpoint, :environment, :exception_level_filters, :failover_handlers, :framework, :ignored_person_ids, :host, :locals, :payload_options, :person_method, :person_id_method, :person_username_method, :person_email_method, :populate_empty_backtraces, :report_dj_data, :open_timeout, :request_timeout, :net_retries, :root, :js_options, :js_enabled, :safely, :scrub_fields, :scrub_user, :scrub_password, :scrub_whitelist, :collect_user_ip, :anonymize_user_ip, :user_ip_obfuscator_secret, :randomize_scrub_length, :uncaught_exception_level, :scrub_headers, :sidekiq_threshold, :sidekiq_use_scoped_block, :verify_ssl_peer, :use_async, :async_json_payload, :web_base, :use_exception_level_filters_default, :proxy, :raise_on_error, :transmit, :log_payload, :backtrace_cleaner, :write_to_file, :filepath, :files_with_pid_name_enabled, :files_processed_enabled, :files_processed_duration, :files_processed_size, :use_payload_access_token, :configured_options
-    attr_reader :before_process, :logger_level, :transform, :use_eventmachine,
-                :send_extra_frame_data, :project_gem_paths
+    attr_accessor :access_token,
+                  :anonymize_user_ip,
+                  :async_handler,
+                  :async_json_payload,
+                  :async_skip_report_handler,
+                  :backtrace_cleaner,
+                  :branch,
+                  :capture_uncaught,
+                  :code_version,
+                  :collect_user_ip,
+                  :configured_options,
+                  :custom_data_method,
+                  :default_logger,
+                  :delayed_job_enabled,
+                  :disable_core_monkey_patch,
+                  :disable_monkey_patch,
+                  :disable_rack_monkey_patch,
+                  :dj_threshold,
+                  :enable_error_context,
+                  :enabled,
+                  :endpoint,
+                  :environment,
+                  :exception_level_filters,
+                  :failover_handlers,
+                  :filepath,
+                  :files_processed_duration,
+                  :files_processed_enabled,
+                  :files_processed_size,
+                  :files_with_pid_name_enabled,
+                  :framework,
+                  :ignored_person_ids,
+                  :js_enabled,
+                  :js_options,
+                  :host,
+                  :locals,
+                  :log_payload,
+                  :net_retries,
+                  :open_timeout,
+                  :payload_options,
+                  :person_email_method,
+                  :person_id_method,
+                  :person_method,
+                  :person_username_method,
+                  :populate_empty_backtraces,
+                  :proxy,
+                  :raise_on_error,
+                  :randomize_scrub_length,
+                  :report_dj_data,
+                  :request_timeout,
+                  :root,
+                  :safely,
+                  :scrub_fields,
+                  :scrub_password,
+                  :scrub_user,
+                  :scrub_whitelist,
+                  :transmit,
+                  :uncaught_exception_level,
+                  :user_ip_obfuscator_secret,
+                  :scrub_headers,
+                  :sidekiq_threshold,
+                  :sidekiq_use_scoped_block,
+                  :use_async,
+                  :use_exception_level_filters_default,
+                  :use_payload_access_token,
+                  :verify_ssl_peer,
+                  :web_base,
+                  :write_to_file
+    attr_reader :before_process,
+                :logger_level,
+                :project_gem_paths,
+                :send_extra_frame_data,
+                :transform,
+                :use_eventmachine
     attr_writer :logger # seconds # bytes
 
     alias safely? safely
@@ -143,7 +212,8 @@ module Rollbar
     def use_active_job(options = {})
       require 'rollbar/delay/active_job'
 
-      Rollbar::Delay::ActiveJob.queue_as(options[:queue] || Rollbar::Delay::ActiveJob.default_queue_name)
+      Rollbar::Delay::ActiveJob.queue_as(options[:queue] ||
+      Rollbar::Delay::ActiveJob.default_queue_name)
 
       @use_async      = true
       @async_handler  = Rollbar::Delay::ActiveJob
@@ -183,8 +253,13 @@ module Rollbar
     end
 
     def use_sidekiq=(value)
-      deprecation_message = '#use_sidekiq=(value) has been deprecated in favor of #use_sidekiq(options = {}). Please update your rollbar configuration.'
-      defined?(ActiveSupport) ? ActiveSupport::Deprecation.warn(deprecation_message) : puts(deprecation_message)
+      deprecation_message = '#use_sidekiq=(value) has been deprecated in favor ' \
+        'of #use_sidekiq(options = {}). Please update your rollbar configuration.'
+      if defined?(ActiveSupport)
+        ActiveSupport::Deprecation.warn(deprecation_message)
+      else
+        puts(deprecation_message)
+      end
 
       value.is_a?(Hash) ? use_sidekiq(value) : use_sidekiq
     end
@@ -203,8 +278,13 @@ module Rollbar
     end
 
     def use_sucker_punch=(_value)
-      deprecation_message = '#use_sucker_punch=(value) has been deprecated in favor of #use_sucker_punch. Please update your rollbar configuration.'
-      defined?(ActiveSupport) ? ActiveSupport::Deprecation.warn(deprecation_message) : puts(deprecation_message)
+      deprecation_message = '#use_sucker_punch=(value) has been deprecated in ' \
+        'favor of #use_sucker_punch. Please update your rollbar configuration.'
+      if defined?(ActiveSupport)
+        ActiveSupport::Deprecation.warn(deprecation_message)
+      else
+        puts(deprecation_message)
+      end
 
       use_sucker_punch
     end
@@ -235,7 +315,9 @@ module Rollbar
 
     def send_extra_frame_data=(value)
       unless SEND_EXTRA_FRAME_DATA_OPTIONS.include?(value)
-        logger.warning("Wrong 'send_extra_frame_data' value, :none, :app or :full is expected")
+        logger.warning(
+          "Wrong 'send_extra_frame_data' value, :none, :app or :full is expected"
+        )
 
         return
       end

--- a/lib/rollbar/delay/shoryuken.rb
+++ b/lib/rollbar/delay/shoryuken.rb
@@ -2,9 +2,10 @@ require 'shoryuken'
 
 module Rollbar
   module Delay
-    # Following class allows to send rollbars using Sho-ryu-ken as a background jobs processor.
-    # see the queue_name method which states that your queues needs to be names as "rollbar_ENVIRONMENT".
-    # retry intervals will be used to retry sending the same message again if failed before.
+    # Following class allows to send rollbars using Sho-ryu-ken as a background
+    # jobs processor. See the queue_name method which states that your queues
+    # needs to be names as "rollbar_ENVIRONMENT". Retry intervals will be used
+    # to retry sending the same message again if failed before.
     class Shoryuken
       include ::Shoryuken::Worker
 

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -9,14 +9,20 @@ module Rollbar
 
       if exception_data.is_a?(Hash)
         env['rollbar.exception_uuid'] = exception_data[:uuid]
-        Rollbar.log_debug "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
+        Rollbar.log_debug(
+          "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
+        )
       elsif exception_data == 'disabled'
-        Rollbar.log_debug '[Rollbar] Exception not reported because Rollbar is disabled'
+        Rollbar.log_debug(
+          '[Rollbar] Exception not reported because Rollbar is disabled'
+        )
       elsif exception_data == 'ignored'
         Rollbar.log_debug '[Rollbar] Exception not reported because it was ignored'
       end
     rescue StandardError => e
-      Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e.message}"
+      Rollbar.log_warning(
+        "[Rollbar] Exception while reporting exception to Rollbar: #{e.message}"
+      )
     end
 
     def capture_uncaught?
@@ -24,7 +30,8 @@ module Rollbar
     end
 
     def log_exception_message(exception)
-      exception_message = exception.respond_to?(:message) ? exception.message : 'No Exception Message'
+      exception_message = exception.message if exception.respond_to?(:message)
+      exception_message ||= 'No Exception Message'
       Rollbar.log_debug "[Rollbar] Reporting exception: #{exception_message}"
     end
 

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -98,10 +98,12 @@ module Rollbar
     end
 
     def configured_options
-      if Gem.loaded_specs['activesupport'] && Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1')
-        # There are too many types that crash ActiveSupport JSON serialization, and not worth
-        # the risk just to send this diagnostic object. In versions < 4.1, ActiveSupport hooks
-        # Ruby's JSON.generate so deeply there's no workaround.
+      if Gem.loaded_specs['activesupport'] &&
+         Gem.loaded_specs['activesupport'].version < Gem::Version.new('4.1')
+        # There are too many types that crash ActiveSupport JSON serialization,
+        # and not worth the risk just to send this diagnostic object.
+        # In versions < 4.1, ActiveSupport hooks Ruby's JSON.generate so deeply
+        # that there's no workaround.
         'not serialized in ActiveSupport < 4.1'
       elsif configuration.use_async && !configuration.async_json_payload
         # The setting allows serialization to be performed by each handler,
@@ -144,12 +146,14 @@ module Rollbar
         nil,
         original_error
       )
-      logger.error("[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}")
+      logger.error('[Rollbar] Payload too large to be sent for UUID ' \
+        "#{uuid}: #{Rollbar::JSON.dump(payload)}")
     end
 
     def too_large_payload_string(attempts)
       'Could not send payload due to it being too large after truncating attempts. ' \
-        "Original size: #{attempts.first} Attempts: #{attempts.join(', ')} Final size: #{attempts.last}"
+        "Original size: #{attempts.first} Attempts: #{attempts.join(', ')} " \
+        "Final size: #{attempts.last}"
     end
 
     def ignored?
@@ -167,8 +171,9 @@ module Rollbar
       # When using async senders, if the access token is changed dynamically in
       # the main process config, the sender process won't see that change.
       #
-      # Until the delayed sender interface is changed to allow passing dynamic config options,
-      # this workaround allows the main process to set the token by adding it to the payload.
+      # Until the delayed sender interface is changed to allow passing dynamic
+      # config options, this workaround allows the main process to set the token
+      # by adding it to the payload.
       if configuration && configuration.use_payload_access_token
         payload['access_token'] ||= configuration.access_token
       end
@@ -204,7 +209,8 @@ module Rollbar
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
         Util.deep_merge(scrub(custom_data), merged_extra)
       else
-        merged_extra.empty? ? nil : merged_extra # avoid putting an empty {} in the payload.
+        merged_extra.empty? ? nil : merged_extra # avoid putting an empty {}
+                                                 # in the payload.
       end
     end
 

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -50,7 +50,10 @@ module Rollbar
 
         current_exception = exception
 
-        while current_exception.respond_to?(:cause) && (cause = current_exception.cause) && cause.is_a?(Exception) && !visited.include?(cause)
+        while current_exception.respond_to?(:cause) &&
+              (cause = current_exception.cause) &&
+              cause.is_a?(Exception) &&
+              !visited.include?(cause)
           traces << trace_data(cause)
           visited << cause
           current_exception = cause

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -30,7 +30,9 @@ module Rollbar
           response_string = add_js(env, app_result[2])
           build_response(env, app_result, response_string)
         rescue StandardError => e
-          Rollbar.log_error("[Rollbar] Rollbar.js could not be added because #{e} exception")
+          Rollbar.log_error(
+            "[Rollbar] Rollbar.js could not be added because #{e} exception"
+          )
 
           app_result
         end
@@ -58,7 +60,8 @@ module Rollbar
       def streaming?(env)
         return false unless defined?(ActionController::Live)
 
-        env['action_controller.instance'].class.included_modules.include?(ActionController::Live)
+        env['action_controller.instance']
+          .class.included_modules.include?(ActionController::Live)
       end
 
       def add_js(env, response)
@@ -72,7 +75,9 @@ module Rollbar
 
         build_body_with_js(env, body, insert_after_idx)
       rescue StandardError => e
-        Rollbar.log_error("[Rollbar] Rollbar.js could not be added because #{e} exception")
+        Rollbar.log_error(
+          "[Rollbar] Rollbar.js could not be added because #{e} exception"
+        )
         nil
       end
 
@@ -91,7 +96,8 @@ module Rollbar
 
         finished = response.finish
 
-        # Rack < 2.x Response#finish returns self in array[2]. Rack >= 2.x returns self.body.
+        # Rack < 2.x Response#finish returns self in array[2].
+        # Rack >= 2.x returns self.body.
         # Always return with the response object here regardless of rack version.
         finished[2] = response
         finished
@@ -159,9 +165,11 @@ module Rollbar
 
       def script_tag(content, env)
         if (nonce = rails5_nonce(env))
-          script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
+          script_tag_content = "\n<script type=\"text/javascript\" " \
+            "nonce=\"#{nonce}\">#{content}</script>"
         elsif (nonce = secure_headers_nonce(env))
-          script_tag_content = "\n<script type=\"text/javascript\" nonce=\"#{nonce}\">#{content}</script>"
+          script_tag_content = "\n<script type=\"text/javascript\" " \
+            "nonce=\"#{nonce}\">#{content}</script>"
         else
           script_tag_content = "\n<script type=\"text/javascript\">#{content}</script>"
         end
@@ -212,7 +220,10 @@ module Rollbar
 
         secure_headers_cls = nil
 
-        secure_headers_cls = if !::SecureHeaders.respond_to?(:content_security_policy_script_nonce)
+        has_nonce = ::SecureHeaders.respond_to?(
+          :content_security_policy_script_nonce
+        )
+        secure_headers_cls = if !has_nonce
                                SecureHeadersFalse
                              elsif config.respond_to?(:get)
                                SecureHeaders3To5
@@ -226,7 +237,8 @@ module Rollbar
       end
 
       def secure_headers_nonce_key(req)
-        defined?(::SecureHeaders::NONCE_KEY) && req.env[::SecureHeaders::NONCE_KEY]
+        defined?(::SecureHeaders::NONCE_KEY) &&
+        req.env[::SecureHeaders::NONCE_KEY]
       end
 
       class SecureHeadersResolver
@@ -266,7 +278,8 @@ module Rollbar
           if csp.respond_to?(:opt_out?) && csp.opt_out?
             csp.opt_out?
           # secure_headers csp 3.0.x-3.4.x doesn't respond to 'opt_out?'
-          elsif defined?(::SecureHeaders::OPT_OUT) && ::SecureHeaders::OPT_OUT.is_a?(Symbol)
+          elsif defined?(::SecureHeaders::OPT_OUT) &&
+                ::SecureHeaders::OPT_OUT.is_a?(Symbol)
             csp == ::SecureHeaders::OPT_OUT
           end
         end

--- a/lib/rollbar/middleware/rails/show_exceptions.rb
+++ b/lib/rollbar/middleware/rails/show_exceptions.rb
@@ -34,7 +34,9 @@ module Rollbar
         def extract_scope_from(env)
           scope = env['rollbar.scope']
           unless scope
-            Rollbar.log_warn('[Rollbar] rollbar.scope key has been removed from Rack env.')
+            Rollbar.log_warn(
+              '[Rollbar] rollbar.scope key has been removed from Rack env.'
+            )
           end
 
           scope || {}

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -203,7 +203,9 @@ module Rollbar
 
     def enabled?
       # Require access_token so we don't try to send events when unconfigured.
-      configuration.enabled && configuration.access_token && !configuration.access_token.empty?
+      configuration.enabled &&
+      configuration.access_token &&
+      !configuration.access_token.empty?
     end
 
     def process_item(item)
@@ -219,7 +221,8 @@ module Rollbar
         send_item(item)
       end
     rescue StandardError => e
-      log_error("[Rollbar] Error processing the item: #{e.class}, #{e.message}. Item: #{item.payload.inspect}")
+      log_error '[Rollbar] Error processing the item: ' \
+        "#{e.class}, #{e.message}. Item: #{item.payload.inspect}"
       raise e unless via_failsafe?(item)
 
       log_error('[Rollbar] Item has already failed. Not re-raising')
@@ -392,8 +395,8 @@ module Rollbar
     end
 
     def enable_locals?
-      configuration.locals[:enabled] && [:app,
-                                         :all].include?(configuration.send_extra_frame_data)
+      configuration.locals[:enabled] &&
+      [:app, :all].include?(configuration.send_extra_frame_data)
     end
 
     def enable_locals
@@ -494,7 +497,9 @@ module Rollbar
 
     def report(level, message, exception, extra, context)
       unless message || exception || extra
-        log_error '[Rollbar] Tried to send a report with no message, exception or extra data.'
+        log_error(
+          '[Rollbar] Tried to send a report with no message, exception or extra data.'
+        )
 
         return 'error'
       end
@@ -521,11 +526,14 @@ module Rollbar
       log_info "[Rollbar] Data: #{data}"
     end
 
-    # Reports an internal error in the Rollbar library. This will be reported within the configured
-    # Rollbar project. We'll first attempt to provide a report including the exception traceback.
-    # If that fails, we'll fall back to a more static failsafe response.
+    # Reports an internal error in the Rollbar library. This will be reported
+    # within the configured Rollbar project. We'll first attempt to provide a
+    # report including the exception traceback. If that fails, we'll fall back
+    # to a more static failsafe response.
     def report_internal_error(exception, original_error = nil)
-      log_error '[Rollbar] Reporting internal error encountered while sending data to Rollbar.'
+      log_error(
+        '[Rollbar] Reporting internal error encountered while sending data to Rollbar.'
+      )
 
       configuration.execute_hook(:on_report_internal_error, exception)
 
@@ -594,7 +602,8 @@ module Rollbar
         if req.response_header.status == 200
           log_info '[Rollbar] Success'
         else
-          log_warning "[Rollbar] Got unexpected status code from Rollbar.io api: #{req.response_header.status}"
+          log_warning '[Rollbar] Got unexpected status code from Rollbar.io api: ' \
+            "#{req.response_header.status}"
           log_info "[Rollbar] Response: #{req.response}"
         end
       end
@@ -602,7 +611,9 @@ module Rollbar
 
     def eventmachine_errback(req)
       req.errback do
-        log_warning "[Rollbar] Call to API failed, status code: #{req.response_header.status}"
+        log_warning(
+          "[Rollbar] Call to API failed, status code: #{req.response_header.status}"
+        )
         log_info "[Rollbar] Error's response: #{req.response}"
       end
     end
@@ -657,7 +668,7 @@ module Rollbar
     def pack_ruby260_bytes(body)
       # Ruby 2.6.0 shipped with a bug affecting multi-byte body for Net::HTTP.
       # Fix (committed one day after 2.6.0p0 shipped) is here:
-      # https://github.com/ruby/ruby/commit/1680a13a926b17661329beec1ded6b32aad16c1b#diff-00a99d8c71daaf5fc60a050da41f7261
+      # ruby/ruby/commit/1680a13a926b17661329beec1ded6b32aad16c1b
       #
       # We work around this by repacking the body as single byte chars if needed.
       if RUBY_VERSION == '2.6.0' && multibyte?(body)
@@ -724,7 +735,9 @@ module Rollbar
       if response.code == '200'
         log_info '[Rollbar] Success'
       else
-        log_warning "[Rollbar] Got unexpected status code from Rollbar api: #{response.code}"
+        log_warning(
+          "[Rollbar] Got unexpected status code from Rollbar api: #{response.code}"
+        )
         log_info "[Rollbar] Response: #{response.body}"
         configuration.execute_hook(:on_error_response, response)
       end
@@ -767,7 +780,8 @@ module Rollbar
       return unless configuration.files_processed_enabled
 
       time_now = Time.now
-      if configuration.files_processed_duration > time_now - file.birthtime && file.size < configuration.files_processed_size
+      if configuration.files_processed_duration > time_now - file.birthtime &&
+         file.size < configuration.files_processed_size
         return
       end
 
@@ -786,7 +800,8 @@ module Rollbar
           nearest_frame = backtrace[0]
 
           exception_info = exception.class.name
-          # #to_s and #message defaults to class.to_s. Add message only if add valuable info.
+          # #to_s and #message defaults to class.to_s.
+          # Add message only if add valuable info.
           if exception.message != exception.class.to_s
             exception_info += %[: "#{exception.message}"]
           end
@@ -837,7 +852,8 @@ module Rollbar
       configuration.async_handler.call(payload)
     rescue StandardError
       if configuration.failover_handlers.empty?
-        log_error '[Rollbar] Async handler failed, and there are no failover handlers configured. See the docs for "failover_handlers"'
+        log_error '[Rollbar] Async handler failed, and there are no failover ' \
+          'handlers configured. See the docs for "failover_handlers"'
         return
       end
 
@@ -855,7 +871,8 @@ module Rollbar
         rescue StandardError
           next unless handler == failover_handlers.last
 
-          log_error "[Rollbar] All failover handlers failed while processing item: #{Rollbar::JSON.dump(item.payload)}"
+          log_error '[Rollbar] All failover handlers failed while processing ' \
+            "item: #{Rollbar::JSON.dump(item.payload)}"
         end
       end
     end
@@ -866,7 +883,9 @@ module Rollbar
       return unless data[:uuid]
 
       uuid_url = Util.uuid_rollbar_url(data, configuration)
-      log_info "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
+      log_info(
+        "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
+      )
     end
 
     def via_failsafe?(item)

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -45,7 +45,8 @@ module Rollbar
             frames.pop
           when :raise
             unless detect_reraise(tp) # ignore reraised exceptions
-              @exception_frames = @frames.dup # may be possible to optimize better than #dup
+              @exception_frames = @frames.dup # may be possible to optimize
+                                              # better than #dup
               @exception_signature = exception_signature(tp)
             end
           end

--- a/lib/rollbar/plugin.rb
+++ b/lib/rollbar/plugin.rb
@@ -112,11 +112,15 @@ module Rollbar
     end
 
     def log_loading_error(error)
-      Rollbar.log_error("Error trying to load plugin '#{name}': #{error.class}, #{error.message}")
+      Rollbar.log_error(
+        "Error trying to load plugin '#{name}': #{error.class}, #{error.message}"
+      )
     end
 
     def log_unloading_error(error)
-      Rollbar.log_error("Error trying to unload plugin '#{name}': #{error.class}, #{error.message}")
+      Rollbar.log_error(
+        "Error trying to unload plugin '#{name}': #{error.class}, #{error.message}"
+      )
     end
   end
 end

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -16,12 +16,13 @@ module Rollbar
           # DelayedJob < 4.1 doesn't provide job#error
           if job.class.method_defined? :error
             if job.error
-              ::Rollbar.scope(:request => data).error(job.error,
-                                                      :use_exception_level_filters => true)
+              ::Rollbar.scope(:request => data)
+                       .error(job.error,:use_exception_level_filters => true)
             end
           elsif job.last_error
             ::Rollbar.scope(:request => data).error(
-              "Job has failed and won't be retried anymore: " + job.last_error, :use_exception_level_filters => true
+              "Job has failed and won't be retried anymore: " + job.last_error,
+              :use_exception_level_filters => true
             )
           end
         end
@@ -61,7 +62,8 @@ module Rollbar
 
       data = build_job_data(job)
 
-      ::Rollbar.scope(:request => data).error(e, :use_exception_level_filters => true)
+      ::Rollbar.scope(:request => data)
+               .error(e, :use_exception_level_filters => true)
     end
 
     def self.skip_report?(job)

--- a/lib/rollbar/plugins/goalie.rb
+++ b/lib/rollbar/plugins/goalie.rb
@@ -20,22 +20,30 @@ Rollbar.plugins.define('goalie') do
             rescue StandardError
               nil
             end
-            exception_data = Rollbar.scope(:request => request_data, :person => person_data).error(
-              exception, :use_exception_level_filters => true
-            )
+            exception_data = Rollbar.scope(
+              :request => request_data,
+              :person => person_data
+            ).error(exception, :use_exception_level_filters => true)
           rescue StandardError => e
-            Rollbar.log_warning "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
+            message = "[Rollbar] Exception while reporting exception to Rollbar: #{e}"
+            Rollbar.log_warning(message)
           end
 
           # if an exception was reported, save uuid in the env
           # so it can be displayed to the user on the error page
           if exception_data.is_a?(Hash)
             env['rollbar.exception_uuid'] = exception_data[:uuid]
-            Rollbar.log_info "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
+            Rollbar.log_info(
+              "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
+            )
           elsif exception_data == 'disabled'
-            Rollbar.log_info '[Rollbar] Exception not reported because Rollbar is disabled'
+            Rollbar.log_info(
+              '[Rollbar] Exception not reported because Rollbar is disabled'
+            )
           elsif exception_data == 'ignored'
-            Rollbar.log_info '[Rollbar] Exception not reported because it was ignored'
+            Rollbar.log_info(
+              '[Rollbar] Exception not reported because it was ignored'
+            )
           end
 
           # now continue as normal

--- a/lib/rollbar/plugins/rails/controller_methods.rb
+++ b/lib/rollbar/plugins/rails/controller_methods.rb
@@ -7,9 +7,11 @@ module Rollbar
       include RequestDataExtractor
 
       def rollbar_person_data
-        (user = send(Rollbar.configuration.person_method)) unless Rollbar::Util.method_in_stack_twice(
-          :rollbar_person_data, __FILE__
-        )
+        user = nil
+        unless Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
+          user = send(Rollbar.configuration.person_method)
+        end
+
         # include id, username, email if non-empty
         if user
           {

--- a/lib/rollbar/plugins/rake.rb
+++ b/lib/rollbar/plugins/rake.rb
@@ -40,7 +40,8 @@ Rollbar.plugins.define('rake') do
       end
 
       def self.skip_patch
-        warn('[Rollbar] Rollbar is disabled for Rake tasks since your Rake version is under 0.9.x. Please upgrade to 0.9.x or higher.')
+        warn('[Rollbar] Rollbar is disabled for Rake tasks since your Rake ' \
+          'version is under 0.9.x. Please upgrade to 0.9.x or higher.')
       end
 
       def self.patch?

--- a/lib/rollbar/plugins/validations.rb
+++ b/lib/rollbar/plugins/validations.rb
@@ -17,7 +17,9 @@ Rollbar.plugins.define('active_model') do
       module ActiveRecordExtension
         def report_validation_errors_to_rollbar
           errors.full_messages.each do |error|
-            Rollbar.log_info "[Rollbar] Reporting form validation error: #{error} for #{self}"
+            Rollbar.log_info(
+              "[Rollbar] Reporting form validation error: #{error} for #{self}"
+            )
             Rollbar.warning("Form Validation Error: #{error} for #{self}")
           end
         end

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -113,13 +113,17 @@ module Rollbar
           { name => Rollbar::Scrubbers.scrub_value(env[header]) }
         elsif name == 'X-Forwarded-For' && !Rollbar.configuration.collect_user_ip
           {}
-        elsif name == 'X-Forwarded-For' && Rollbar.configuration.collect_user_ip && Rollbar.configuration.anonymize_user_ip
+        elsif name == 'X-Forwarded-For' &&
+              Rollbar.configuration.collect_user_ip &&
+              Rollbar.configuration.anonymize_user_ip
           ips = env[header].sub(' ', '').split(',')
           ips = ips.map { |ip| Rollbar::Util::IPAnonymizer.anonymize_ip(ip) }
           { name => ips.join(', ') }
         elsif name == 'X-Real-Ip' && !Rollbar.configuration.collect_user_ip
           {}
-        elsif name == 'X-Real-Ip' && Rollbar.configuration.collect_user_ip && Rollbar.configuration.anonymize_user_ip
+        elsif name == 'X-Real-Ip' &&
+              Rollbar.configuration.collect_user_ip &&
+              Rollbar.configuration.anonymize_user_ip
           { name => Rollbar::Util::IPAnonymizer.anonymize_ip(env[header]) }
         else
           { name => env[header] }
@@ -135,9 +139,8 @@ module Rollbar
       host = host.split(',').first.strip unless host.empty?
 
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
-      path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{unless env['QUERY_STRING'].to_s.empty?
-                                                            "?#{env['QUERY_STRING']}"
-                                                          end}"
+      query = env['QUERY_STRING'].to_s.empty? ? nil : "?#{env['QUERY_STRING']}"
+      path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{query}"
       if !(path.nil? || path.empty?) && (path.to_s.slice(0, 1) != '/')
         path = '/' + path.to_s
       end
@@ -155,7 +158,10 @@ module Rollbar
     def rollbar_user_ip(env)
       return nil unless Rollbar.configuration.collect_user_ip
 
-      user_ip_string = (env['action_dispatch.remote_ip'] || env['HTTP_X_REAL_IP'] || x_forwarded_for_client(env['HTTP_X_FORWARDED_FOR']) || env['REMOTE_ADDR']).to_s
+      user_ip_string = (env['action_dispatch.remote_ip'] ||
+                        env['HTTP_X_REAL_IP'] ||
+                        x_forwarded_for_client(env['HTTP_X_FORWARDED_FOR']) ||
+                        env['REMOTE_ADDR']).to_s
 
       user_ip_string = Rollbar::Util::IPAnonymizer.anonymize_ip(user_ip_string)
 
@@ -254,7 +260,8 @@ module Rollbar
     end
 
     def sensitive_headers_list
-      unless Rollbar.configuration.scrub_headers && Rollbar.configuration.scrub_headers.is_a?(Array)
+      unless Rollbar.configuration.scrub_headers &&
+             Rollbar.configuration.scrub_headers.is_a?(Array)
         return []
       end
 

--- a/lib/rollbar/rollbar_test.rb
+++ b/lib/rollbar/rollbar_test.rb
@@ -27,7 +27,9 @@ module RollbarTest # :nodoc:
   end
 
   def self.error_message
-    'Test failed! You may have a configuration issue, or you could be using a gem that\'s blocking the test. Contact support@rollbar.com if you need help troubleshooting.'
+    'Test failed! You may have a configuration issue, or you could be using a ' \
+    'gem that\'s blocking the test. Contact support@rollbar.com if you need ' \
+    'help troubleshooting.'
   end
 
   def self.success_message

--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -76,7 +76,8 @@ module Rollbar
 
         params.to_hash.inject({}) do |result, (key, value)|
           encoded_key = Rollbar::Encoding.encode(key).to_s
-          result[key] = if (fields_regex === encoded_key) && !(whitelist_regex === encoded_key)
+          result[key] = if (fields_regex === encoded_key) &&
+                           !(whitelist_regex === encoded_key)
                           scrub_value(value)
                         elsif value.is_a?(Hash)
                           scrub(value, options)

--- a/lib/rollbar/scrubbers/url.rb
+++ b/lib/rollbar/scrubbers/url.rb
@@ -23,7 +23,9 @@ module Rollbar
                options[:scrub_fields].include?(SCRUB_ALL),
                build_whitelist_regex(options[:whitelist] || []))
       rescue StandardError => e
-        Rollbar.logger.error("[Rollbar] There was an error scrubbing the url: #{e}, options: #{options.inspect}")
+        message = '[Rollbar] There was an error scrubbing the url: ' \
+          "#{e}, options: #{options.inspect}"
+        Rollbar.logger.error(message)
         url
       end
 
@@ -32,10 +34,11 @@ module Rollbar
       def ascii_encode(url)
         # In some cases non-ascii characters won't be properly encoded, so we do it here.
         #
-        # The standard encoders (the CGI and URI methods) are not reliable when the query string
-        # is already embedded in the full URL, but the inconsistencies are limited to issues
-        # with characters in the ascii range. (For example, the '#' if it appears in an unexpected place.)
-        # For escaping non-ascii, they are all OK, so we'll take care to skip the ascii chars.
+        # The standard encoders (the CGI and URI methods) are not reliable when
+        # the query string is already embedded in the full URL, but the inconsistencies
+        # are limited to issues with characters in the ascii range. (For example,
+        # the '#' if it appears in an unexpected place.) For escaping non-ascii,
+        # they are all OK, so we'll take care to skip the ascii chars.
 
         return url if url.ascii_only?
 
@@ -50,7 +53,8 @@ module Rollbar
         Regexp.new(fields.map { |val| /\A#{Regexp.escape(val.to_s)}\z/ }.join('|'))
       end
 
-      def filter(url, regex, scrub_user, scrub_password, randomize_scrub_length, scrub_all, whitelist)
+      def filter(url, regex, scrub_user, scrub_password, randomize_scrub_length,
+                 scrub_all, whitelist)
         uri = URI.parse(url)
 
         uri.user = filter_user(uri.user, scrub_user, randomize_scrub_length)
@@ -103,12 +107,14 @@ module Rollbar
       def restore_square_brackets(query)
         # We want this to rebuild array params like foo[]=1&foo[]=2
         #
-        # URI.encode_www_form follows the spec at https://url.spec.whatwg.org/#concept-urlencoded-serializer
+        # URI.encode_www_form follows the spec at
+        # https://url.spec.whatwg.org/#concept-urlencoded-serializer
         # and percent encodes square brackets. Here we change them back.
         query.gsub('%5B', '[').gsub('%5D', ']')
       end
 
-      def filter_query_params(params, regex, randomize_scrub_length, scrub_all, whitelist)
+      def filter_query_params(params, regex, randomize_scrub_length, scrub_all,
+                              whitelist)
         params.map do |key, value|
           [key,
            if filter_key?(key, regex, scrub_all,

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -50,7 +50,7 @@ describe HomeController do
       data['data'][:environment].should eq('dev')
     end
 
-    it 'should use the default "unspecified" environment if rails env ends up being empty' do
+    it 'should use the default "unspecified" environment if rails env is empty' do
       old_env = ::Rails.env
       ::Rails.env = ''
       preconfigure_rails_notifier
@@ -299,7 +299,8 @@ describe HomeController do
 
   describe 'configuration.locals', :type => 'request',
                                    :if => RUBY_VERSION >= '2.3.0' &&
-                                          !(defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
+                                          !(defined?(RUBY_ENGINE) &&
+                                          RUBY_ENGINE == 'jruby') do
     context 'when locals is enabled' do
       before do
         Rollbar.configure do |config|
@@ -450,7 +451,8 @@ describe HomeController do
         end
 
         context 'default' do
-          it 'sends the current user data excluding personally identifiable information' do
+          it 'sends the current user data excluding personally identifiable ' \
+           'information' do
             expect(person_data).to eq(:id => user.id,
                                       :email => nil,
                                       :username => nil)
@@ -459,7 +461,9 @@ describe HomeController do
 
         context 'without EU GDPR subjects' do
           context 'configured to send email addresses' do
-            before { Rollbar.configure { |config| config.person_email_method = 'email' } }
+            before do
+              Rollbar.configure { |config| config.person_email_method = 'email' }
+            end
 
             it 'sends the current user data including email address' do
               expect(person_data).to eq(:id => user.id,
@@ -603,7 +607,8 @@ describe HomeController do
 
       request_data = Rollbar.last_report[:request]
 
-      expect(request_data[:url]).to match('http:\/\/www.example.com\/cause_exception\?password=\*{3,8}')
+      expect(request_data[:url])
+        .to match('http:\/\/www.example.com\/cause_exception\?password=\*{3,8}')
     end
   end
 

--- a/spec/delay/sidekiq_spec.rb
+++ b/spec/delay/sidekiq_spec.rb
@@ -48,7 +48,9 @@ describe Rollbar::Delay::Sidekiq do
       subject { Rollbar::Delay::Sidekiq.new custom_config }
 
       it 'enqueues to custom queue' do
-        options = Rollbar::Delay::Sidekiq::OPTIONS.merge(custom_config.merge('args' => [payload]))
+        options = Rollbar::Delay::Sidekiq::OPTIONS.merge(
+          custom_config.merge('args' => [payload])
+        )
         ::Sidekiq::Client.should_receive(:push).with(options) { true }
 
         subject.call payload

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -67,11 +67,15 @@ module Delayed
           end
         end
 
-        # Find a few candidate jobs to run (in case some immediately get locked by others).
-        def self.find_available(worker_name, limit = 5, max_run_time = Worker.max_run_time) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # Find a few candidate jobs to run
+        # (in case some immediately get locked by others).
+        def self.find_available(worker_name, limit = 5,
+                                max_run_time = Worker.max_run_time)
           jobs = all.select do |j|
             j.run_at <= db_time_now &&
-              (j.locked_at.nil? || j.locked_at < db_time_now - max_run_time || j.locked_by == worker_name) &&
+              (j.locked_at.nil? ||
+                j.locked_at < db_time_now - max_run_time ||
+                j.locked_by == worker_name) &&
               !j.failed?
           end
           jobs.select! { |j| j.priority <= Worker.max_priority } if Worker.max_priority

--- a/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
+++ b/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
@@ -11,7 +11,10 @@ if Rails::VERSION::STRING.start_with?('3.0')
   describe :rollbar do
     context 'with no arguments' do
       it 'outputs a help message' do
-        subject.should output(/You'll need to add an environment variable ROLLBAR_ACCESS_TOKEN with your access token/)
+        subject.should output(
+          /You'll\ need\ to\ add\ an\ environment\ variable
+          \ ROLLBAR_ACCESS_TOKEN\ with\ your\ access\ token/x
+        )
       end
 
       it 'generates a Rollbar initializer with ENV' do

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -11,7 +11,8 @@ describe HomeController do
   context 'with broken request' do
     it 'should report uncaught exceptions' do
       # only seems to be relevant in 3.1 and 3.2
-      if ::Rails::VERSION::STRING.starts_with?('3.1') || ::Rails::VERSION::STRING.starts_with?('3.2')
+      if ::Rails::VERSION::STRING.starts_with?('3.1') ||
+        ::Rails::VERSION::STRING.starts_with?('3.2')
         expect { get '/current_user', nil, :cookie => '8%B' }.to raise_exception
 
         Rollbar.last_report.should_not be_nil

--- a/spec/rollbar/capistrano_tasks_spec.rb
+++ b/spec/rollbar/capistrano_tasks_spec.rb
@@ -69,7 +69,8 @@ describe ::Rollbar::CapistranoTasks do
     end
 
     context 'when an invalid response from the API is received' do
-      it "prints the API request, response, doesn't set deploy_id and shows an error with the message from the API" do
+      it "prints the API request, response, doesn't set deploy_id and shows an ' \
+        'error with the message from the API" do
         expect(::Rollbar::Deploy).to receive(:report)
           .and_return(
             :request_info => 'dummy request content',
@@ -118,7 +119,8 @@ describe ::Rollbar::CapistranoTasks do
 
       it 'prints the API request, the skipping message and sets a dummy deploy_id' do
         expect(::Rollbar::Deploy).to receive(:report)
-          .with(hash_including(:dry_run => dry_run), rollbar_token, rollbar_env, rollbar_revision)
+          .with(hash_including(:dry_run => dry_run),
+                rollbar_token, rollbar_env, rollbar_revision)
           .and_return(:request_info => 'dummy request content')
 
         expect(logger).to receive(:debug).with('dummy request content')
@@ -140,7 +142,7 @@ describe ::Rollbar::CapistranoTasks do
       end
 
       context 'when a valid response from the API is received' do
-        it 'prints the API request, response and updates the appropriate deploy to succeeded' do
+        it 'prints the API request, response and updates to succeeded' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
                     :comment => rollbar_comment,
@@ -216,7 +218,8 @@ describe ::Rollbar::CapistranoTasks do
         let(:dry_run) { true }
         let(:deploy_id) { 123 }
 
-        it 'calls deploy update with the dummy deploy_id, prints the API request and the skipping message' do
+        it 'calls deploy update with the dummy deploy_id, prints the API request ' \
+          'and the skipping message' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
                     :dry_run => dry_run
@@ -260,7 +263,7 @@ describe ::Rollbar::CapistranoTasks do
       end
 
       context 'when a valid response from the API is received' do
-        it 'prints the API request, response and updates the appropriate deploy to failed' do
+        it 'prints the API request, response and updates to failed' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
                     :comment => rollbar_comment,
@@ -341,7 +344,8 @@ describe ::Rollbar::CapistranoTasks do
           capistrano.set(:rollbar_deploy_id, deploy_id)
         end
 
-        it 'calls deploy update with the dummy deploy_id, prints the API request and the skipping message' do
+        it 'calls deploy update with the dummy deploy_id, prints the API request ' \
+          'and the skipping message' do
           expect(::Rollbar::Deploy).to receive(:update)
             .with(hash_including(
                     :dry_run => dry_run

--- a/spec/rollbar/configuration_spec.rb
+++ b/spec/rollbar/configuration_spec.rb
@@ -7,20 +7,24 @@ describe Rollbar::Configuration do
       require 'rollbar/delay/active_job'
 
       describe '#use_active_job' do
-        it 'enables async and sets ActiveJob as the handler and uses default queue name' do
-          subject.use_active_job
+        context 'with default queue name' do
+          it 'enables async and sets ActiveJob as the handler' do
+            subject.use_active_job
 
-          expect(subject.use_async).to be_eql(true)
-          expect(Rollbar::Delay::ActiveJob.queue_name).to be_eql('default')
-          expect(subject.async_handler).to be_eql(Rollbar::Delay::ActiveJob)
+            expect(subject.use_async).to be_eql(true)
+            expect(Rollbar::Delay::ActiveJob.queue_name).to be_eql('default')
+            expect(subject.async_handler).to be_eql(Rollbar::Delay::ActiveJob)
+          end
         end
 
-        it 'enables async and sets ActiveJob as the handler and uses provided queue name' do
-          subject.use_active_job(:queue => 'my_test_queue')
+        context 'with provided queue name' do
+          it 'enables async and sets ActiveJob as the handler' do
+            subject.use_active_job(:queue => 'my_test_queue')
 
-          expect(subject.use_async).to be_eql(true)
-          expect(Rollbar::Delay::ActiveJob.queue_name).to be_eql('my_test_queue')
-          expect(subject.async_handler).to be_eql(Rollbar::Delay::ActiveJob)
+            expect(subject.use_async).to be_eql(true)
+            expect(Rollbar::Delay::ActiveJob.queue_name).to be_eql('my_test_queue')
+            expect(subject.async_handler).to be_eql(Rollbar::Delay::ActiveJob)
+          end
         end
       end
     end

--- a/spec/rollbar/delay/girl_friday_spec.rb
+++ b/spec/rollbar/delay/girl_friday_spec.rb
@@ -25,12 +25,14 @@ describe Rollbar::Delay::GirlFriday do
       let(:exception) { Exception.new }
 
       before do
-        expect(Rollbar).to receive(:process_from_async_handler).with(payload).and_raise(exception)
+        expect(Rollbar).to receive(:process_from_async_handler)
+          .with(payload)
+          .and_raise(exception)
       end
 
       it 'raises an exception cause we are using immediate queue' do
         # This will not happen with a norma work queue cause this:
-        # https://github.com/mperham/girl_friday/blob/master/lib/girl_friday/work_queue.rb#L90-L106
+        # mperham/girl_friday/blob/v0.11.2/lib/girl_friday/work_queue.rb#L90-L106
         expect do
           described_class.call(payload)
         end.to raise_error(exception)

--- a/spec/rollbar/delay/resque_spec.rb
+++ b/spec/rollbar/delay/resque_spec.rb
@@ -24,7 +24,9 @@ describe Rollbar::Delay::Resque do
       let(:exception) { Exception.new }
 
       before do
-        expect(Rollbar).to receive(:process_from_async_handler).with(loaded_hash).and_raise(exception)
+        expect(Rollbar).to receive(:process_from_async_handler)
+          .with(loaded_hash)
+          .and_raise(exception)
       end
 
       it 'raises an exception' do

--- a/spec/rollbar/delay/shoryuken_spec.rb
+++ b/spec/rollbar/delay/shoryuken_spec.rb
@@ -35,7 +35,9 @@ describe Rollbar::Delay::Shoryuken do
       end
 
       it 'uses specified queue' do
-        expect(Shoryuken::Client).to receive(:queues).with('non_default_queue').and_return(sqs_queue)
+        expect(Shoryuken::Client).to receive(:queues)
+          .with('non_default_queue')
+          .and_return(sqs_queue)
         expect(sqs_queue).to receive(:send_message)
         described_class.call(payload)
       end

--- a/spec/rollbar/delay/thread_spec.rb
+++ b/spec/rollbar/delay/thread_spec.rb
@@ -14,7 +14,9 @@ describe Rollbar::Delay::Thread do
       let(:exception) { StandardError.new }
 
       before do
-        expect(Rollbar).to receive(:process_from_async_handler).with(payload).and_raise(exception)
+        expect(Rollbar).to receive(:process_from_async_handler)
+          .with(payload)
+          .and_raise(exception)
       end
 
       it 'doesnt raise any exception' do

--- a/spec/rollbar/deploy_spec.rb
+++ b/spec/rollbar/deploy_spec.rb
@@ -60,7 +60,8 @@ describe ::Rollbar::Deploy do
     # depends on let(:expected_request_info_url)
     it 'builds the request info string' do
       expect(@result[:request_info]).to match(
-        /#{Regexp.escape(expected_request_info_url)}.*#{Regexp.escape(::JSON.dump(expected_request_data))}/
+        /#{Regexp.escape(expected_request_info_url)}.*
+          #{Regexp.escape(::JSON.dump(expected_request_data))}/x
       )
     end
 

--- a/spec/rollbar/item/frame_spec.rb
+++ b/spec/rollbar/item/frame_spec.rb
@@ -44,7 +44,8 @@ foo13
         END
       end
       let(:filepath) do
-        '/var/www/rollbar/playground/rails4.2/vendor/bundle/gems/actionpack-4.2.0/lib/action_controller/metal/implicit_render.rb'
+        '/var/www/rollbar/playground/rails4.2/vendor/bundle/gems/actionpack-4.2.0' \
+        '/lib/action_controller/metal/implicit_render.rb'
       end
       let(:frame) do
         "#{filepath}:7:in `send_action'"
@@ -54,7 +55,9 @@ foo13
       end
 
       before do
-        allow(backtrace).to receive(:get_file_lines).with(filepath).and_return(file.split("\n"))
+        allow(backtrace).to receive(:get_file_lines)
+          .with(filepath)
+          .and_return(file.split("\n"))
       end
 
       context 'with send_extra_frame_data = :none' do
@@ -117,7 +120,9 @@ foo13
 
         context 'if the file couldnt be read' do
           before do
-            allow(backtrace).to receive(:get_file_lines).with(filepath).and_return(nil)
+            allow(backtrace).to receive(:get_file_lines)
+              .with(filepath)
+              .and_return(nil)
           end
 
           it 'just returns the basic data' do

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -72,7 +72,8 @@ describe Rollbar::Item do
       end
 
       it 'should have the correct data keys' do
-        payload['data'].keys.should include(:timestamp, :environment, :level, :language, :framework, :server,
+        payload['data'].keys.should include(:timestamp, :environment, :level,
+                                            :language, :framework, :server,
                                             :notifier, :body)
       end
 
@@ -165,10 +166,11 @@ describe Rollbar::Item do
         end
 
         payload['data'][:body][:message][:extra].should_not be_nil
-        payload['data'][:body][:message][:extra][:result].should == 'MyApp#' + context[:controller]
+        payload['data'][:body][:message][:extra][:result]
+          .should == 'MyApp#' + context[:controller]
       end
 
-      it 'should not include data passed in :context if there is no custom_data_method configured' do
+      it 'should not include data passed in :context if there is no custom_data_method' do
         configuration.custom_data_method = nil
 
         payload['data'][:body][:message][:extra].should be_nil
@@ -179,8 +181,9 @@ describe Rollbar::Item do
           { :result => 'Transformed in custom_data_method: ' + message }
         end
 
-        payload['data'][:body][:message][:extra].should_not be_nil
-        payload['data'][:body][:message][:extra][:result].should == 'Transformed in custom_data_method: ' + message
+        extra = payload['data'][:body][:message][:extra]
+        extra.should_not be_nil
+        extra[:result].should == 'Transformed in custom_data_method: ' + message
       end
 
       context do
@@ -191,8 +194,10 @@ describe Rollbar::Item do
             { :result => 'Transformed in custom_data_method: ' + exception.message }
           end
 
-          payload['data'][:body][:trace][:extra].should_not be_nil
-          payload['data'][:body][:trace][:extra][:result].should == 'Transformed in custom_data_method: ' + exception.message
+          extra = payload['data'][:body][:trace][:extra]
+          extra.should_not be_nil
+          expect(extra[:result])
+            .to eq('Transformed in custom_data_method: ' + exception.message)
         end
       end
     end
@@ -236,7 +241,8 @@ describe Rollbar::Item do
       end
 
       it 'doesnt crash the report' do
-        expect(subject).to receive(:report_custom_data_error).once.and_return(custom_data_report)
+        expect(subject).to receive(:report_custom_data_error)
+          .once.and_return(custom_data_report)
 
         expect(payload['data'][:body][:message][:extra]).to be_eql(expected_extra)
       end
@@ -291,7 +297,7 @@ describe Rollbar::Item do
       context 'with no exception' do
         let(:exception) { nil }
 
-        it 'should build a message body when no exception is passed in' do
+        it 'should build a message body' do
           payload['data'][:body][:message][:body].should == 'message'
           payload['data'][:body][:message][:extra].should be_nil
           payload['data'][:body][:trace].should be_nil
@@ -302,7 +308,7 @@ describe Rollbar::Item do
             { :a => 'b' }
           end
 
-          it 'should build a message body when no exception and extra data is passed in' do
+          it 'should build a message body' do
             payload['data'][:body][:message][:body].should == 'message'
             payload['data'][:body][:message][:extra].should == { :a => 'b' }
             payload['data'][:body][:trace].should be_nil
@@ -327,7 +333,7 @@ describe Rollbar::Item do
           { :a => 'b' }
         end
 
-        it 'should build an exception body when one is passed in along with extra data' do
+        it 'should build an exception body' do
           body = payload['data'][:body]
           body[:message].should be_nil
 
@@ -350,6 +356,11 @@ describe Rollbar::Item do
         end
       end
 
+      let(:pattern) do
+        /^(undefined\ local\ variable\ or\ method\ `bar'|
+          undefined\ method\ `bar'\ on\ an\ instance\ of)/x
+      end
+
       it 'should build valid exception data' do
         body = payload['data'][:body]
         body[:message].should be_nil
@@ -367,7 +378,7 @@ describe Rollbar::Item do
         # should be NameError, but can be NoMethodError sometimes on rubinius 1.8
         # http://yehudakatz.com/2010/01/02/the-craziest-fing-bug-ive-ever-seen/
         trace[:exception][:class].should match(/^(NameError|NoMethodError)$/)
-        trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
+        trace[:exception][:message].should match(pattern)
       end
 
       context 'with description message' do
@@ -378,7 +389,7 @@ describe Rollbar::Item do
 
           trace = body[:trace]
 
-          trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
+          trace[:exception][:message].should match(pattern)
           trace[:exception][:description].should == 'exception description'
         end
 
@@ -391,7 +402,7 @@ describe Rollbar::Item do
             body = payload['data'][:body]
             trace = body[:trace]
 
-            trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
+            trace[:exception][:message].should match(pattern)
             trace[:exception][:description].should == 'exception description'
             trace[:extra][:key].should == 'value'
             trace[:extra][:hash].should == { :inner_key => 'inner_value' }
@@ -407,7 +418,7 @@ describe Rollbar::Item do
           body = payload['data'][:body]
           trace = body[:trace]
 
-          trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
+          trace[:exception][:message].should match(pattern)
           trace[:extra][:key].should == 'value'
           trace[:extra][:hash].should == { :inner_key => 'inner_value' }
         end
@@ -423,7 +434,7 @@ describe Rollbar::Item do
           body = payload['data'][:body]
           trace = body[:trace]
 
-          trace[:exception][:message].should match(/^(undefined local variable or method `bar'|undefined method `bar' on an instance of)/)
+          trace[:exception][:message].should match(pattern)
           trace[:extra][:key].should == 'value'
           trace[:extra][:hash].should == { :inner_key => 'inner_value' }
         end
@@ -524,7 +535,8 @@ describe Rollbar::Item do
         it 'should build a message with extra data' do
           payload['data'][:body][:message][:body].should == 'message'
           payload['data'][:body][:message][:extra][:key].should == 'value'
-          payload['data'][:body][:message][:extra][:hash].should == { :inner_key => 'inner_value' }
+          payload['data'][:body][:message][:extra][:hash]
+            .should == { :inner_key => 'inner_value' }
         end
       end
 
@@ -537,7 +549,8 @@ describe Rollbar::Item do
         it 'should build an empty message with extra data' do
           payload['data'][:body][:message][:body].should == 'Empty message'
           payload['data'][:body][:message][:extra][:key].should == 'value'
-          payload['data'][:body][:message][:extra][:hash].should == { :inner_key => 'inner_value' }
+          payload['data'][:body][:message][:extra][:hash]
+            .should == { :inner_key => 'inner_value' }
         end
       end
     end
@@ -624,8 +637,9 @@ describe Rollbar::Item do
           end
 
           it 'doesnt call the second handler and logs the error' do
+            message = "[Rollbar] Error calling the `transform` hook: #{exception}"
             expect(handler2).not_to receive(:call)
-            expect(logger).to receive(:error).with("[Rollbar] Error calling the `transform` hook: #{exception}")
+            expect(logger).to receive(:error).with(message)
 
             subject.build
           end
@@ -649,7 +663,8 @@ describe Rollbar::Item do
         end
 
         it 'returns the uuid in :_error_in_custom_data_method' do
-          expect(payload['data'][:body][:message][:extra]).to be_eql(:_error_in_custom_data_method => expected_url)
+          expect(payload['data'][:body][:message][:extra])
+            .to be_eql(:_error_in_custom_data_method => expected_url)
         end
       end
 
@@ -772,10 +787,11 @@ describe Rollbar::Item do
         begin
           _json = item.dump
 
-        # If you get an uninitialized constant "Java" error, it just means an unexpected exception
-        # occurred (i.e. one not in the below list) and caused Java::JavaLang::StackOverflowError.
-        # If the test case is working correctly, this shouldn't happen ang the Java error type
-        # will only be evaluated on JRuby builds.
+        # If you get an uninitialized constant "Java" error, it just means an
+        # unexpected exception occurred (i.e. one not in the below list) and
+        # caused Java::JavaLang::StackOverflowError.
+        # If the test case is working correctly, this shouldn't happen and the
+        # Java error type will only be evaluated on JRuby builds.
         rescue NoMemoryError,
                SystemStackError,
                ActiveSupport::JSON::Encoding::CircularReferenceError,
@@ -792,8 +808,8 @@ describe Rollbar::Item do
           expect(error).not_to be_eql(:SystemError)
         else
           # This ActiveSupport is vulnerable to circular reference errors, and is
-          # virtually impossible to correct, because these versions of AS even hook into
-          # core Ruby JSON.
+          # virtually impossible to correct, because these versions of AS even
+          # hook into core Ruby JSON.
           expect(error).to be_eql(:SystemError)
         end
       end
@@ -810,7 +826,10 @@ describe Rollbar::Item do
       # didn't exercise the failure condition.
       #
       let(:redis_connection) do
-        ::Redis::Connection::Ruby.connect(:host => '127.0.0.1', :port => 6370) # try to pick a polite port
+        ::Redis::Connection::Ruby.connect(
+          :host => '127.0.0.1',
+          :port => 6370 # try to pick a polite port
+        )
       end
 
       let(:payload) do
@@ -852,13 +871,17 @@ describe Rollbar::Item do
         final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload),
                                                   attempts).bytesize
         # final_size = original_size
-        rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
+        rollbar_message = 'Could not send payload due to it being too large ' \
+          'after truncating attempts. Original size: ' \
+          "#{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
         uuid = payload['data']['uuid']
         host = payload['data']['server']['host']
-        log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
+        log_message = '[Rollbar] Payload too large to be sent for UUID ' \
+          "#{uuid}: #{Rollbar::JSON.dump(payload)}"
 
-        expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil,
-                                                         hash_including(:uuid => uuid, :host => host))
+        expect(notifier)
+          .to receive(:send_failsafe)
+          .with(rollbar_message, nil, hash_including(:uuid => uuid, :host => host))
         expect(logger).to receive(:error).with(log_message)
 
         item.dump
@@ -872,9 +895,12 @@ describe Rollbar::Item do
           final_size = Rollbar::Truncation.truncate(Rollbar::Util.deep_copy(payload),
                                                     attempts).bytesize
           # final_size = original_size
-          rollbar_message = "Could not send payload due to it being too large after truncating attempts. Original size: #{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
+          rollbar_message = 'Could not send payload due to it being too large ' \
+            'after truncating attempts. Original size: ' \
+            "#{original_size} Attempts: #{attempts.join(', ')} Final size: #{final_size}"
           uuid = payload['data']['uuid']
-          log_message = "[Rollbar] Payload too large to be sent for UUID #{uuid}: #{Rollbar::JSON.dump(payload)}"
+          log_message = '[Rollbar] Payload too large to be sent for UUID ' \
+            "#{uuid}: #{Rollbar::JSON.dump(payload)}"
 
           expect(notifier).to receive(:send_failsafe).with(rollbar_message, nil,
                                                            hash_including(:uuid => uuid))

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -3,7 +3,8 @@ require 'rollbar/middleware/js'
 require 'rollbar/middleware/js/json_value'
 
 shared_examples 'secure_headers' do
-  it 'renders the snippet and config in the response with nonce in script tag when SecureHeaders installed' do
+  it 'renders the snippet and config in the response with nonce in script tag ' \
+    'when SecureHeaders installed' do
     SecureHeadersMocks::CSP.config = {
       :opt_out? => false
     }
@@ -12,7 +13,8 @@ shared_examples 'secure_headers' do
 
     new_body = response.body.join
 
-    expect(new_body).to include('<script type="text/javascript" nonce="lorem-ipsum-nonce">')
+    expect(new_body)
+      .to include('<script type="text/javascript" nonce="lorem-ipsum-nonce">')
     expect(new_body).to include("var _rollbarConfig = #{json_options};")
     expect(new_body).to include(snippet)
   end
@@ -56,7 +58,14 @@ describe Rollbar::Middleware::Js do
   end
   let(:minified_html) do
     <<-END
-<html><head><link rel="stylesheet" href="url" type="text/css" media="screen" /><script type="text/javascript" src="foo"></script></head><body><h1>Testing the middleware</h1></body></html>
+<html>
+  <head><link rel="stylesheet" href="url" type="text/css" media="screen" />
+    <script type="text/javascript" src="foo"></script>
+  </head>
+  <body>
+    <h1>Testing the middleware</h1>
+  </body>
+</html>
     END
   end
   let(:meta_charset_html) do
@@ -200,7 +209,8 @@ describe Rollbar::Middleware::Js do
           expect(new_body).to include(json_options)
           expect(res_status).to be_eql(status)
           expect(res_headers['Content-Type']).to be_eql(content_type)
-          meta_tag = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>'
+          meta_tag = '<meta http-equiv="Content-Type" content="text/html; ' \
+            'charset=utf-8"/>'
           expect(new_body.index(snippet)).to be > new_body.index(meta_tag)
         end
       end
@@ -247,7 +257,8 @@ describe Rollbar::Middleware::Js do
           stub_const('::SecureHeaders', ::SecureHeadersMocks::SecureHeaders20)
         end
 
-        it 'renders the snippet and config in the response without nonce in script tag when too old SecureHeaders installed' do
+        it 'renders the snippet and config in the response without nonce in ' \
+          'script tag when too old SecureHeaders installed' do
           _, _, response = subject.call(env)
           new_body = response.body.join
 

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -125,7 +125,8 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
       let(:exception) { Exception.new }
 
       before do
-        allow_any_instance_of(described_class).to receive(:framework_error).and_raise(exception)
+        allow_any_instance_of(described_class).to receive(:framework_error)
+          .and_raise(exception)
         allow(app.settings).to receive(:raise_errors?).and_return(false)
       end
 
@@ -231,7 +232,8 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
     end
 
     describe 'configuration.locals', :if => RUBY_VERSION >= '2.3.0' &&
-                                            !(defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
+                                            !(defined?(RUBY_ENGINE) &&
+                                            RUBY_ENGINE == 'jruby') do
       context 'when locals is enabled' do
         before do
           Rollbar.configure do |config|

--- a/spec/rollbar/notifier_spec.rb
+++ b/spec/rollbar/notifier_spec.rb
@@ -74,7 +74,9 @@ describe Rollbar::Notifier do
         notifier.configuration.files_processed_enabled = true
       end
 
-      let(:dummy_file) { double(File, :birthtime => Time.now, :size => 0).as_null_object }
+      let(:dummy_file) do
+        double(File, :birthtime => Time.now, :size => 0).as_null_object
+      end
 
       it 'writes to the file' do
         allow(File).to receive(:open).with(nil, 'a').and_return(dummy_file)
@@ -87,7 +89,8 @@ describe Rollbar::Notifier do
       end
     end
 
-    context 'when configured to write with process file and file birthtime is already greater than default value' do
+    context 'when configured to write with process file and file birthtime is ' \
+      'already greater than default value' do
       before do
         notifier.configuration.write_to_file = true
         notifier.configuration.files_processed_enabled = true
@@ -95,8 +98,11 @@ describe Rollbar::Notifier do
       end
 
       let(:dummy_file) do
+        duration = notifier.configuration.files_processed_duration
         double(
-          File, :birthtime => Time.now - (notifier.configuration.files_processed_duration + 1).seconds, :size => 0
+          File,
+          :birthtime => Time.now - (duration + 1).seconds,
+          :size => 0
         ).as_null_object
       end
 
@@ -119,8 +125,11 @@ describe Rollbar::Notifier do
       end
 
       let(:dummy_file) do
-        double(File, :birthtime => Time.now,
-                     :size => notifier.configuration.files_processed_size + 1).as_null_object
+        double(
+          File,
+          :birthtime => Time.now,
+          :size => notifier.configuration.files_processed_size + 1
+        ).as_null_object
       end
 
       it 'writes to the file and rename' do
@@ -208,7 +217,9 @@ describe Rollbar::Notifier do
       end
 
       RSpec::Matchers.define :access_token_header do |value|
-        match { |actual| (actual.fetch('X-Rollbar-Access-Token', 'undefined') == value) }
+        match do |actual|
+          (actual.fetch('X-Rollbar-Access-Token', 'undefined') == value)
+        end
       end
 
       it 'sets the access token header' do
@@ -224,7 +235,8 @@ describe Rollbar::Notifier do
         end
 
         it 'omits the access token header' do
-          expect(dummy_http).to receive(:request).with(access_token_header('undefined'))
+          expect(dummy_http).to receive(:request)
+            .with(access_token_header('undefined'))
 
           process_from_async_handler
         end
@@ -241,8 +253,14 @@ describe Rollbar::Notifier do
           let(:payload) { { 'data' => { 'failsafe' => true } } }
 
           it 'does not pass the message on' do
-            expect(notifier).to receive(:log_error).with("[Rollbar] Error processing the item: SocketError, SocketError. Item: #{payload.inspect}")
-            expect(notifier).to receive(:log_error).with('[Rollbar] Item has already failed. Not re-raising')
+            error_message =  '[Rollbar] Error processing the item: ' \
+              "SocketError, SocketError. Item: #{payload.inspect}"
+            expect(notifier)
+              .to receive(:log_error)
+              .with(error_message)
+            expect(notifier)
+              .to receive(:log_error)
+              .with('[Rollbar] Item has already failed. Not re-raising')
 
             process_from_async_handler
           end

--- a/spec/rollbar/plugin_spec.rb
+++ b/spec/rollbar/plugin_spec.rb
@@ -125,7 +125,8 @@ describe Rollbar::Plugin do
         end
 
         it 'it logs a plugin unload error message' do
-          expect(::Rollbar).to receive(:log_error).with(/Error trying to unload plugin/)
+          expect(::Rollbar).to receive(:log_error)
+            .with(/Error trying to unload plugin/)
 
           subject.unload!
         end
@@ -257,7 +258,9 @@ describe Rollbar::Plugin do
       it 'doesnt finish loading the plugin' do
         expect(dummy_object).not_to receive(:upcase)
         expect(dummy_object).not_to receive(:downcase)
-        expect(Rollbar).to receive(:log_error).with("Error trying to load plugin 'plugin': StandardError, the-error")
+        expect(Rollbar)
+          .to receive(:log_error)
+          .with("Error trying to load plugin 'plugin': StandardError, the-error")
 
         subject.load!
 
@@ -291,7 +294,9 @@ describe Rollbar::Plugin do
 
       it 'doesnt finish loading the plugin' do
         expect(dummy_object).not_to receive(:downcase)
-        expect(Rollbar).to receive(:log_error).with("Error trying to load plugin 'plugin': StandardError, the-error")
+        expect(Rollbar)
+          .to receive(:log_error)
+          .with("Error trying to load plugin 'plugin': StandardError, the-error")
 
         subject.load!
 

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -36,11 +36,14 @@ describe Rollbar::ActiveJob do
       :arguments => [argument]
     }
     expect(Rollbar).to receive(:error).with(exception, expected_params)
-    TestJob.new(argument).perform(exception, job_id) rescue nil # rubocop:disable Style/RescueModifier
+    TestJob.new(argument)
+           .perform(exception, job_id) rescue nil # rubocop:disable Style/RescueModifier
   end
 
   it 'reraises the error so the job backend can handle the failure and retry' do
-    expect { TestJob.new(argument).perform(exception, job_id) }.to raise_error exception
+    expect do
+      TestJob.new(argument).perform(exception, job_id)
+    end.to raise_error exception
   end
 
   context 'using ActionMailer::DeliveryJob', :if => defined?(ActionMailer::DeliveryJob) do
@@ -71,7 +74,8 @@ describe Rollbar::ActiveJob do
       expect(Rollbar).to receive(:error).with(kind_of(StandardError),
                                               hash_including(expected_params))
       perform_enqueued_jobs do
-        TestMailer.test_email(argument).deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        TestMailer.test_email(argument)
+                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
       end
     end
 
@@ -81,9 +85,11 @@ describe Rollbar::ActiveJob do
       end
 
       perform_enqueued_jobs do
-        TestMailer.test_email(:user_id => '15').deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        TestMailer.test_email(:user_id => '15')
+                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
       end
-      Rollbar.last_report[:body][:trace][:extra][:arguments][3][:user_id].should match(/^*+$/)
+      Rollbar.last_report[:body][:trace][:extra][:arguments][3][:user_id]
+             .should match(/^*+$/)
     end
 
     it 'scrubs job arguments HashWithIndifferentAccess' do
@@ -95,9 +101,11 @@ describe Rollbar::ActiveJob do
       params['user_id'] = '15'
 
       perform_enqueued_jobs do
-        TestMailer.test_email(params).deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        TestMailer.test_email(params)
+                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
       end
-      Rollbar.last_report[:body][:trace][:extra][:arguments][3]['user_id'].should match(/^*+$/)
+      Rollbar.last_report[:body][:trace][:extra][:arguments][3]['user_id']
+             .should match(/^*+$/)
     end
   end
 end

--- a/spec/rollbar/plugins/delayed_job_spec.rb
+++ b/spec/rollbar/plugins/delayed_job_spec.rb
@@ -28,7 +28,8 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
   context 'with delayed method without arguments failing' do
     it 'sends the exception' do
       expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
-      expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*expected_args)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+        .with(*expected_args)
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
     end
@@ -43,8 +44,8 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
 
-      expect(payload['data'][:request]['handler']).to include({ :args => [:foo, :bar],
-                                                                :method_name => :do_job_please! })
+      expect(payload['data'][:request]['handler'])
+        .to include({ :args => [:foo, :bar], :method_name => :do_job_please! })
     end
   end
 
@@ -59,11 +60,15 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
 
     it 'sends the exception' do
       expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
-      allow_any_instance_of(Delayed::Backend::Base).to receive(:payload_object).and_raise(Delayed::DeserializationError)
+      allow_any_instance_of(Delayed::Backend::Base)
+        .to receive(:payload_object)
+        .and_raise(Delayed::DeserializationError)
       if Delayed::Backend::Base.method_defined? :error
-        expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*new_expected_args)
+        expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+          .with(*new_expected_args)
       else
-        expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*old_expected_args)
+        expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+          .with(*old_expected_args)
       end
 
       FailingJob.new.delay.do_job_please!(:foo, :bar)
@@ -78,11 +83,15 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
 
       it 'sends the exception' do
         expect(Rollbar).to receive(:scope).with(kind_of(Hash)).and_call_original
-        allow_any_instance_of(Delayed::Backend::Base).to receive(:payload_object).and_raise(Delayed::DeserializationError)
+        allow_any_instance_of(Delayed::Backend::Base)
+          .to receive(:payload_object)
+          .and_raise(Delayed::DeserializationError)
         if Delayed::Backend::Base.method_defined? :error
-          expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*new_expected_args)
+          expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+            .with(*new_expected_args)
         else
-          expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(*old_expected_args)
+          expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+            .with(*old_expected_args)
         end
 
         FailingJob.new.delay.do_job_please!(:foo, :bar)
@@ -158,7 +167,8 @@ describe Rollbar::Delayed, :reconfigure_notifier => true do
       let(:handler) { double('handler') }
 
       before do
-        allow(configuration).to receive(:async_skip_report_handler).and_return(handler)
+        allow(configuration).to receive(:async_skip_report_handler)
+          .and_return(handler)
         allow(handler).to receive(:respond_to).with(:call).and_return(true)
       end
 

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -20,11 +20,12 @@ describe ApplicationController, :type => 'request' do
     it 'renders the snippet and config in the response', :type => 'request' do
       get '/test_rollbar_js'
 
-      snippet_from_submodule = File.read(File.expand_path(
-                                           '../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__
-                                         ))
+      snippet_from_submodule = File.read(
+        File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
 
-      expect(response.body).to include("var _rollbarConfig = #{Rollbar.configuration.js_options.to_json};")
+      expect(response.body).to include(
+        "var _rollbarConfig = #{Rollbar.configuration.js_options.to_json};"
+      )
       expect(response.body).to include(snippet_from_submodule)
     end
   end
@@ -145,7 +146,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response without nonce in script tag' do
         get '/test_rollbar_js'
 
-        expect(response.body).to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to include '<script type="text/javascript">'
       end
 
@@ -158,7 +160,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response without nonce in script tag' do
         get '/test_rollbar_js'
 
-        expect(response.body).to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to include '<script type="text/javascript">'
       end
 
@@ -171,7 +174,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response with nonce in script tag' do
         get '/test_rollbar_js'
 
-        expect(response.body).to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to_not include '<script type="text/javascript">'
       end
 
@@ -184,7 +188,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response with nonce in script tag' do
         get '/test_rollbar_js'
 
-        expect(response.body).to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to_not include '<script type="text/javascript">'
       end
 
@@ -256,7 +261,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response without nonce in script tag' do
         get '/test_rollbar_js'
 
-        expect(response.body).to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to include '<script type="text/javascript">'
       end
 
@@ -269,7 +275,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response with nonce in script tag' do
         get '/test_rollbar_js_with_nonce'
 
-        expect(response.body).to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to_not include '<script type="text/javascript">'
       end
 
@@ -282,7 +289,8 @@ describe ApplicationController, :type => 'request' do
       it 'renders the snippet and config in the response with nonce in script tag' do
         get '/test_rollbar_js_with_nonce'
 
-        expect(response.body).to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
+        expect(response.body)
+          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
         expect(response.body).to_not include '<script type="text/javascript">'
       end
 

--- a/spec/rollbar/plugins/resque/failure_spec.rb
+++ b/spec/rollbar/plugins/resque/failure_spec.rb
@@ -16,8 +16,8 @@ describe Resque::Failure::Rollbar do
     end
 
     it 'should be notified of an error' do
-      expect_any_instance_of(Rollbar::Notifier).to receive(:log).with('error', exception,
-                                                                      payload)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:log)
+        .with('error', exception, payload)
       backend.save
     end
   end
@@ -30,8 +30,8 @@ describe Resque::Failure::Rollbar do
     end
 
     it 'sends the :use_exception_level_filters option' do
-      expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(exception,
-                                                                        payload_with_options)
+      expect_any_instance_of(Rollbar::Notifier).to receive(:error)
+        .with(exception, payload_with_options)
       backend.save
     end
   end

--- a/spec/rollbar/plugins/sidekiq_spec.rb
+++ b/spec/rollbar/plugins/sidekiq_spec.rb
@@ -141,7 +141,8 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
         )
       end
 
-      it "does not blow up and doesn't send the error to rollbar if retry is true but there is no retry count" do
+      it "does not blow up and doesn't send the error to rollbar if " \
+        'retry is true but there is no retry count' do
         allow(Rollbar).to receive(:scope).and_return(rollbar)
         expect(rollbar).to receive(:error).never
 

--- a/spec/rollbar/plugins/validations_spec.rb
+++ b/spec/rollbar/plugins/validations_spec.rb
@@ -6,7 +6,8 @@ Rollbar.plugins.load!
 describe Rollbar::ActiveRecordExtension do
   it 'has the extensions loaded into ActiveRecord::Base' do
     expect(ActiveModel::Validations.ancestors).to include(described_class)
-    expect(ActiveModel::Validations.instance_methods.map(&:to_sym)).to include(:report_validation_errors_to_rollbar)
+    expect(ActiveModel::Validations.instance_methods.map(&:to_sym))
+      .to include(:report_validation_errors_to_rollbar)
   end
 
   context 'with an ActiveRecord::Base instance' do

--- a/spec/rollbar/plugins_spec.rb
+++ b/spec/rollbar/plugins_spec.rb
@@ -18,7 +18,8 @@ describe Rollbar::Plugins do
 
   before do
     Rollbar.plugins = nil
-    allow_any_instance_of(described_class).to receive(:plugin_files).and_return(plugin_files_path)
+    allow_any_instance_of(described_class).to receive(:plugin_files)
+      .and_return(plugin_files_path)
   end
 
   after do

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -57,8 +57,10 @@ describe Rollbar::RequestDataExtractor do
     let(:scrub_whitelist) { false }
 
     before do
-      allow(Rollbar.configuration).to receive(:scrub_fields).and_return(scrub_fields)
-      allow(Rollbar.configuration).to receive(:scrub_whitelist).and_return(scrub_whitelist)
+      allow(Rollbar.configuration).to receive(:scrub_fields)
+        .and_return(scrub_fields)
+      allow(Rollbar.configuration).to receive(:scrub_whitelist)
+        .and_return(scrub_whitelist)
     end
 
     it 'calls the scrubber with the correct options' do
@@ -77,8 +79,12 @@ describe Rollbar::RequestDataExtractor do
 
   describe '#extract_request_data_from_rack' do
     it 'returns a Hash object' do
-      expect(Rollbar::Scrubbers::URL).to receive(:call).with(kind_of(Hash)).and_call_original
-      expect(Rollbar::Scrubbers::Params).to receive(:call).with(kind_of(Hash)).and_call_original.exactly(6)
+      expect(Rollbar::Scrubbers::URL).to receive(:call)
+        .with(kind_of(Hash))
+        .and_call_original
+      expect(Rollbar::Scrubbers::Params).to receive(:call)
+        .with(kind_of(Hash))
+        .and_call_original.exactly(6)
 
       result = subject.extract_request_data_from_rack(env)
 
@@ -98,7 +104,8 @@ describe Rollbar::RequestDataExtractor do
       end
 
       before do
-        allow(Rollbar.configuration).to receive(:scrub_headers).and_return(scrub_headers)
+        allow(Rollbar.configuration).to receive(:scrub_headers)
+          .and_return(scrub_headers)
       end
 
       it 'returns scrubbed headers' do
@@ -245,7 +252,8 @@ describe Rollbar::RequestDataExtractor do
         it 'extracts the correct X-Forwarded-For' do
           result = subject.extract_request_data_from_rack(env)
 
-          expect(result[:headers]['X-Forwarded-For']).to be_eql('192.168.1.1, 2.2.2.2, 3.3.3.3')
+          expect(result[:headers]['X-Forwarded-For'])
+            .to be_eql('192.168.1.1, 2.2.2.2, 3.3.3.3')
         end
 
         it 'extracts the correct X-Real-Ip' do

--- a/spec/rollbar/scrubbers/url_spec.rb
+++ b/spec/rollbar/scrubbers/url_spec.rb
@@ -66,22 +66,26 @@ describe Rollbar::Scrubbers::URL do
 
       context 'with params to be filtered' do
         let(:url) do
-          'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue#fragment'
+          'http://foo.com/some-interesting-path' \
+          '?foo=bar&password=mypassword&secret=somevalue#fragment'
         end
 
         it 'returns the URL with some params filtered' do
-          expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password=\*{3,8}&secret=\*{3,8}#fragment}
+          expected_url = %r{http://foo.com/some-interesting-path
+            \?foo=bar&password=\*{3,8}&secret=\*{3,8}#fragment}x
 
           expect(subject.call(options)).to match(expected_url)
         end
 
         context 'having array params' do
           let(:url) do
-            'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue#fragment'
+            'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword' \
+            '&password[]=otherpassword&secret=somevalue#fragment'
           end
 
           it 'returns the URL with some params filtered' do
-            expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=\*{3,8}#fragment}
+            expected_url = %r{http://foo.com/some-interesting-path\?foo=bar
+            &password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=\*{3,8}#fragment}x
 
             expect(subject.call(options)).to match(expected_url)
           end
@@ -104,7 +108,8 @@ describe Rollbar::Scrubbers::URL do
         end
 
         it 'scrubs with same length than the scrubbed param' do
-          expected_url = %r{http://foo.com/some-interesting-path\?foo=bar&password=\*{#{password.length}}#fragment}
+          expected_url = %r{http://foo.com/some-interesting-path
+            \?foo=bar&password=\*{#{password.length}}#fragment}x
 
           expect(subject.call(options)).to match(expected_url)
         end
@@ -144,13 +149,19 @@ describe Rollbar::Scrubbers::URL do
 
       context 'with URL with spaces and arrays' do
         let(:url) do
-          'https://server.com/api/v1/assignments/4430038?user_id=1&assignable_id=2&starts_at=Wed%20Jul%2013%202016%2000%3A00%3A00%20GMT-0700%20(PDT)&ends_at=Fri%20Jul%2029%202016%2000%3A00%3A00%20GMT-0700%20(PDT)&allocation_mode=hours_per_day&percent=&fixed_hours=&hours_per_day=0&auth=REMOVED&___uidh=2228207862&password[]=mypassword'
+          'https://server.com/api/v1/assignments/4430038' \
+          '?user_id=1&assignable_id=2' \
+          '&starts_at=Wed%20Jul%2013%202016%2000%3A00%3A00%20GMT-0700%20(PDT)' \
+          '&ends_at=Fri%20Jul%2029%202016%2000%3A00%3A00%20GMT-0700%20(PDT)' \
+          '&allocation_mode=hours_per_day&percent=&fixed_hours=&hours_per_day=0' \
+          '&auth=REMOVED&___uidh=2228207862&password[]=mypassword'
         end
         let(:options) do
           {
             :url => url,
             :scrub_fields => [:passwd, :password, :password_confirmation, :secret,
-                              :confirm_password, :secret_token, :api_key, :access_token, :auth, :SAMLResponse, :password, :auth],
+                              :confirm_password, :secret_token, :api_key, :access_token,
+                              :auth, :SAMLResponse, :password, :auth],
             :scrub_user => true,
             :scrub_password => true,
             :randomize_scrub_length => true
@@ -190,7 +201,8 @@ describe Rollbar::Scrubbers::URL do
           let(:url) { 'http://user:password@foo.com/some-interesting-path#fragment' }
 
           it 'returns the URL without any change' do
-            expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/some-interesting-path#fragment}
+            expected_url = %r{http://\*{3,8}:\*{3,8}@foo.com/
+              some-interesting-path#fragment}x
 
             expect(subject.call(options)).to match(expected_url)
           end
@@ -207,22 +219,27 @@ describe Rollbar::Scrubbers::URL do
             }
           end
           let(:url) do
-            'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment'
+            'http://foo.com/some-interesting-path?foo=bar&password=mypassword' \
+            '&secret=somevalue&dont_scrub=foo#fragment'
           end
 
           it 'returns the URL with some params filtered' do
-            expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
+            expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}
+              &password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}x
 
             expect(subject.call(options)).to match(expected_url)
           end
 
           context 'having array params' do
             let(:url) do
-              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
+              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword' \
+              '&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
             end
 
             it 'returns the URL with some params filtered' do
-              expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
+              expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}
+                &password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue
+                &dont_scrub=\*{3,8}#fragment}x
 
               expect(subject.call(options)).to match(expected_url)
             end
@@ -241,22 +258,27 @@ describe Rollbar::Scrubbers::URL do
           end
 
           let(:url) do
-            'http://foo.com/some-interesting-path?foo=bar&password=mypassword&secret=somevalue&dont_scrub=foo#fragment'
+            'http://foo.com/some-interesting-path?foo=bar&password=mypassword' \
+            '&secret=somevalue&dont_scrub=foo#fragment'
           end
 
           it 'returns the URL with some params filtered' do
-            expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
+            expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}
+              &password=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}x
 
             expect(subject.call(options)).to match(expected_url)
           end
 
           context 'having array params' do
             let(:url) do
-              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
+              'http://foo.com/some-interesting-path?foo=bar&password[]=mypassword' \
+              '&password[]=otherpassword&secret=somevalue&dont_scrub=foo#fragment'
             end
 
             it 'returns the URL with some params filtered' do
-              expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}&password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue&dont_scrub=\*{3,8}#fragment}
+              expected_url = %r{http://foo.com/some-interesting-path\?foo=\*{3,8}
+                &password\[\]=\*{3,8}&password\[\]=\*{3,8}&secret=somevalue
+                &dont_scrub=\*{3,8}#fragment}x
 
               expect(subject.call(options)).to match(expected_url)
             end

--- a/spec/rollbar/truncation/remove_extra_strategy_spec.rb
+++ b/spec/rollbar/truncation/remove_extra_strategy_spec.rb
@@ -24,7 +24,8 @@ describe Rollbar::Truncation::RemoveExtraStrategy do
       end
 
       it 'should truncate the extra data in the payload' do
-        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+        json = described_class.call(Rollbar::Util.deep_copy(payload))
+        result = Rollbar::JSON.load(json)
 
         expect(result['data']['body']['message']['extra']).to be_nil
         expect(result['data']['body']['message']['body']).to be_eql(message_body)
@@ -50,7 +51,8 @@ describe Rollbar::Truncation::RemoveExtraStrategy do
       end
 
       it 'should truncate the extra data in the payload' do
-        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+        json = described_class.call(Rollbar::Util.deep_copy(payload))
+        result = Rollbar::JSON.load(json)
 
         expect(result['data']['body']['trace']['extra']).to be_nil
         expect(result['data']['body']['trace']['frames']).to be_eql(trace_frames)
@@ -76,7 +78,8 @@ describe Rollbar::Truncation::RemoveExtraStrategy do
       end
 
       it 'should truncate the extra data in the payload' do
-        result = Rollbar::JSON.load(described_class.call(Rollbar::Util.deep_copy(payload)))
+        json = described_class.call(Rollbar::Util.deep_copy(payload))
+        result = Rollbar::JSON.load(json)
 
         expect(result['data']['body']['trace_chain'][0]['extra']).to be_nil
         expect(result['data']['body']['trace_chain'][0]['frames']).to be_eql(trace_frames)

--- a/spec/rollbar/truncation_spec.rb
+++ b/spec/rollbar/truncation_spec.rb
@@ -8,7 +8,8 @@ describe Rollbar::Truncation do
     context 'if truncation is not needed' do
       it 'only calls RawStrategy is truncation is not needed' do
         allow(described_class).to receive(:truncate?).and_return(false)
-        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload).and_return('')
+        expect(Rollbar::Truncation::RawStrategy)
+          .to receive(:call).with(payload).and_return('')
 
         Rollbar::Truncation.truncate(payload)
       end
@@ -17,8 +18,10 @@ describe Rollbar::Truncation do
     context 'if truncation is needed' do
       it 'calls the next strategy, FramesStrategy' do
         allow(described_class).to receive(:truncate?).and_return(true, false)
-        expect(Rollbar::Truncation::RawStrategy).to receive(:call).with(payload).and_return('')
-        expect(Rollbar::Truncation::FramesStrategy).to receive(:call).with(payload).and_return('')
+        expect(Rollbar::Truncation::RawStrategy)
+          .to receive(:call).with(payload).and_return('')
+        expect(Rollbar::Truncation::FramesStrategy)
+          .to receive(:call).with(payload).and_return('')
 
         Rollbar::Truncation.truncate(payload)
       end

--- a/spec/rollbar_bc_spec.rb
+++ b/spec/rollbar_bc_spec.rb
@@ -41,8 +41,12 @@ describe Rollbar do
 
     it 'should report messages with extra data' do
       logger_mock.should_receive(:info).with('[Rollbar] Success')
-      Rollbar.report_message('Test message with extra data', 'debug', :foo => 'bar',
-                                                                      :hash => { :a => 123, :b => 'xyz' })
+      Rollbar.report_message(
+        'Test message with extra data',
+        'debug',
+        :foo => 'bar',
+        :hash => { :a => 123, :b => 'xyz' }
+      )
     end
 
     it 'should not crash with circular extra_data' do
@@ -287,13 +291,17 @@ describe Rollbar do
       Rollbar.last_report.should_not be_nil
     end
 
-    it 'should allow callables to set exception filtered level with :use_exception_level_filters option' do
+    it 'should allow callables to set exception filtered level with' \
+      ':use_exception_level_filters option' do
       callable_mock = double
       Rollbar.configure do |config|
         config.exception_level_filters = { 'NameError' => callable_mock }
       end
 
-      callable_mock.should_receive(:call).with(@exception).at_least(:once).and_return('info')
+      callable_mock.should_receive(:call)
+                   .with(@exception)
+                   .at_least(:once)
+                   .and_return('info')
       logger_mock.should_receive(:info)
       logger_mock.should_not_receive(:error)
 
@@ -360,7 +368,8 @@ describe Rollbar do
 
       Rollbar.report_exception(exception)
 
-      payload['data'][:body][:trace][:frames][0][:method].should eq('custom backtrace line')
+      payload['data'][:body][:trace][:frames][0][:method]
+        .should eq('custom backtrace line')
     end
 
     it 'should report exceptions with a custom level' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,11 +81,13 @@ RSpec.configure do |config|
     stub_request(:any, /api.rollbar.com/).to_rack(RollbarAPI.new) if defined?(WebMock)
     if defined?(WebMock)
       stub_request(:post,
-                   %r{api.rollbar.com/api/[0-9]/deploy/$}).to_rack(DeployAPI::Report.new)
+                   %r{api.rollbar.com/api/[0-9]/deploy/$})
+        .to_rack(DeployAPI::Report.new)
     end
     if defined?(WebMock)
       stub_request(:patch,
-                   %r{api.rollbar.com/api/[0-9]/deploy/[0-9]+}).to_rack(DeployAPI::Update.new)
+                   %r{api.rollbar.com/api/[0-9]/deploy/[0-9]+})
+        .to_rack(DeployAPI::Update.new)
     end
   end
 

--- a/spec/support/notifier_helpers.rb
+++ b/spec/support/notifier_helpers.rb
@@ -22,9 +22,13 @@ module NotifierHelpers
 
     Rollbar.preconfigure do |config|
       config.logger = rails_logger
-      config.environment = defined?(::Rails.env) && ::Rails.env || defined?(RAILS_ENV) && RAILS_ENV
-      config.root = defined?(::Rails.root) && ::Rails.root || defined?(RAILS_ROOT) && RAILS_ROOT
-      config.framework = defined?(::Rails.version) && "Rails: #{::Rails.version}" || defined?(::Rails::VERSION::STRING) && "Rails: #{::Rails::VERSION::STRING}"
+      config.environment = defined?(::Rails.env) && ::Rails.env ||
+                           defined?(RAILS_ENV) && RAILS_ENV
+      config.root = defined?(::Rails.root) && ::Rails.root ||
+                    defined?(RAILS_ROOT) && RAILS_ROOT
+      version = defined?(::Rails.version) && ::Rails.version ||
+                  defined?(::Rails::VERSION::STRING) && ::Rails::VERSION::STRING
+      config.framework = "Rails: #{version}"
     end
   end
 


### PR DESCRIPTION
## Description of the change

This PR addresses all remaining line length offenses.

For literal strings, line continuation (`\`) is used by default. Ruby has several techniques for concatenation, but line continuation allows the parser to treat multiple lines as one literal string. This is more performant than concatenation and readability is improved as well.

In some cases, if a comment or test label should be more concise, the line length is solved by improving the text. I'm sure there are even more cases where this can be done, but I took the opportunity where it was obvious to me.

There are multiple places where "https://github.com" has been removed from a code reference in a comment, since it has been determined in earlier PRs that comments should not specifically reference Github URLs.

Long regular expressions are refactored to use the /x modifier. Other techniques are possible in Ruby, but this should be the most familiar to most people.

 Note: This PR also adds rubocop exclusions for spec/tmp and spec/dummyapp. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch86350

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
