### PR TITLE
Specify rack env key for user ip address

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -62,6 +62,7 @@ module Rollbar
                   :transmit,
                   :uncaught_exception_level,
                   :user_ip_obfuscator_secret,
+                  :user_ip_rack_env_key,
                   :scrub_headers,
                   :sidekiq_threshold,
                   :sidekiq_use_scoped_block,
@@ -156,6 +157,7 @@ module Rollbar
       @collect_user_ip = true
       @anonymize_user_ip = false
       @user_ip_obfuscator_secret = nil
+      @user_ip_rack_env_key = nil
       @backtrace_cleaner = nil
       @hooks = {
         :on_error_response => nil, # params: response

--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -157,7 +157,8 @@ module Rollbar
     def rollbar_user_ip(env)
       return nil unless Rollbar.configuration.collect_user_ip
 
-      user_ip_string = (env['action_dispatch.remote_ip'] ||
+      user_ip_string = (user_ip_at_configured_key(env) ||
+                        env['action_dispatch.remote_ip'] ||
                         env['HTTP_X_REAL_IP'] ||
                         x_forwarded_for_client(env['HTTP_X_FORWARDED_FOR']) ||
                         env['REMOTE_ADDR']).to_s
@@ -167,6 +168,12 @@ module Rollbar
       Rollbar::Util::IPObfuscator.obfuscate_ip(user_ip_string)
     rescue StandardError
       nil
+    end
+
+    def user_ip_at_configured_key(env)
+      return nil unless Rollbar.configuration.user_ip_rack_env_key
+
+      env[Rollbar.configuration.user_ip_rack_env_key]
     end
 
     def x_forwarded_for_client(header_value)


### PR DESCRIPTION
## Description of the change

Allows a config override to select the rack env key for the user IP. This solves the Cloudflare scenario in https://github.com/rollbar/rollbar-gem/issues/1064 as well as any others where the default keys and/or precedence order need an override.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fixes ch90310
Fixes https://github.com/rollbar/rollbar-gem/issues/1064

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
