### PR TITLE
feat: print async_handler class to the log "Ready for review"

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -901,9 +901,12 @@ module Rollbar
       return unless data[:uuid]
 
       uuid_url = Util.uuid_rollbar_url(data, configuration)
-      log_info(
-        "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
-      )
+      info_message = "[Rollbar] Details: #{uuid_url} (only available if report was successful)"
+      if configuration.async_handler
+        async_handler = configuration.async_handler.class == Class ? configuration.async_handler : configuration.async_handler.class
+        info_message += ". With async handler = #{async_handler}"
+      end
+      log_info(info_message)
     end
 
     def via_failsafe?(item)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -1798,6 +1798,16 @@ describe Rollbar do
         Rollbar.configure(&:use_sucker_punch)
         Rollbar.error(exception)
       end
+
+      it "shows 'Rollbar::Delay::SuckerPunch' on the log" do
+        Rollbar.configure do |config|
+          config.use_sucker_punch
+          config.transmit = false
+        end
+
+        expect(Rollbar.notifier).to receive(:log_info).with(/With async handler = Rollbar::Delay::SuckerPunch/)
+        Rollbar.notifier.info('info', 'foo bar')
+      end
     end
 
     describe '#use_shoryuken', :if => defined?(Shoryuken) do
@@ -1807,6 +1817,16 @@ describe Rollbar do
 
         Rollbar.configure(&:use_shoryuken)
         Rollbar.error(exception)
+      end
+
+      it "shows 'Rollbar::Delay::Shoryuken' on the log" do
+        Rollbar.configure do |config|
+          config.use_shoryuken
+          config.transmit = false
+        end
+
+        expect(Rollbar.notifier).to receive(:log_info).with(/With async handler = Rollbar::Delay::Shoryuken/)
+        Rollbar.notifier.info('info', 'foo bar')
       end
     end
 
@@ -1827,6 +1847,16 @@ describe Rollbar do
         end
 
         Rollbar.error(exception)
+      end
+
+      it "shows 'Rollbar::Delay::Sidekiq' on the log" do
+        Rollbar.configure do |config|
+          config.use_sidekiq
+          config.transmit = false
+        end
+
+        expect(Rollbar.notifier).to receive(:log_info).with(/With async handler = Rollbar::Delay::Sidekiq/)
+        Rollbar.notifier.info('info', 'foo bar')
       end
     end
 
@@ -1862,6 +1892,16 @@ describe Rollbar do
         sleep(1) # More reliable than Thread.pass to let the thread set its priority.
         expect(thread.priority).to eq(custom_priority)
         thread.join
+      end
+
+      it "shows 'Rollbar::Delay::Thread' on the log" do
+        Rollbar.configure do |config|
+          config.use_thread
+          config.transmit = false
+        end
+
+        expect(Rollbar.notifier).to receive(:log_info).with(/With async handler = Rollbar::Delay::Thread/)
+        Rollbar.notifier.info('info', 'foo bar')
       end
     end
   end


### PR DESCRIPTION
## Description of the change

Related to the issue https://github.com/rollbar/rollbar-gem/issues/1075.  
Example:

```
[Rollbar] Details: https://rollbar.com/instance/uuid?uuid=f70a781d-234b-41e4-bc1d-dedace740e5d (only available if report was successful). With async handler = Rollbar::Delay::SuckerPunch
```

## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
