### PR TITLE
Resolve rubocop Style/CaseLikeIf violations

### DIFF
--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -7,16 +7,17 @@ module Rollbar
 
       exception_data = exception_data(exception)
 
-      if exception_data.is_a?(Hash)
+      case exception_data
+      when Hash
         env['rollbar.exception_uuid'] = exception_data[:uuid]
         Rollbar.log_debug(
           "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
         )
-      elsif exception_data == 'disabled'
+      when 'disabled'
         Rollbar.log_debug(
           '[Rollbar] Exception not reported because Rollbar is disabled'
         )
-      elsif exception_data == 'ignored'
+      when 'ignored'
         Rollbar.log_debug '[Rollbar] Exception not reported because it was ignored'
       end
     rescue StandardError => e

--- a/lib/rollbar/plugins/goalie.rb
+++ b/lib/rollbar/plugins/goalie.rb
@@ -31,16 +31,17 @@ Rollbar.plugins.define('goalie') do
 
           # if an exception was reported, save uuid in the env
           # so it can be displayed to the user on the error page
-          if exception_data.is_a?(Hash)
+          case exception_data
+          when Hash
             env['rollbar.exception_uuid'] = exception_data[:uuid]
             Rollbar.log_info(
               "[Rollbar] Exception uuid saved in env: #{exception_data[:uuid]}"
             )
-          elsif exception_data == 'disabled'
+          when 'disabled'
             Rollbar.log_info(
               '[Rollbar] Exception not reported because Rollbar is disabled'
             )
-          elsif exception_data == 'ignored'
+          when 'ignored'
             Rollbar.log_info(
               '[Rollbar] Exception not reported because it was ignored'
             )

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -91,9 +91,10 @@ module Rollbar
     def mergeable_raw_body_params(rack_req)
       raw_body_params = rollbar_raw_body_params(rack_req)
 
-      if raw_body_params.is_a?(Hash)
+      case raw_body_params
+      when Hash
         raw_body_params
-      elsif raw_body_params.is_a?(Array)
+      when Array
         { 'body.multi' => raw_body_params }
       else
         { 'body.value' => raw_body_params }

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -59,9 +59,10 @@ module Rollbar
       # This is the point of doing the work in two steps.
       copied[obj] = result
 
-      if obj.is_a?(::Hash)
+      case obj
+      when ::Hash
         obj.each { |k, v| result[k] = deep_copy(v, copied) }
-      elsif obj.is_a?(Array)
+      when Array
         obj.each { |v| result << deep_copy(v, copied) }
       end
 
@@ -69,9 +70,10 @@ module Rollbar
     end
 
     def self.clone_obj(obj)
-      if obj.is_a?(::Hash)
+      case obj
+      when ::Hash
         obj.dup
-      elsif obj.is_a?(Array)
+      when Array
         obj.dup.clear
       else
         obj

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -48,13 +48,14 @@ describe ApplicationController, :type => 'request' do
   context 'using rails5 content_security_policy',
           :if => (Gem::Version.new(Rails.version) >= Gem::Version.new('5.2.0')) do
     def configure_csp(mode)
-      if mode == :nonce_present
+      case mode
+      when :nonce_present
         nonce_present
-      elsif mode == :nonce_not_present
+      when :nonce_not_present
         nonce_not_present
-      elsif mode == :script_src_not_present
+      when :script_src_not_present
         script_src_not_present
-      elsif mode == :unsafe_inline_present
+      when :unsafe_inline_present
         unsafe_inline_present
       else
         raise 'Unknown CSP mode'
@@ -210,11 +211,12 @@ describe ApplicationController, :type => 'request' do
     def configure_csp(mode)
       return unless defined?(::SecureHeaders)
 
-      if mode == :nonce_present
+      case mode
+      when :nonce_present
         nonce_present
-      elsif mode == :nonce_not_present
+      when :nonce_not_present
         nonce_not_present
-      elsif mode == :unsafe_inline_present
+      when :unsafe_inline_present
         unsafe_inline_present
       else
         raise 'Unknown CSP mode'

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,12 +1,13 @@
 RSpec::Matchers.define :be_eql_hash_with_regexes do |expected|
   def check_value(actual_value, expected_value)
-    if expected_value.is_a?(Hash)
+    case expected_value
+    when Hash
       expected_value.all? { |k, _| check_value(actual_value[k], expected_value[k]) }
-    elsif expected_value.is_a?(Array)
+    when Array
       expected_value.each_with_index.map do |v, i|
         check_value(actual_value[i], v)
       end.all?
-    elsif expected_value.is_a?(Regexp)
+    when Regexp
       actual_value.match(expected_value)
     else
       actual_value == expected_value


### PR DESCRIPTION
## Description of the change

Rubocop flags with Style/CaseLikeIf when if/elsif syntax would be better as case/when. The case/when syntax is generally more compact and readable, and this PR updates the violations to use case/when.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CaseLikeIf

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch87751

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
