### PR TITLE
Resolve various rubocop Style, Layout violations

### DIFF
--- a/lib/rails/rollbar_runner.rb
+++ b/lib/rails/rollbar_runner.rb
@@ -52,9 +52,9 @@ module Rails
     def legacy_runner
       string_to_eval = File.read(runner_path)
 
-      ::Rails.module_eval(<<-EOL, __FILE__, __LINE__ + 1)
+      ::Rails.module_eval(<<-FILE, __FILE__, __LINE__ + 1)
           #{string_to_eval}
-      EOL
+      FILE
     end
 
     def rails5_runner

--- a/lib/rollbar/capistrano_tasks.rb
+++ b/lib/rollbar/capistrano_tasks.rb
@@ -29,7 +29,8 @@ module Rollbar
       def deploy_succeeded(capistrano, logger, dry_run)
         deploy_update(
           capistrano, logger, dry_run,
-          :desc => 'Setting deployment status to `succeeded` in Rollbar') do
+          :desc => 'Setting deployment status to `succeeded` in Rollbar'
+        ) do
           report_deploy_succeeded(capistrano, dry_run)
         end
       end

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -92,7 +92,7 @@ module Rollbar
       @capture_uncaught = nil
       @code_version = nil
       @custom_data_method = nil
-      @default_logger = lambda { ::Logger.new(STDERR) }
+      @default_logger = lambda { ::Logger.new($stderr) }
       @logger_level = :info
       @delayed_job_enabled = true
       @disable_monkey_patch = false

--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -343,14 +343,14 @@ module Rollbar
     end
 
     def hook(symbol, &block)
-      if @hooks.key?(symbol)
-        if block_given?
-          @hooks[symbol] = block
-        else
-          @hooks[symbol]
-        end
-      else
+      unless @hooks.key?(symbol)
         raise StandardError, "Hook :#{symbol} is not supported by Rollbar SDK."
+      end
+
+      if block_given?
+        @hooks[symbol] = block
+      else
+        @hooks[symbol]
       end
     end
 

--- a/lib/rollbar/delay/sidekiq.rb
+++ b/lib/rollbar/delay/sidekiq.rb
@@ -10,10 +10,9 @@ module Rollbar
       end
 
       def call(payload)
-        if ::Sidekiq::Client.push(@options.merge('args' => [payload])).nil?
-          raise StandardError,
-                'Unable to push the job to Sidekiq'
-        end
+        return unless ::Sidekiq::Client.push(@options.merge('args' => [payload])).nil?
+
+        raise(StandardError, 'Unable to push the job to Sidekiq')
       end
 
       include ::Sidekiq::Worker

--- a/lib/rollbar/item.rb
+++ b/lib/rollbar/item.rb
@@ -209,8 +209,8 @@ module Rollbar
       if custom_data_method? && !Rollbar::Util.method_in_stack(:custom_data, __FILE__)
         Util.deep_merge(scrub(custom_data), merged_extra)
       else
-        merged_extra.empty? ? nil : merged_extra # avoid putting an empty {}
-                                                 # in the payload.
+        # avoid putting an empty {} in the payload.
+        merged_extra.empty? ? nil : merged_extra
       end
     end
 

--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -236,7 +236,7 @@ module Rollbar
 
       def secure_headers_nonce_key(req)
         defined?(::SecureHeaders::NONCE_KEY) &&
-        req.env[::SecureHeaders::NONCE_KEY]
+          req.env[::SecureHeaders::NONCE_KEY]
       end
 
       class SecureHeadersResolver

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -77,13 +77,12 @@ module Rollbar
         end
 
         def context(request_data)
-          return unless request_data[:params]
-
           route_params = request_data[:params]
+
           # make sure route is a hash built by RequestDataExtractor
-          if route_params.is_a?(Hash) && !route_params.empty?
-            "#{route_params[:controller]}##{route_params[:action]}"
-          end
+          return unless route_params && route_params.is_a?(Hash) && !route_params.empty?
+
+          "#{route_params[:controller]}##{route_params[:action]}"
         end
       end
     end

--- a/lib/rollbar/middleware/rails/rollbar.rb
+++ b/lib/rollbar/middleware/rails/rollbar.rb
@@ -80,7 +80,7 @@ module Rollbar
           route_params = request_data[:params]
 
           # make sure route is a hash built by RequestDataExtractor
-          return unless route_params && route_params.is_a?(Hash) && !route_params.empty?
+          return unless route_params.is_a?(Hash) && !route_params.empty?
 
           "#{route_params[:controller]}##{route_params[:action]}"
         end

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -32,10 +32,9 @@ module Rollbar
         self.scope_object = ::Rollbar::LazyStore.new(scope)
       end
 
-      if payload_options
-        Rollbar::Util.deep_merge(configuration.payload_options,
-                                 payload_options)
-      end
+      return unless payload_options
+
+      Rollbar::Util.deep_merge(configuration.payload_options, payload_options)
     end
 
     def reset!

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -203,8 +203,8 @@ module Rollbar
     def enabled?
       # Require access_token so we don't try to send events when unconfigured.
       configuration.enabled &&
-      configuration.access_token &&
-      !configuration.access_token.empty?
+        configuration.access_token &&
+        !configuration.access_token.empty?
     end
 
     def process_item(item)
@@ -395,7 +395,7 @@ module Rollbar
 
     def enable_locals?
       configuration.locals[:enabled] &&
-      [:app, :all].include?(configuration.send_extra_frame_data)
+        [:app, :all].include?(configuration.send_extra_frame_data)
     end
 
     def enable_locals

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -45,8 +45,8 @@ module Rollbar
             frames.pop
           when :raise
             unless detect_reraise(tp) # ignore reraised exceptions
-              @exception_frames = @frames.dup # may be possible to optimize
-                                              # better than #dup
+              # may be possible to optimize better than #dup
+              @exception_frames = @frames.dup
               @exception_signature = exception_signature(tp)
             end
           end

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -142,9 +142,7 @@ module Rollbar
       path = env['ORIGINAL_FULLPATH'] || env['REQUEST_URI']
       query = env['QUERY_STRING'].to_s.empty? ? nil : "?#{env['QUERY_STRING']}"
       path ||= "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}#{query}"
-      if !(path.nil? || path.empty?) && (path.to_s.slice(0, 1) != '/')
-        path = "/#{path}"
-      end
+      path = "/#{path}" if !(path.nil? || path.empty?) && (path.to_s.slice(0, 1) != '/')
 
       port = env['HTTP_X_FORWARDED_PORT']
       if port && !(!scheme.nil? && scheme.casecmp('http').zero? && port.to_i == 80) && \

--- a/lib/rollbar/truncation/remove_any_key_strategy.rb
+++ b/lib/rollbar/truncation/remove_any_key_strategy.rb
@@ -92,9 +92,8 @@ module Rollbar
         return body['message']['body'] if body['message'] && body['message']['body']
         return extract_title_from_trace(body['trace']) if body['trace']
 
-        if body['trace_chain'] && body['trace_chain'][0]
-          extract_title_from_trace(body['trace_chain'][0])
-        end
+        return unless body['trace_chain'] && body['trace_chain'][0]
+        extract_title_from_trace(body['trace_chain'][0])
       end
 
       def extract_title_from_trace(trace)

--- a/lib/rollbar/truncation/remove_extra_strategy.rb
+++ b/lib/rollbar/truncation/remove_extra_strategy.rb
@@ -24,9 +24,8 @@ module Rollbar
       end
 
       def delete_trace_chain_extra(body)
-        if body['trace_chain'] && body['trace_chain'][0]['extra']
-          body['trace_chain'][0].delete('extra')
-        end
+        return unless body['trace_chain'] && body['trace_chain'][0]['extra']
+        body['trace_chain'][0].delete('extra')
       end
 
       def delete_trace_extra(body)

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -86,9 +86,7 @@ module Rollbar
       merged.compare_by_identity
 
       # If we've already merged these two objects, return hash1 now.
-      if merged[hash1] && merged[hash1].include?(hash2.object_id)
-        return hash1
-      end
+      return hash1 if merged[hash1] && merged[hash1].include?(hash2.object_id)
 
       merged[hash1] ||= []
       merged[hash1] << hash2.object_id

--- a/lib/rollbar/util.rb
+++ b/lib/rollbar/util.rb
@@ -30,7 +30,7 @@ module Rollbar
     end
 
     def self.iterate_and_update_hash(obj, block, seen)
-      obj.keys.each do |k|
+      obj.keys.each do |k| # rubocop:disable Style/HashEachMethods
         v = obj[k]
         new_key = block.call(k)
 

--- a/lib/rollbar/util/hash.rb
+++ b/lib/rollbar/util/hash.rb
@@ -35,7 +35,7 @@ module Rollbar
       def self.replace_seen_children(thing, seen)
         case thing
         when ::Hash
-          thing.keys.each do |key|
+          thing.keys.each do |key| # rubocop:disable Style/HashEachMethods
             if seen[thing[key]]
               thing[key] =
                 "removed circular reference: #{thing[key]}"

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -12,7 +12,7 @@ describe HomeController do
     it 'should report uncaught exceptions' do
       # only seems to be relevant in 3.1 and 3.2
       if ::Rails::VERSION::STRING.starts_with?('3.1') ||
-        ::Rails::VERSION::STRING.starts_with?('3.2')
+         ::Rails::VERSION::STRING.starts_with?('3.2')
         expect { get '/current_user', nil, :cookie => '8%B' }.to raise_exception
 
         Rollbar.last_report.should_not be_nil

--- a/spec/rollbar/item/frame_spec.rb
+++ b/spec/rollbar/item/frame_spec.rb
@@ -27,7 +27,7 @@ describe Rollbar::Item::Frame do
 
     context 'with valid frame' do
       let(:file) do
-        <<-END
+        <<-FILE
 foo1
 foo2
 foo3
@@ -41,7 +41,7 @@ foo10
 foo11
 foo12
 foo13
-        END
+        FILE
       end
       let(:filepath) do
         '/var/www/rollbar/playground/rails4.2/vendor/bundle/gems/actionpack-4.2.0' \

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -44,7 +44,7 @@ describe Rollbar::Middleware::Js do
     end
   end
   let(:html) do
-    <<-END
+    <<-HTML
 <html>
   <head>
     <link rel="stylesheet" href="url" type="text/css" media="screen" />
@@ -54,10 +54,10 @@ describe Rollbar::Middleware::Js do
     <h1>Testing the middleware</h1>
   </body>
 </html>
-    END
+    HTML
   end
   let(:minified_html) do
-    <<-END
+    <<-HTML
 <html>
   <head><link rel="stylesheet" href="url" type="text/css" media="screen" />
     <script type="text/javascript" src="foo"></script>
@@ -66,10 +66,10 @@ describe Rollbar::Middleware::Js do
     <h1>Testing the middleware</h1>
   </body>
 </html>
-    END
+    HTML
   end
   let(:meta_charset_html) do
-    <<-END
+    <<-HTML
 <html>
   <head>
     <meta charset="UTF-8"/>
@@ -80,10 +80,10 @@ describe Rollbar::Middleware::Js do
     <h1>Testing the middleware</h1>
   </body>
 </html>
-    END
+    HTML
   end
   let(:meta_content_html) do
-    <<-END
+    <<-HTML
 <html>
   <head>
     <meta content="origin" id="mref" name="referrer">
@@ -95,7 +95,7 @@ describe Rollbar::Middleware::Js do
     <h1>Testing the middleware</h1>
   </body>
 </html>
-    END
+    HTML
   end
   let(:snippet) { 'THIS IS THE SNIPPET' }
   let(:content_type) { 'text/html' }

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -36,8 +36,11 @@ describe Rollbar::ActiveJob do
       :arguments => [argument]
     }
     expect(Rollbar).to receive(:error).with(exception, expected_params)
-    TestJob.new(argument)
-           .perform(exception, job_id) rescue nil # rubocop:disable Style/RescueModifier
+    begin
+      TestJob.new(argument).perform(exception, job_id)
+    rescue StandardError
+      nil
+    end
   end
 
   it 'reraises the error so the job backend can handle the failure and retry' do
@@ -74,8 +77,11 @@ describe Rollbar::ActiveJob do
       expect(Rollbar).to receive(:error).with(kind_of(StandardError),
                                               hash_including(expected_params))
       perform_enqueued_jobs do
-        TestMailer.test_email(argument)
-                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        begin
+          TestMailer.test_email(argument).deliver_later
+        rescue StandardError
+          nil
+        end
       end
     end
 
@@ -85,8 +91,11 @@ describe Rollbar::ActiveJob do
       end
 
       perform_enqueued_jobs do
-        TestMailer.test_email(:user_id => '15')
-                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        begin
+          TestMailer.test_email(:user_id => '15').deliver_later
+        rescue StandardError
+          nil
+        end
       end
       Rollbar.last_report[:body][:trace][:extra][:arguments][3][:user_id]
              .should match(/^*+$/)
@@ -101,8 +110,11 @@ describe Rollbar::ActiveJob do
       params['user_id'] = '15'
 
       perform_enqueued_jobs do
-        TestMailer.test_email(params)
-                  .deliver_later rescue nil # rubocop:disable Style/RescueModifier
+        begin
+          TestMailer.test_email(params).deliver_later
+        rescue StandardError
+          nil
+        end
       end
       Rollbar.last_report[:body][:trace][:extra][:arguments][3]['user_id']
              .should match(/^*+$/)

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -21,7 +21,8 @@ describe ApplicationController, :type => 'request' do
       get '/test_rollbar_js'
 
       snippet_from_submodule = File.read(
-        File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__))
+        File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__)
+      )
 
       expect(response.body).to include(
         "var _rollbarConfig = #{Rollbar.configuration.js_options.to_json};"

--- a/spec/rollbar/util_spec.rb
+++ b/spec/rollbar/util_spec.rb
@@ -136,7 +136,7 @@ describe Rollbar::Util do
 
       payload = {
         :bad_value => force_to_ascii("bad value 1\255"),
-        :bad_value_2 => force_to_ascii("bad\255 value 2"),
+        :bad_value2 => force_to_ascii("bad\255 value 2"),
         force_to_ascii("bad\255 key") => 'good value',
         :hash => {
           :inner_bad_value => force_to_ascii("\255\255bad value 3"),
@@ -155,7 +155,7 @@ describe Rollbar::Util do
       described_class.enforce_valid_utf8(payload_copy)
 
       payload_copy[:bad_value].should eq('bad value 1')
-      payload_copy[:bad_value_2].should eq('bad value 2')
+      payload_copy[:bad_value2].should eq('bad value 2')
       payload_copy['bad key'].should eq('good value')
       payload_copy.keys.should_not include("bad\456 key")
       payload_copy[:hash][:inner_bad_value].should eq('bad value 3')

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1782,7 +1782,7 @@ describe Rollbar do
     end
 
     it 'should use the default_logger when no logger is set' do
-      logger = Logger.new(STDERR)
+      logger = Logger.new($stderr)
 
       Rollbar.configure do |config|
         config.default_logger = lambda { logger }

--- a/spec/support/deploy_api/update.rb
+++ b/spec/support/deploy_api/update.rb
@@ -30,9 +30,8 @@ module DeployAPI
     end
 
     def access_token(request)
-      unless CGI.parse(request.env['QUERY_STRING'])['access_token'].empty?
-        CGI.parse(request.env['QUERY_STRING'])['access_token'][0]
-      end
+      return if CGI.parse(request.env['QUERY_STRING'])['access_token'].empty?
+      CGI.parse(request.env['QUERY_STRING'])['access_token'][0]
     end
 
     def success_body(json, request)

--- a/spec/support/notifier_helpers.rb
+++ b/spec/support/notifier_helpers.rb
@@ -27,7 +27,7 @@ module NotifierHelpers
       config.root = defined?(::Rails.root) && ::Rails.root ||
                     defined?(RAILS_ROOT) && RAILS_ROOT
       version = defined?(::Rails.version) && ::Rails.version ||
-                  defined?(::Rails::VERSION::STRING) && ::Rails::VERSION::STRING
+                defined?(::Rails::VERSION::STRING) && ::Rails::VERSION::STRING
       config.framework = "Rails: #{version}"
     end
   end


### PR DESCRIPTION
## Description of the change

Resolves Style and Layout category violations. They are separated cleanly by commit, for convenience of reviewing each rule separately.

**Style/GuardClause**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GuardClause

**Style/RescueModifier**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RescueModifier

**Naming/HeredocDelimiterNaming**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/HeredocDelimiterNaming

**Layout/MultilineOperationIndentation**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineOperationIndentation

**Layout/CommentIndentation**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/CommentIndentation

**Layout/MultilineMethodCallBraceLayout**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/MultilineMethodCallBraceLayout

**Naming/VariableNumber**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/VariableNumber

**Style/GlobalStdStream**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/GlobalStdStream

**Style/HashEachMethods**
For the flagged cases, the rule is disabled since the hash is modified while iterating the keys. The `#each_keys` iterator isn't safe for that pattern,  and we continue to use `keys.each` which returns the array of keys before iteration.
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashEachMethods

**Style/IfUnlessModifier**
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Style

## Related issues

ch87995

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
