### PR TITLE
Resolve rubocop Lint/HashCompareByIdentity violations

### DIFF
--- a/lib/rollbar/scrubbers/params.rb
+++ b/lib/rollbar/scrubbers/params.rb
@@ -22,7 +22,7 @@ module Rollbar
         params = options[:params]
         return {} unless params
 
-        @scrubbed_object_ids = {}
+        @scrubbed_objects = {}.compare_by_identity
 
         config = options[:config]
         extra_fields = options[:extra_fields]
@@ -64,9 +64,9 @@ module Rollbar
       end
 
       def scrub(params, options)
-        return params if @scrubbed_object_ids[params.object_id]
+        return params if @scrubbed_objects[params]
 
-        @scrubbed_object_ids[params.object_id] = true
+        @scrubbed_objects[params] = true
 
         fields_regex = options[:fields_regex]
         scrub_all = options[:scrub_all]

--- a/lib/rollbar/util/hash.rb
+++ b/lib/rollbar/util/hash.rb
@@ -2,9 +2,10 @@ module Rollbar
   module Util
     module Hash # :nodoc:
       def self.deep_stringify_keys(hash, seen = {})
-        return if seen[hash.object_id]
+        seen.compare_by_identity
+        return if seen[hash]
 
-        seen[hash.object_id] = true
+        seen[hash] = true
         replace_seen_children(hash, seen)
 
         hash.reduce({}) do |h, (key, value)|
@@ -19,10 +20,10 @@ module Rollbar
         when ::Hash
           send(meth, thing, seen)
         when Array
-          if seen[thing.object_id]
+          if seen[thing]
             thing
           else
-            seen[thing.object_id] = true
+            seen[thing] = true
             replace_seen_children(thing, seen)
             thing.map { |v| map_value(v, meth, seen) }
           end
@@ -35,14 +36,14 @@ module Rollbar
         case thing
         when ::Hash
           thing.keys.each do |key|
-            if seen[thing[key].object_id]
+            if seen[thing[key]]
               thing[key] =
                 "removed circular reference: #{thing[key]}"
             end
           end
         when Array
           thing.each_with_index do |_, i|
-            if seen[thing[i].object_id]
+            if seen[thing[i]]
               thing[i] =
                 "removed circular reference: #{thing[i]}"
             end


### PR DESCRIPTION
## Description of the change

Rubocop prefers using `Hash#compare_by_identity` over using `object_id` for hash keys. This has the advantage of being more compact and readable. The code was originally written using `object_id` for compatibility with Ruby 1.8.7, which didn't yet have `Hash#compare_by_identity`. This compatibility is no longer required.

Note that one section of code uses `object_id` in an array. `Array` doesn't have `compare_by_identity` and even if we wanted to use `Set`, it didn't have it prior to Ruby 2.4. So we continue to use `object_id` in this case.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/HashCompareByIdentity

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch86992

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
