### PR TITLE
Scrub all arguments when an ActiveJob is configured not to log arguments

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -3,11 +3,17 @@ module Rollbar
   module ActiveJob
     def self.included(base)
       base.send :rescue_from, Exception do |exception|
+        args = if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
+                 arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
+               else
+                 arguments
+               end
+
         Rollbar.error(exception,
                       :job => self.class.name,
                       :job_id => job_id,
                       :use_exception_level_filters => true,
-                      :arguments => arguments)
+                      :arguments => args)
         raise exception
       end
     end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -49,6 +49,23 @@ describe Rollbar::ActiveJob do
     end.to raise_error exception
   end
 
+  it 'scrubs all arguments if job has `log_arguments` disabled' do
+    allow(TestJob).to receive(:log_arguments?).and_return(false)
+     
+    expected_params = {
+      :job => 'TestJob',
+      :job_id => job_id,
+      :use_exception_level_filters => true,
+      :arguments => ['******', '******', '******']
+    }
+    expect(Rollbar).to receive(:error).with(exception, expected_params)
+    begin
+      TestJob.new(1, 2, 3).perform(exception, job_id)
+    rescue StandardError
+      nil
+    end
+  end
+
   context 'using ActionMailer::DeliveryJob', :if => defined?(ActionMailer::DeliveryJob) do
     include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
 


### PR DESCRIPTION
## Description of the change
Rails 6.1.0 introduced an option for disabling logging of job arguments in ActiveJob[1][2]. This change makes the ActiveJob plugin aware of this config option and scrubs all arguments if we're dealing with a sensitive job.

\[1]: https://github.com/rails/rails/releases/tag/v6.1.0
\[2]: https://github.com/rails/rails/pull/37660
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists
### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
