### PR TITLE
Fix CI errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ else
   gem 'delayed_job', '~> 4.1', :require => false
 end
 gem 'generator_spec'
-gem 'redis'
+gem 'redis', '<= 4.8.0'
 gem 'resque', '< 2.0.0'
 gem 'rubocop', '1.15.0', :require => false # pin specific version, update manually
 gem 'rubocop-performance', :require => false

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -34,7 +34,7 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
-gem 'redis'
+gem 'redis', '<= 4.8.0'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov', '<= 0.17.1'

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -30,7 +30,7 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
-gem 'redis'
+gem 'redis', '<= 4.8.0'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -30,7 +30,7 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
-gem 'redis'
+gem 'redis', '<= 4.8.0'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -30,7 +30,7 @@ gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.10', :require => false
 gem 'generator_spec'
-gem 'redis'
+gem 'redis', '<= 4.8.0'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'

--- a/spec/delay/sidekiq_spec.rb
+++ b/spec/delay/sidekiq_spec.rb
@@ -13,7 +13,7 @@ rescue LoadError
 end
 
 describe Rollbar::Delay::Sidekiq do
-  let(:payload) { anything }
+  let(:payload) {{ 'foo' => 'bar' }}
 
   describe '#perform' do
     it 'performs payload' do


### PR DESCRIPTION
## Description of the change

This PR fixes CI errors caused by updated dependency versions.
* Only use simple json types in Sidekiq args. The latest Sidekiq now errors on this.
* Pin redis to 4.x while tests depend on `Redis::Connection::Ruby`.  https://github.com/rollbar/rollbar-gem/issues/1115 is opened to track updating this test to be 5.x compatible.

## Type of change

- [x] Maintenance

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
