### PR TITLE
Resolve rubocop Style/StringConcatenation violations

### DIFF
--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -71,7 +71,7 @@ module Rails
     end
 
     def runner_path
-      railties_gem_dir + '/lib/rails/commands/runner.rb'
+      "#{railties_gem_dir}/lib/rails/commands/runner.rb"
     end
 
     def railties_gem

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -350,7 +350,7 @@ module Rollbar
           @hooks[symbol]
         end
       else
-        raise StandardError, 'Hook :' + symbol.to_s + ' is not supported by Rollbar SDK.'
+        raise StandardError, "Hook :#{symbol} is not supported by Rollbar SDK."
       end
     end
 

--- a/lib/rollbar/deploy.rb
+++ b/lib/rollbar/deploy.rb
@@ -30,9 +30,7 @@ module Rollbar
       return {} unless access_token && !access_token.empty?
 
       uri = ::URI.parse(
-        ::Rollbar::Deploy::ENDPOINT +
-        deploy_id.to_s +
-        '?access_token=' + access_token
+        "#{::Rollbar::Deploy::ENDPOINT}#{deploy_id}?access_token=#{access_token}"
       )
 
       request = ::Net::HTTP::Patch.new(uri.request_uri)
@@ -74,17 +72,18 @@ module Rollbar
 
       def request_result(uri, request)
         {
-          :request_info => uri.inspect + ': ' + request.body,
+          :request_info => "#{uri.inspect}: #{request.body}",
           :request => request
         }
       end
 
       def response_result(response)
+        code = response.code
+        message = response.message
+        body = response.body.delete("\n")
         {
           :response => response,
-          :response_info => response.code + '; ' +
-            response.message + '; ' +
-            response.body.delete("\n")
+          :response_info => "#{code}; #{message}; #{body}"
         }.merge(::JSON.parse(response.body, :symbolize_names => true))
       end
     end

--- a/lib/rollbar/item/backtrace.rb
+++ b/lib/rollbar/item/backtrace.rb
@@ -110,7 +110,8 @@ module Rollbar
       end
 
       def rollbar_lib_gem_dir
-        Gem::Specification.find_by_name('rollbar').gem_dir + '/lib'
+        gem_dir = Gem::Specification.find_by_name('rollbar').gem_dir
+        "#{gem_dir}/lib"
       end
     end
   end

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -82,7 +82,7 @@ module Rollbar
           route_params = request_data[:params]
           # make sure route is a hash built by RequestDataExtractor
           if route_params.is_a?(Hash) && !route_params.empty?
-            route_params[:controller].to_s + '#' + route_params[:action].to_s
+            "#{route_params[:controller]}##{route_params[:action]}"
           end
         end
       end

--- a/lib/rollbar/plugins/delayed_job/plugin.rb
+++ b/lib/rollbar/plugins/delayed_job/plugin.rb
@@ -21,7 +21,7 @@ module Rollbar
             end
           elsif job.last_error
             ::Rollbar.scope(:request => data).error(
-              "Job has failed and won't be retried anymore: " + job.last_error,
+              "Job has failed and won't be retried anymore: #{job.last_error}",
               :use_exception_level_filters => true
             )
           end

--- a/lib/rollbar/plugins/rails/railtie_mixin.rb
+++ b/lib/rollbar/plugins/rails/railtie_mixin.rb
@@ -16,9 +16,9 @@ module Rollbar
             config.framework = "Rails: #{::Rails::VERSION::STRING}"
             config.filepath ||= begin
               if ::Rails.application.class.respond_to?(:module_parent_name)
-                ::Rails.application.class.module_parent_name + '.rollbar'
+                "#{::Rails.application.class.module_parent_name}.rollbar"
               else
-                ::Rails.application.class.parent_name + '.rollbar'
+                "#{::Rails.application.class.parent_name}.rollbar"
               end
             end
           end

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -142,14 +142,14 @@ module Rollbar
       query = env['QUERY_STRING'].to_s.empty? ? nil : "?#{env['QUERY_STRING']}"
       path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{query}"
       if !(path.nil? || path.empty?) && (path.to_s.slice(0, 1) != '/')
-        path = '/' + path.to_s
+        path = "/#{path}"
       end
 
       port = env['HTTP_X_FORWARDED_PORT']
       if port && !(!scheme.nil? && scheme.casecmp('http').zero? && port.to_i == 80) && \
          !(!scheme.nil? && scheme.casecmp('https').zero? && port.to_i == 443) && \
          !(host.include? ':')
-        host = host + ':' + port
+        host = "#{host}:#{port}"
       end
 
       [scheme, '://', host, path].join

--- a/lib/rollbar/util/ip_anonymizer.rb
+++ b/lib/rollbar/util/ip_anonymizer.rb
@@ -24,7 +24,7 @@ module Rollbar
       def self.anonymize_ipv6(ip)
         ip_parts = ip.to_s.split ':'
 
-        ip_string = ip_parts[0..2].join(':') + ':0000:0000:0000:0000:0000'
+        ip_string = "#{ip_parts[0..2].join(':')}:0000:0000:0000:0000:0000"
 
         IPAddr.new(ip_string).to_s
       end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -162,12 +162,12 @@ describe Rollbar::Item do
 
       it 'should have access to the context in custom_data_method' do
         configuration.custom_data_method = lambda do |_message, _exception, context|
-          { :result => 'MyApp#' + context[:controller] }
+          { :result => "MyApp##{context[:controller]}" }
         end
 
         payload['data'][:body][:message][:extra].should_not be_nil
         payload['data'][:body][:message][:extra][:result]
-          .should == 'MyApp#' + context[:controller]
+          .should == "MyApp##{context[:controller]}"
       end
 
       it 'should not include data passed in :context if there is no custom_data_method' do
@@ -178,12 +178,12 @@ describe Rollbar::Item do
 
       it 'should have access to the message in custom_data_method' do
         configuration.custom_data_method = lambda do |message, _exception, _context|
-          { :result => 'Transformed in custom_data_method: ' + message }
+          { :result => "Transformed in custom_data_method: #{message}" }
         end
 
         extra = payload['data'][:body][:message][:extra]
         extra.should_not be_nil
-        extra[:result].should == 'Transformed in custom_data_method: ' + message
+        extra[:result].should == "Transformed in custom_data_method: #{message}"
       end
 
       context do
@@ -191,13 +191,13 @@ describe Rollbar::Item do
 
         it 'should have access to the current exception in custom_data_method' do
           configuration.custom_data_method = lambda do |_message, exception, _context|
-            { :result => 'Transformed in custom_data_method: ' + exception.message }
+            { :result => "Transformed in custom_data_method: #{exception.message}" }
           end
 
           extra = payload['data'][:body][:trace][:extra]
           extra.should_not be_nil
           expect(extra[:result])
-            .to eq('Transformed in custom_data_method: ' + exception.message)
+            .to eq("Transformed in custom_data_method: #{exception.message}")
         end
       end
     end

--- a/spec/rollbar/truncation/strings_strategy_spec.rb
+++ b/spec/rollbar/truncation/strings_strategy_spec.rb
@@ -27,7 +27,7 @@ describe Rollbar::Truncation::StringsStrategy do
     end
 
     context 'with utf8 strings' do
-      let(:long_message) { 'Ŝǻмρļẻ śţяịņģ' + 'a' * 2000 }
+      let(:long_message) { "Ŝǻмρļẻ śţяịņģ#{'a' * 2000}" }
       let(:payload) do
         {
           'truncated' => long_message,

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -289,7 +289,7 @@ describe Rollbar do
           before do
             Rollbar.configure do |config|
               config.custom_data_method = lambda do |_message, _exception, context|
-                { :result => 'MyApp#' + context[:controller] }
+                { :result => "MyApp##{context[:controller]}" }
               end
             end
           end
@@ -300,7 +300,7 @@ describe Rollbar do
 
             result[:body][:message][:extra].should_not be_nil
             result[:body][:message][:extra][:result]
-              .should eq('MyApp#' + context[:controller])
+              .should eq("MyApp##{context[:controller]}")
             result[:body][:message][:extra][:custom_data_method_context].should be_nil
           end
         end
@@ -1084,7 +1084,7 @@ describe Rollbar do
       Rollbar.error(exception)
 
       gem_dir = Gem::Specification.find_by_name('rollbar').gem_dir
-      gem_lib_dir = gem_dir + '/lib'
+      gem_lib_dir = "#{gem_dir}/lib"
       last_report = Rollbar.last_report
 
       filepaths = last_report[:body][:trace][:frames].map do |frame|


### PR DESCRIPTION
## Description of the change

Interpolation syntax for interpolated strings is preferred over concatenation, as it is more performant, more idomatic, and doesn't require explicitly calling `to_s` on non-string values. 

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringConcatenation

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch86955

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
