### PR TITLE
ci: add ruby 3.1 and rails 7 to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ jobs:
           - gemfiles/rails60.gemfile
           - gemfiles/rails61.gemfile
         include:
+          - gemfile: gemfiles/rails70.gemfile
+            ruby-version: 3.1.1
+          - gemfile: gemfiles/rails70.gemfile
+            ruby-version: 3.0.3
           - gemfile: gemfiles/rails61.gemfile
-            ruby-version: 3.0.0
+            ruby-version: 3.0.3
           - gemfile: gemfiles/rails42.gemfile
             ruby-version: 2.4.5
           - gemfile: gemfiles/rails42.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
-GEMFILE_RAILS_VERSION = '~> 6.1.3'.freeze
+GEMFILE_RAILS_VERSION = '~> 6.1.5'.freeze
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
 gem 'jruby-openssl', :platform => :jruby

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -6,7 +6,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == '
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '~> 6.1.5'
+gem 'rails', '~> 7.0.2.3'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-rails', '~> 4.0.2'
@@ -28,7 +28,7 @@ gem 'sucker_punch', '~> 2.0'
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 
 gem 'database_cleaner'
-gem 'delayed_job', '4.1.9', :require => false
+gem 'delayed_job', '4.1.10', :require => false
 gem 'generator_spec'
 gem 'redis'
 gem 'resque'


### PR DESCRIPTION
## Description of the change

Updates the CI matrix to include Ruby 3.1 and Rails 7.

## Type of change

- [x] Maintenance


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
