### PR TITLE
Add config option to ignore internal errors

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -34,6 +34,7 @@ module Rollbar
                   :files_processed_size,
                   :files_with_pid_name_enabled,
                   :framework,
+                  :ignore_internal_errors,
                   :ignored_person_ids,
                   :js_enabled,
                   :js_options,
@@ -112,6 +113,11 @@ module Rollbar
       }
       @failover_handlers = []
       @framework = 'Plain'
+      @ignore_internal_errors = [
+        'Net::ReadTimeout',
+        'Net::OpenTimeout',
+        'SocketError'
+      ]
       @ignored_person_ids = []
       @host = nil
       @payload_options = {}


### PR DESCRIPTION
## Description of the change

This PR allows specifying error classes to ignore for internal errors (errors generated within the SDK), or allows setting `true` to ignore all internal errors. The default is configured to ignore errors caused by network timeouts:
* `Net::ReadTimeout`
* `Net::OpenTimeout`
* `SocketError`

### Usage

Error classes are passed as an array of strings. This ensures class names that aren't loaded yet during config, or in runtime code paths, can be safely passed.

```
Rollbar.configure do |config|
  config.ignore_internal_errors = ['StandardError']
end
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes sc92845

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
