### PR TITLE
fix wrong option message

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -324,7 +324,7 @@ module Rollbar
     def send_extra_frame_data=(value)
       unless SEND_EXTRA_FRAME_DATA_OPTIONS.include?(value)
         logger.warning(
-          "Wrong 'send_extra_frame_data' value, :none, :app or :full is expected"
+          "Wrong 'send_extra_frame_data' value, :none, :app or :all is expected"
         )
 
         return


### PR DESCRIPTION
## Description of the change

Hi!

I found wrong option message.

This warning message says `Wrong 'send_extra_frame_data' value, :none, :app or :full is expected`

https://github.com/rollbar/rollbar-gem/blob/9ff048ba81c805670bfcca4ff8562ec719ee0c96/lib/rollbar/configuration.rb#L324-L331

However, `SEND_EXTRA_FRAME_DATA_OPTIONS` only includes `:none`, `:app` and  **:all** not `:full`

https://github.com/rollbar/rollbar-gem/blob/9ff048ba81c805670bfcca4ff8562ec719ee0c96/lib/rollbar/configuration.rb#L5

I would be glad if I could help.

Thank you :)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
