### PR TITLE
Feature/extend filter configuration

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -26,6 +26,7 @@ module Rollbar
                   :enabled,
                   :endpoint,
                   :environment,
+                  :exception_level_filter,
                   :exception_level_filters,
                   :failover_handlers,
                   :filepath,
@@ -106,6 +107,7 @@ module Rollbar
       @enabled = nil # set to true when configure is called
       @endpoint = DEFAULT_ENDPOINT
       @environment = nil
+      @exception_level_filter = nil
       @exception_level_filters = {
         'ActiveRecord::RecordNotFound' => 'warning',
         'AbstractController::ActionNotFound' => 'warning',

--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -488,11 +488,15 @@ module Rollbar
       return unless exception
 
       filter = configuration.exception_level_filters[exception.class.name]
-      if filter.respond_to?(:call)
+      level = if filter.respond_to?(:call)
         filter.call(exception)
       else
         filter
       end
+
+      return level if level && !level.empty?
+
+      configuration.exception_level_filter&.call(exception)
     end
 
     def report(level, message, exception, extra, context)

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -843,17 +843,54 @@ describe Rollbar do
       end
 
       context 'without use_exception_level_filters argument' do
+        context 'with explicit exception_level_filters' do
+          it 'sends the correct filtered level' do
+            Rollbar.configure do |config|
+              config.exception_level_filters = { 'NameError' => 'warning' }
+            end
+
+            Rollbar.error(exception)
+
+            expect(Rollbar.last_report[:level]).to be_eql('warning')
+          end
+
+          it 'ignores ignored exception classes' do
+            Rollbar.configure do |config|
+              config.exception_level_filters = { 'NameError' => 'ignore' }
+            end
+
+            logger_mock.should_not_receive(:info)
+            logger_mock.should_not_receive(:warn)
+            logger_mock.should_not_receive(:error)
+
+            Rollbar.error(exception)
+          end
+
+          it 'should not use the filters if overriden at log site' do
+            Rollbar.configure do |config|
+              config.exception_level_filters = { 'NameError' => 'ignore' }
+            end
+
+            Rollbar.error(exception, :use_exception_level_filters => false)
+
+            expect(Rollbar.last_report[:level]).to be_eql('error')
+          end
+        end
+      end
+    end
+
+    context 'using :use_exception_level_filters option as true' do
+      context 'with explicit exception_level_filters' do
         it 'sends the correct filtered level' do
           Rollbar.configure do |config|
             config.exception_level_filters = { 'NameError' => 'warning' }
           end
 
-          Rollbar.error(exception)
-
+          Rollbar.error(exception, :use_exception_level_filters => true)
           expect(Rollbar.last_report[:level]).to be_eql('warning')
         end
 
-        it 'ignore ignored exception classes' do
+        it 'ignores ignored exception classes' do
           Rollbar.configure do |config|
             config.exception_level_filters = { 'NameError' => 'ignore' }
           end
@@ -862,97 +899,66 @@ describe Rollbar do
           logger_mock.should_not_receive(:warn)
           logger_mock.should_not_receive(:error)
 
-          Rollbar.error(exception)
+          Rollbar.error(exception, :use_exception_level_filters => true)
         end
 
-        it 'should not use the filters if overriden at log site' do
+        it 'sets error level using lambda' do
           Rollbar.configure do |config|
-            config.exception_level_filters = { 'NameError' => 'ignore' }
+            config.exception_level_filters = {
+              'NameError' => lambda { |_error| 'info' }
+            }
           end
 
-          Rollbar.error(exception, :use_exception_level_filters => false)
+          logger_mock.should_receive(:info)
+          logger_mock.should_not_receive(:warn)
+          logger_mock.should_not_receive(:error)
 
-          expect(Rollbar.last_report[:level]).to be_eql('error')
-        end
-      end
-    end
-
-    context 'using :use_exception_level_filters option as true' do
-      it 'sends the correct filtered level' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'warning' }
+          Rollbar.error(exception, :use_exception_level_filters => true)
         end
 
-        Rollbar.error(exception, :use_exception_level_filters => true)
-        expect(Rollbar.last_report[:level]).to be_eql('warning')
-      end
+        context 'using :use_exception_level_filters option as false' do
+          it 'sends the correct filtered level' do
+            Rollbar.configure do |config|
+              config.exception_level_filters = { 'NameError' => 'warning' }
+            end
 
-      it 'ignore ignored exception classes' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'ignore' }
-        end
-
-        logger_mock.should_not_receive(:info)
-        logger_mock.should_not_receive(:warn)
-        logger_mock.should_not_receive(:error)
-
-        Rollbar.error(exception, :use_exception_level_filters => true)
-      end
-
-      it 'sets error level using lambda' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = {
-            'NameError' => lambda { |_error| 'info' }
-          }
-        end
-
-        logger_mock.should_receive(:info)
-        logger_mock.should_not_receive(:warn)
-        logger_mock.should_not_receive(:error)
-
-        Rollbar.error(exception, :use_exception_level_filters => true)
-      end
-
-      context 'using :use_exception_level_filters option as false' do
-        it 'sends the correct filtered level' do
-          Rollbar.configure do |config|
-            config.exception_level_filters = { 'NameError' => 'warning' }
+            Rollbar.error(exception, :use_exception_level_filters => false)
+            expect(Rollbar.last_report[:level]).to be_eql('error')
           end
 
-          Rollbar.error(exception, :use_exception_level_filters => false)
-          expect(Rollbar.last_report[:level]).to be_eql('error')
-        end
+          it 'ignores ignored exception classes' do
+            Rollbar.configure do |config|
+              config.exception_level_filters = { 'NameError' => 'ignore' }
+            end
 
-        it 'ignore ignored exception classes' do
-          Rollbar.configure do |config|
-            config.exception_level_filters = { 'NameError' => 'ignore' }
+            Rollbar.error(exception, :use_exception_level_filters => false)
+
+            expect(Rollbar.last_report[:level]).to be_eql('error')
           end
-
-          Rollbar.error(exception, :use_exception_level_filters => false)
-
-          expect(Rollbar.last_report[:level]).to be_eql('error')
         end
       end
     end
 
     context 'if not using :use_exception_level_filters option' do
-      it 'sends the level defined by the used method' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'warning' }
+      context 'with explicit exception_level_filters' do
+        it 'sends the level defined by the used method' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'warning' }
+          end
+
+          Rollbar.error(exception)
+          expect(Rollbar.last_report[:level]).to be_eql('error')
         end
 
-        Rollbar.error(exception)
-        expect(Rollbar.last_report[:level]).to be_eql('error')
-      end
+        it 'ignores ignored exception classes' do
+          Rollbar.configure do |config|
+            config.exception_level_filters = { 'NameError' => 'ignore' }
+          end
 
-      it 'ignore ignored exception classes' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'ignore' }
+          Rollbar.error(exception)
+
+          expect(Rollbar.last_report[:level]).to be_eql('error')
         end
-
-        Rollbar.error(exception)
-
-        expect(Rollbar.last_report[:level]).to be_eql('error')
       end
     end
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -935,29 +935,6 @@ describe Rollbar do
       end
     end
 
-    context 'using :use_exception_level_filters option as true' do
-      it 'sends the correct filtered level' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'warning' }
-        end
-
-        Rollbar.error(exception, :use_exception_level_filters => true)
-        expect(Rollbar.last_report[:level]).to be_eql('warning')
-      end
-
-      it 'ignore ignored exception classes' do
-        Rollbar.configure do |config|
-          config.exception_level_filters = { 'NameError' => 'ignore' }
-        end
-
-        logger_mock.should_not_receive(:info)
-        logger_mock.should_not_receive(:warn)
-        logger_mock.should_not_receive(:error)
-
-        Rollbar.error(exception, :use_exception_level_filters => true)
-      end
-    end
-
     context 'if not using :use_exception_level_filters option' do
       it 'sends the level defined by the used method' do
         Rollbar.configure do |config|


### PR DESCRIPTION
## Description of the change

Exception level filters configuration allows to specify level (directly or through a lambda) for explicit class names but we reach a limit when using inheritance or more generally want the level to be determined by a lambda for distinct exception classes without having to go through declaring each single classes in the configuration.

```ruby
class UnmonitoredError < StandardError; end
class SpecificUnmonitoredError < UnmonitoredError; end

Rollbar.configure do |config|
  config.exception_level_filters.merge!('UnmonitoredError' => 'ignored')
end

Rollbar.error(SpecificUnmonitoredError.new("Boom"), :use_exception_level_filters => true)
# => Actually reported error 😢
```

With this change we could get this to work
```ruby
class UnmonitoredError < StandardError; end
class SpecificUnmonitoredError < UnmonitoredError; end

Rollbar.configure do |config|
  config.exception_level_filter = ->(exception) { exception.is_a? UnmonitoredError }
end

Rollbar.error(SpecificUnmonitoredError.new("Boom"), :use_exception_level_filters => true)
# => 'ignored'
```

This change is basic and just add another configuration, it could be interesting to have the exception_level_filter chainable similarly to how the current implementation uses the `.merge!` to add behaviour without resetting the entire configuration but this is probably for another iteration...

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- #351 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
