### PR TITLE
Add missing require

### DIFF
--- a/lib/rollbar/middleware/js.rb
+++ b/lib/rollbar/middleware/js.rb
@@ -134,6 +134,7 @@ module Rollbar
 
       def config_js_tag(env)
         require 'json'
+        require 'rollbar/middleware/js/json_value'
 
         js_config = Rollbar::Util.deep_copy(config[:options])
 


### PR DESCRIPTION
## Description of the change

Adds the missing require for `Rollbar::JSON::JsOptionsState`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1100


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
