### PR TITLE
(locals) gracefully handle binding error when on a Fiber

### DIFF
--- a/lib/rollbar/item/locals.rb
+++ b/lib/rollbar/item/locals.rb
@@ -32,6 +32,8 @@ module Rollbar
         end
 
         def locals_for(frame)
+          return {} unless frame
+
           {}.tap do |hash|
             frame.local_variables.map do |var|
               hash[var] = prepare_value(frame.local_variable_get(var))

--- a/lib/rollbar/notifier/trace_with_bindings.rb
+++ b/lib/rollbar/notifier/trace_with_bindings.rb
@@ -55,12 +55,20 @@ module Rollbar
 
       def frame(trace)
         {
-          :binding => trace.binding,
+          :binding => binding(trace),
           :defined_class => trace.defined_class,
           :method_id => trace.method_id,
           :path => trace.path,
           :lineno => trace.lineno
         }
+      end
+
+      def binding(trace)
+        trace.binding
+      rescue StandardError
+        # Ruby internals will raise if we're on a Fiber,
+        # since bindings aren't valid on Fibers.
+        nil
       end
     end
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -337,7 +337,9 @@ describe HomeController do
       it 'should include locals in extra data' do
         logger_mock.should_receive(:info).with('[Rollbar] Success').once
 
-        expect { get '/cause_exception_with_locals' }.to raise_exception(NoMethodError)
+        expect {
+          get '/cause_exception_with_locals?test_fibers=true'
+        }.to raise_exception(NoMethodError)
 
         frames = Rollbar.last_report[:body][:trace][:frames]
 

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -29,11 +29,19 @@ class HomeController < ApplicationController
   def cause_exception_with_locals
     foo = false
 
+    enumerator_using_fibers if params[:test_fibers]
+
     (0..2).each do |index|
       foo = Post
 
       build_hash_with_locals(foo, index)
     end
+  end
+
+  def enumerator_using_fibers
+    # Calling each without a block returns an Iterator.
+    # Calling #next on the iterator causes execution on a fiber.
+    [1, 2, 3].each.next
   end
 
   def build_hash_with_locals(foo, _index)


### PR DESCRIPTION
## Description of the change

### Background

`TracePoint#binding` cannot be called from a Fiber, though I haven't seen anywhere that this is documented. This can be confirmed by reviewing the location where the exception is raised in Ruby:
https://github.com/ruby/ruby/blob/744d17ff6c33b09334508e8110007ea2a82252f5/vm.c#L1240

And of course it can be confirmed by calling `binding` while on a Fiber. The above exception will be produced.

In the reported issue, the error happens when `next` is called on an `Enumerator` instance. Calling `next` causes execution to switch to a Fiber.
https://github.com/ice-cube-ruby/ice_cube/blob/2cdfdbaf75bd809831df1af3f0e96639bbc69ee6/lib/ice_cube/schedule.rb#L217

When local variable capture is enabled in rollbar-gem, the stack frames within the Fiber context are captured. The reported issue happens because `TracePoint#binding` is called while capturing these frames.

### Fix

This PR rescues the failed attempt to get the binding and returns `nil`. Later when building the payload, it skips insertion of locals for frames where the binding is missing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1094

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
