### PR TITLE
Change stipulated compatibility guarantees.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ For complete usage instructions and configuration reference, see our [Ruby SDK d
 
 ## Compatibility
 
-Version >= 3.0.0 is compatible with Ruby >= 2.0.0.
+Version >= 3.0.0 is compatible with Ruby ~> 2.0.0.
 
-Version >= 2.19.0 is compatible with Ruby >= 1.9.3.
+Version >= 2.19.0 is compatible with Ruby ~> 1.9.3.
 
-Version < 2.19.0 is compatible with Ruby >= 1.8.7.
+Version < 2.19.0 is compatible with Ruby ~> 1.8.7.
 
 ### Ruby 2.6.0
 


### PR DESCRIPTION
## Change stipulated compatibility guarantees.

I believe the compatibility table is wrong. Taking what it currently says in the readme at face value e.g. `rollbar-2.22.1` would support `ruby-3.0.2`. I'm pretty sure this is not what was intended, but why not be explicit?

## Type of change

- Maintenance

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
