### PR TITLE
Resolve rubocop Lint/SuppressedException violations

### DIFF
--- a/lib/generators/rollbar/rollbar_generator.rb
+++ b/lib/generators/rollbar/rollbar_generator.rb
@@ -22,6 +22,7 @@ module Rollbar
         begin
           require 'ey_config'
         rescue LoadError
+          # Skip loading
         end
 
         if defined? EY::Config

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -8,6 +8,7 @@ require 'forwardable'
 begin
   require 'securerandom'
 rescue LoadError
+  # Skip loading
 end
 
 require 'rollbar/version'

--- a/lib/rollbar/plugins/rails.rb
+++ b/lib/rollbar/plugins/rails.rb
@@ -64,6 +64,7 @@ Rollbar.plugins.define('rails-rollbar.js') do
               begin
                 require 'secure_headers'
               rescue LoadError
+                # Skip loading
               end
 
               defined?(::SecureHeaders::Middleware)

--- a/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
+++ b/spec/generators/rollbar/rollbar_generator_rails30_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 begin
   require 'genspec'
 rescue LoadError
+  # Skip loading
 end
 
 require 'generators/rollbar/rollbar_generator'

--- a/spec/generators/rollbar/rollbar_generator_spec.rb
+++ b/spec/generators/rollbar/rollbar_generator_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 begin
   require 'generator_spec'
 rescue LoadError
+  # Skip loading
 end
 
 require 'generators/rollbar/rollbar_generator'

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -16,17 +16,20 @@ begin
   require 'rollbar/delay/sidekiq'
   require 'rollbar/delay/sucker_punch'
 rescue LoadError
+  # Skip loading
 end
 
 begin
   require 'sucker_punch'
   require 'sucker_punch/testing/inline'
 rescue LoadError
+  # Skip loading
 end
 
 begin
   require 'rollbar/delay/shoryuken'
 rescue LoadError
+  # Skip loading
 end
 
 describe Rollbar do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ begin
   # and write an updated coverage/index.html
   Codacy::Reporter.start if Codacy::Formatter.new.send :should_run?
 rescue LoadError
+  # Skip loading
 end
 
 require 'rubygems'
@@ -31,6 +32,7 @@ begin
   require 'webmock/rspec'
   WebMock.disable_net_connect!(:allow => 'codeclimate.com')
 rescue LoadError
+  # Skip loading
 end
 
 namespace :dummy do


### PR DESCRIPTION
## Description of the change

Rollbar-gem  frequently uses `rescue LoadError` to support optional `require` scenarios. Rubocop will flag this with Lint/SuppressedException unless the rescue clause contains a comment (or `nil`.)

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SuppressedException

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch87746

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
