### PR TITLE
Use scrub_whitelist when scrubbing sidekiq job params

### DIFF
--- a/lib/rollbar/plugins/sidekiq/plugin.rb
+++ b/lib/rollbar/plugins/sidekiq/plugin.rb
@@ -50,7 +50,8 @@ module Rollbar
     def self.scrub_params(params)
       options = {
         :params => params,
-        :config => Rollbar.configuration.scrub_fields
+        :config => Rollbar.configuration.scrub_fields,
+        :whitelist => Rollbar.configuration.scrub_whitelist
       }
 
       Rollbar::Scrubbers::Params.call(options)

--- a/spec/rollbar/plugins/sidekiq_spec.rb
+++ b/spec/rollbar/plugins/sidekiq_spec.rb
@@ -106,6 +106,35 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
       end
     end
 
+    context 'with scrub_whitelist configured' do
+      let(:ctx_hash) do
+        {
+          :context => 'Job raised exception',
+          :job => job_hash
+        }
+      end
+
+      before do
+        reconfigure_notifier
+        allow(Rollbar.configuration)
+          .to receive(:scrub_fields)
+          .and_return(:scrub_all)
+        allow(Rollbar.configuration)
+          .to receive(:scrub_whitelist)
+          .and_return([:queue, :class])
+      end
+
+      it 'does not scrub the whitelisted fields' do
+        described_class.handle_exception(ctx_hash, exception)
+
+        expect(Rollbar.last_report[:request][:params]).to be_eql_hash_with_regexes(
+          'class' => job_hash['class'],
+          'queue' => job_hash['queue'],
+          'jid' => /\*+/
+        )
+      end
+    end
+
     context 'with a sidekiq_threshold set' do
       before do
         Rollbar.configuration.sidekiq_threshold = 3


### PR DESCRIPTION
## Description of the change

Updates sidekiq job param scrubbing to use configured whitelist.

Every instance of `Rollbar::Scrubbers::Params.call(options)`, except for in the sidekiq plugin, includes the scrub whitelist. It looks like maybe it was accidentally missed for sidekiq?

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
