### PR TITLE
Enable reporting rack framework errors

### DIFF
--- a/lib/rollbar/middleware/rack.rb
+++ b/lib/rollbar/middleware/rack.rb
@@ -44,8 +44,8 @@ module Rollbar
         proc { extract_person_data_from_controller(env) }
       end
 
-      def framework_error(_env)
-        nil
+      def framework_error(env)
+        env['rack.exception']
       end
     end
   end

--- a/spec/rollbar/middleware/rack_spec.rb
+++ b/spec/rollbar/middleware/rack_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'rollbar/middleware/rack'
+require 'rack/test'
+
+describe Rollbar::Middleware::Rack, :reconfigure_notifier => true do
+  include Rack::Test::Methods
+
+  class RackMockError < RuntimeError; end
+
+  let(:logger_mock) { double('logger').as_null_object }
+
+  before do
+    Rollbar.configure do |config|
+      config.logger = logger_mock
+      config.framework = 'Rack'
+    end
+  end
+
+  let(:uncaught_level) do
+    Rollbar.configuration.uncaught_exception_level
+  end
+
+  let(:expected_report_args) do
+    [uncaught_level, exception, { :use_exception_level_filters => true }]
+  end
+
+  describe '#call' do
+    context 'for a framework reported error' do
+      let(:exception) { kind_of(RackMockError) }
+      let(:env) { Rack::MockRequest.env_for('/', 'rack.exception' => exception) }
+      let(:mock_app) { MockApp.new }
+      let(:middleware) { described_class.new(mock_app) }
+
+      it 'reports the error' do
+        expect(Rollbar).to receive(:log).with(*expected_report_args)
+
+        middleware.call(env)
+      end
+    end
+  end
+end

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -121,6 +121,19 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
       end
     end
 
+    context 'for a framework reported error' do
+      let(:exception) { kind_of(SinatraDummy::DummyError) }
+      let(:env) { Rack::MockRequest.env_for('/', 'sinatra.error' => exception) }
+      let(:mock_app) { MockApp.new }
+      let(:middleware) { described_class.new(mock_app) }
+
+      it 'reports the error' do
+        expect(Rollbar).to receive(:log).with(*expected_report_args)
+
+        middleware.call(env)
+      end
+    end
+
     context 'if the middleware itself fails' do
       let(:exception) { Exception.new }
 

--- a/spec/support/mock_app.rb
+++ b/spec/support/mock_app.rb
@@ -1,0 +1,5 @@
+class MockApp
+  def call(_env)
+    return [200, {}, ['Success']]
+  end
+end


### PR DESCRIPTION
## Description of the change

It's a standard convention for rack apps and middleware to report errors via `env['rack.exception']`. This PR enables reporting for these. See https://github.com/rollbar/rollbar-gem/issues/1031 for more detail.

This PR also adds a test for the existing Sinatra code path.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1031

ch90509 

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
