### PR TITLE
Waltjones/rails 7.1 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           - gemfiles/rails60.gemfile
           - gemfiles/rails61.gemfile
         include:
+          - gemfile: gemfiles/rails71.gemfile
+            ruby-version: 3.2.2
+          - gemfile: gemfiles/rails71.gemfile
+            ruby-version: 3.1.1
           - gemfile: gemfiles/rails70.gemfile
             ruby-version: 3.1.1
           - gemfile: gemfiles/rails70.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # This Gemfile is compatible with Ruby 2.5.0 or greater. To test with
 # earlier Rubies, use the appropriate Gemfile from the ./gemfiles/ dir.
-ruby '>= 2.5.0'
+ruby '3.2.2'
 
 source 'https://rubygems.org'
 
@@ -13,7 +13,7 @@ ENV['CURRENT_GEMFILE'] ||= __FILE__
 
 is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby')
 
-GEMFILE_RAILS_VERSION = '~> 6.1.5'.freeze
+GEMFILE_RAILS_VERSION = '~> 7.1.0'.freeze
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'appraisal'
 gem 'jruby-openssl', :platform => :jruby
@@ -21,8 +21,10 @@ gem 'rails', GEMFILE_RAILS_VERSION
 gem 'rake'
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'rspec-rails', '~> 3.4'
-else
+elsif GEMFILE_RAILS_VERSION < '7.0'
   gem 'rspec-rails', '~> 4.0.2'
+else
+  gem 'rspec-rails', '~> 6.0.3'
 end
 
 if GEMFILE_RAILS_VERSION < '6.0'

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -6,7 +6,7 @@ is_jruby = defined?(JRUBY_VERSION) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == '
 
 gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
 gem 'jruby-openssl', :platform => :jruby
-gem 'rails', '~> 7.0.8'
+gem 'rails', '~> 7.1.0'
 gem 'sqlite3', '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 gem 'rspec-rails', '~> 6.0.3'

--- a/lib/rollbar/middleware/rails/show_exceptions.rb
+++ b/lib/rollbar/middleware/rails/show_exceptions.rb
@@ -4,7 +4,7 @@ module Rollbar
       module ShowExceptions
         include ExceptionReporter
 
-        def render_exception_with_rollbar(env, exception)
+        def render_exception_with_rollbar(env, exception, wrapper = nil)
           key = 'action_dispatch.show_detailed_exceptions'
 
           if exception.is_a?(ActionController::RoutingError) && env[key]
@@ -15,7 +15,12 @@ module Rollbar
             end
           end
 
-          render_exception_without_rollbar(env, exception)
+          # Rails 7.1 changes the method signature for render_exception.
+          if self.class.instance_method(:render_exception_without_rollbar).arity == 2
+            render_exception_without_rollbar(env, exception)
+          else
+            render_exception_without_rollbar(env, exception, wrapper)
+          end
         end
 
         def call_with_rollbar(env)


### PR DESCRIPTION
## Description of the change

This PR updates CI to include Rails 7.1, and fixes a compatibility issue with `DebugExceptions#render_exception`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Maintenance

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1122

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
