### PR TITLE
[Doc] default_logger expects a callable interface

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,10 +59,10 @@ end
 
 ### default_logger
 
-**Default** `Logger.new(STDERR)`
+**Default** `lambda { Logger.new(STDERR) }`
 
 What logger to use for printing debugging and informational messages during
-operation.
+operation. Expects a callable object that returns a logger interface.
 
 ### logger_level
 


### PR DESCRIPTION
## Description of the change

Update configuration doc to accurately reflect expected type. Current wording makes it sound like it directly accepts a Logger; in reality it must be a callable object that returns a Logger.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
