### PR TITLE
fix: remove type attribute from script tag

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -166,10 +166,9 @@ module Rollbar
       def script_tag(content, env)
         nonce = rails5_nonce(env) || secure_headers_nonce(env)
         script_tag_content = if nonce
-                               "\n<script type=\"text/javascript\" " \
-                                 "nonce=\"#{nonce}\">#{content}</script>"
+                               "\n<script nonce=\"#{nonce}\">#{content}</script>"
                              else
-                               "\n<script type=\"text/javascript\">#{content}</script>"
+                               "\n<script>#{content}</script>"
                              end
 
         html_safe_if_needed(script_tag_content)

--- a/spec/rollbar/middleware/js_spec.rb
+++ b/spec/rollbar/middleware/js_spec.rb
@@ -14,7 +14,7 @@ shared_examples 'secure_headers' do
     new_body = response.body.join
 
     expect(new_body)
-      .to include('<script type="text/javascript" nonce="lorem-ipsum-nonce">')
+      .to include('<script nonce="lorem-ipsum-nonce">')
     expect(new_body).to include("var _rollbarConfig = #{json_options};")
     expect(new_body).to include(snippet)
   end
@@ -27,7 +27,7 @@ shared_examples 'secure_headers' do
     _, _, response = subject.call(env)
     new_body = response.body.join
 
-    expect(new_body).to include('<script type="text/javascript">')
+    expect(new_body).to include('<script>')
     expect(new_body).to include("var _rollbarConfig = #{json_options};")
     expect(new_body).to include(snippet)
   end
@@ -48,7 +48,7 @@ describe Rollbar::Middleware::Js do
 <html>
   <head>
     <link rel="stylesheet" href="url" type="text/css" media="screen" />
-    <script type="text/javascript" src="foo"></script>
+    <script src="foo"></script>
   </head>
   <body>
     <h1>Testing the middleware</h1>
@@ -60,7 +60,7 @@ describe Rollbar::Middleware::Js do
     <<-HTML
 <html>
   <head><link rel="stylesheet" href="url" type="text/css" media="screen" />
-    <script type="text/javascript" src="foo"></script>
+    <script src="foo"></script>
   </head>
   <body>
     <h1>Testing the middleware</h1>
@@ -74,7 +74,7 @@ describe Rollbar::Middleware::Js do
   <head>
     <meta charset="UTF-8"/>
     <link rel="stylesheet" href="url" type="text/css" media="screen" />
-    <script type="text/javascript" src="foo"></script>
+    <script src="foo"></script>
   </head>
   <body>
     <h1>Testing the middleware</h1>
@@ -89,7 +89,7 @@ describe Rollbar::Middleware::Js do
     <meta content="origin" id="mref" name="referrer">
     <link rel="stylesheet" href="url" type="text/css" media="screen" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <script type="text/javascript" src="foo"></script>
+    <script src="foo"></script>
   </head>
   <body>
     <h1>Testing the middleware</h1>
@@ -262,7 +262,7 @@ describe Rollbar::Middleware::Js do
           _, _, response = subject.call(env)
           new_body = response.body.join
 
-          expect(new_body).to include('<script type="text/javascript">')
+          expect(new_body).to include('<script>')
           expect(new_body).to include("var _rollbarConfig = #{json_options};")
           expect(new_body).to include(snippet)
         end

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -149,8 +149,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js'
 
         expect(response.body)
-          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to include '<script type="text/javascript">'
+          .to_not include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -163,8 +163,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js'
 
         expect(response.body)
-          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to include '<script type="text/javascript">'
+          .to_not include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -177,8 +177,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js'
 
         expect(response.body)
-          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to_not include '<script type="text/javascript">'
+          .to include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to_not include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -191,8 +191,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js'
 
         expect(response.body)
-          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to_not include '<script type="text/javascript">'
+          .to include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to_not include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -265,8 +265,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js'
 
         expect(response.body)
-          .to_not include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to include '<script type="text/javascript">'
+          .to_not include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -279,8 +279,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js_with_nonce'
 
         expect(response.body)
-          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to_not include '<script type="text/javascript">'
+          .to include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to_not include '<script>'
       end
 
       include_examples 'adds the snippet'
@@ -293,8 +293,8 @@ describe ApplicationController, :type => 'request' do
         get '/test_rollbar_js_with_nonce'
 
         expect(response.body)
-          .to include %[<script type="text/javascript" nonce="#{nonce(response)}">]
-        expect(response.body).to_not include '<script type="text/javascript">'
+          .to include %[<script nonce="#{nonce(response)}">]
+        expect(response.body).to_not include '<script>'
       end
 
       include_examples 'adds the snippet'


### PR DESCRIPTION
## Description of the change

This PR removes the type attribute from the script tag that gets inserted for the js snippet. For HTML 5 it is strongly recommended to not include this attribute, and for HTML 4 all browsers assume javascript, so the change is safe there as well. This change will help prevent static analysis warnings for some users.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1020

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
