### PR TITLE
Avoid calling send(nil) when building rollbar_person_data

### DIFF
--- a/lib/rollbar/plugins/rails/controller_methods.rb
+++ b/lib/rollbar/plugins/rails/controller_methods.rb
@@ -7,33 +7,30 @@ module Rollbar
       include RequestDataExtractor
 
       def rollbar_person_data
-        user = nil
-        unless Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
-          user = send(Rollbar.configuration.person_method)
-        end
+        return {} if Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
+
+        config = Rollbar.configuration
+        user = send(config.person_method)
+        return {} unless user
 
         # include id, username, email if non-empty
-        if user
-          {
-            :id => (begin
-              user.send(Rollbar.configuration.person_id_method)
-            rescue StandardError
-              nil
-            end),
-            :username => (begin
-              user.send(Rollbar.configuration.person_username_method)
-            rescue StandardError
-              nil
-            end),
-            :email => (begin
-              user.send(Rollbar.configuration.person_email_method)
-            rescue StandardError
-              nil
-            end)
-          }
-        else
-          {}
-        end
+        {
+          :id => (begin
+            user.send(config.person_id_method) if config.person_id_method
+          rescue StandardError
+            nil
+          end),
+          :username => (begin
+            user.send(config.person_username_method) if config.person_username_method
+          rescue StandardError
+            nil
+          end),
+          :email => (begin
+            user.send(config.person_email_method) if config.person_email_method
+          rescue StandardError
+            nil
+          end)
+        }
       rescue NameError
         {}
       end


### PR DESCRIPTION
## Description of the change

Calling `user.send(nil)` raises a `TypeError`, which is subsequently swallowed. This is much less performant than using a conditional to guard against calling `user.send(nil)` (see benchmark at bottom of PR).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
  - :x: `Metrics/CyclomaticComplexity` [10/7]
  - :x: `Metrics/MethodLength` [23/15]
  - :x: `Metrics/PerceivedComplexity` [10/8]
  - I can break it down into a couple of smaller methods if needed
- [x] The code changed/added as part of this pull request has been covered with tests
  - Already covered by existing tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer

---------

```ruby
object = Object.new
method_name = nil

Benchmark.ips do |x|
  x.report('without guard') do
    object.send(method_name)
  rescue StandardError
    nil
  end

  x.report('guarded') do
    object.send(method_name) if method_name
  rescue StandardError
    nil
  end

  x.compare!
end

# Warming up --------------------------------------
#        without guard    70.391k i/100ms
#              guarded     2.001M i/100ms
# Calculating -------------------------------------
#        without guard    694.934k (± 2.8%) i/s -      3.520M in   5.068625s
#              guarded     20.060M (± 3.2%) i/s -    102.066M in   5.093412s
# 
# Comparison:
#              guarded: 20059621.4 i/s
#        without guard:   694934.2 i/s - 28.87x  slower
```
