### PR TITLE
Fix error reports not being sent on Sidekiq non-retries

### DIFF
--- a/lib/rollbar/plugins/sidekiq/plugin.rb
+++ b/lib/rollbar/plugins/sidekiq/plugin.rb
@@ -24,11 +24,11 @@ module Rollbar
       job_hash = job_hash_from_msg(msg)
 
       return false if job_hash.nil?
+      return false unless job_hash['retry_count'] # This job  is not a retry attempt if retry_count is not set
 
-      # when rollbar middleware catches, sidekiq's retry_job processor hasn't set
-      # the retry_count for the current job yet, so adding 1 gives the actual retry count
-      actual_retry_count = job_hash.fetch('retry_count', -1) + 1
-      job_hash['retry'] && actual_retry_count < ::Rollbar.configuration.sidekiq_threshold
+      # Sidekiq retry_count tracks the number of previous retries attempted, which means that for the first retry,
+      # it would be set to 0.
+      job_hash['retry_count'] + 1 < ::Rollbar.configuration.sidekiq_threshold
     end
 
     def self.job_scope(msg)


### PR DESCRIPTION
### Summary

There was a bug introduced on #761 which prevented errors on being reported from jobs that are running for the first time (not a retry).

### Details

Some wrong assumptions were made on the behavior of retries on #761, mainly the following:

* `retry` would be set to a falsey value if the job is not a retry attempt. This is wrong.
* `retry_count` can potentially be not present in a retry attempt.

Here's a sample of a message hash for a job running first time with retries set:

```
{"retry"=>3, "queue"=>"test", "class"=>"TestWorker", "args"=>[], "jid"=>"db020cf431b76e59f12b54d3", "created_at"=>1623896659.149288, "enqueued_at"=>1623896659.150045}
```

While this is the message hash for a job that has been retried first time:

```
{"retry"=>3, "queue"=>"test", "class"=>"TestWorker", "args"=>[], "jid"=>"db020cf431b76e59f12b54d3", "created_at"=>1623896659.149288, "enqueued_at"=>1623896687.795098, "error_message"=>"undefined local variable or method `meh' for #<TestWorker:0x00007fe79eeb7480>", "error_class"=>"NameError", "failed_at"=>1623896663.811552, "retry_count"=>0}
```

This commit aims to correct the bug introduced and allow failed jobs to report errors when they are running for the first time.