### PR TITLE
fix: stringify js options when serialized for the payload

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -141,7 +141,7 @@ module Rollbar
 
         # MUST use the Ruby JSON encoder (JSON#generate).
         # See lib/rollbar/middleware/js/json_value
-        json = ::JSON.generate(js_config)
+        json = ::JSON.generate(js_config, Rollbar::JSON::JsOptionsState.new)
 
         script_tag("var _rollbarConfig = #{json};", env)
       end

--- a/lib/rollbar/middleware/js/json_value.rb
+++ b/lib/rollbar/middleware/js/json_value.rb
@@ -1,8 +1,12 @@
-# Allows a Ruby String to be used to create native Javascript objects
-# when calling JSON#generate.
+# Allows a Ruby String to be used to pass native Javascript objects/functions
+# when calling JSON#generate with a Rollbar::JSON::JsOptionsState instance.
 #
 # Example:
-# JSON.generate({ foo: Rollbar::JSON::Value.new('function(){ alert("bar") }') })
+# JSON.generate(
+#   { foo: Rollbar::JSON::Value.new('function(){ alert("bar") }') },
+#   Rollbar::JSON::JsOptionsState.new
+# )
+#
 # => '{"foo":function(){ alert(\"bar\") }}'
 #
 # MUST use the Ruby JSON encoder, as in the example. The ActiveSupport encoder,
@@ -11,6 +15,8 @@
 #
 module Rollbar
   module JSON
+    class JsOptionsState < ::JSON::State; end
+
     class Value # :nodoc:
       attr_accessor :value
 
@@ -18,8 +24,12 @@ module Rollbar
         @value = value
       end
 
-      def to_json(*_args)
-        value
+      def to_json(opts = {})
+        # Return the raw value if this is from the js middleware
+        return value if opts.class == Rollbar::JSON::JsOptionsState
+
+        # Otherwise convert to a string
+        %Q["#{value}"]
       end
     end
   end

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'rollbar/configuration'
 require 'rollbar/item'
 require 'rollbar/lazy_store'
+require 'rollbar/middleware/js/json_value'
 
 describe Rollbar::Item do
   let(:notifier) { double('notifier', :safely => safely_notifier) }
@@ -908,6 +909,23 @@ describe Rollbar::Item do
 
           item.dump
         end
+      end
+    end
+
+    context 'with js function options' do
+      let(:payload) do
+        {
+          :js_options => {
+            :checkIgnore => Rollbar::JSON::Value.new('function(){ alert("bar") }')
+          }
+        }
+      end
+      let(:item) { Rollbar::Item.build_with(payload) }
+
+      it 'stringifies the js function' do
+        json = item.dump
+
+        expect(json).to include(%q["function(){ alert("bar") }"])
       end
     end
   end

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -118,7 +118,7 @@ describe Rollbar::Middleware::Js do
   let(:json_options) do
     # MUST use the Ruby JSON encoder (JSON#generate).
     # See lib/rollbar/middleware/js/json_value
-    ::JSON.generate(config[:options])
+    ::JSON.generate(config[:options], Rollbar::JSON::JsOptionsState.new)
   end
 
   shared_examples "doesn't add the snippet or config", :add_js => false do
@@ -408,7 +408,8 @@ describe Rollbar::Middleware::Js do
           { 'Content-Type' => content_type }
         end
         let(:json_value) do
-          Rollbar::JSON::Value.new('function(){ alert("bar") }').to_json
+          Rollbar::JSON::Value.new('function(){ alert("bar") }')
+            .to_json(Rollbar::JSON::JsOptionsState.new)
         end
 
         context 'using Ruby JSON encoder' do


### PR DESCRIPTION
## Description of the change

**Background**
Rollbar-gem includes middleware that configures Rollbar.js for the javascript client. The Rollbar.js options are passed as part of the Rollbar-gem config. Some valid js options are javascript functions that by default, the Ruby JSON serializer will convert to strings, however the js config needs these as functions not strings. 

In https://github.com/rollbar/rollbar-gem/pull/821 a custom type was added that allows these to be passed to the js config correctly as functions. When serializing the same options to the payload (for the diagnostic `configured_options` key) these were passed as strings.

In https://github.com/rollbar/rollbar-gem/pull/890 the payload serialization was refactored, and the js functions were no longer stringified correctly in the payload. The test automation didn't cover this case and it went unnoticed.

**The fix**
This PR signals to the custom data type whether it should stringify the js functions by optionally sending a subclassed state object when calling `JSON.generate`. The subclass is necessary because the state class doesn't allow custom attributes to be added.

This PR also adds a test to confirm the payload serialization.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1086

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
