### PR TITLE
test: add test for warn method

### DIFF
--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -607,6 +607,19 @@ describe Rollbar do
         notifier.warning(exception, 'description', extra_data)
       end
 
+      it 'should report using warn method with a warning level' do
+        expect(notifier).to receive(:report).with('warning', nil, exception, nil, nil)
+        notifier.warn(exception)
+
+        expect(notifier).to receive(:report).with('warning', 'description', exception,
+                                                  nil, nil)
+        notifier.warn(exception, 'description')
+
+        expect(notifier).to receive(:report).with('warning', 'description', exception,
+                                                  extra_data, nil)
+        notifier.warn(exception, 'description', extra_data)
+      end
+
       it 'should report with an error level' do
         expect(notifier).to receive(:report).with('error', nil, exception, nil, nil)
         notifier.error(exception)


### PR DESCRIPTION
## Description of the change

Adds a test case to verify existing behavior. (The SDK supports both `warn` and `warning` methods for broader compatibility.)

## Type of change

- [x] Maintenance: Test

## Related issues

Verifies https://github.com/rollbar/rollbar-gem/issues/1078

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
