### PR TITLE
CI: Set bundler env on each step where it's used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,8 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Rspec
-        run: bundle exec rspec
+        run: |
+          export BUNDLE_GEMFILE=${{ matrix.gemfile }}
+          bundle config path vendor/bundle
+          bundle config gemfile ${{ matrix.gemfile }}
+          bundle exec rspec


### PR DESCRIPTION
## Description of the change

Until sometime between Feb 8 - 9, the bundler env could be set once and later steps would inherit that env. Starting on Feb 9, CI on all branches started failing because the step that runs rspec no longer inherits the bundler env set in a previous step.

This PR sets the bundler env in the Rspec step where it is used.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
