### PR TITLE
Fix error with body.rewind with rack 3.0

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -214,7 +214,7 @@ module Rollbar
       return {} unless correct_method
       return {} unless json_request?(rack_req)
 
-      raw_body = rack_req.body.read
+      raw_body = read_raw_body(rack_req.body)
       begin
         Rollbar::JSON.load(raw_body)
       rescue StandardError
@@ -222,8 +222,15 @@ module Rollbar
       end
     rescue StandardError
       {}
-    ensure
-      rack_req.body.rewind
+    end
+
+    def read_raw_body(body)
+      return {} unless body.respond_to?(:rewind)
+
+      body.rewind
+      raw_body = body.read
+      body.rewind
+      raw_body
     end
 
     def json_request?(rack_req)


### PR DESCRIPTION
In rack 3.0 there are no method `#rewind` in Rack::Lint::InputWrapper that existed in rack 2.2

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues
- Fix [#1106](https://github.com/rollbar/rollbar-gem/issues/1106)
