### PR TITLE
Take third parameter for Sidekiq error_handler

### DIFF
--- a/lib/rollbar/plugins/sidekiq.rb
+++ b/lib/rollbar/plugins/sidekiq.rb
@@ -12,7 +12,7 @@ Rollbar.plugins.define('sidekiq >= 3') do
         chain.add Rollbar::Sidekiq::ResetScope
       end
 
-      config.error_handlers << proc do |e, context|
+      config.error_handlers << proc do |e, context, _sidekiq_config = nil|
         Rollbar::Sidekiq.handle_exception(context, e)
       end
     end


### PR DESCRIPTION
## Description of the change

In https://github.com/sidekiq/sidekiq/commit/287051673f050b39c9ad985c1c21a3488dbbbd3a Sidekiq starts accepting a the Sidekiq Configuration option as a parameter to error_handlers and marks two parameter handlers as deprecated.    The following deprecation notice is now printed when Rollbar handles an exception from Sidekiq:

```
DEPRECATION: Sidekiq exception handlers now take three arguments, see #<Proc:0x000000011b32c870 /Users/atomaka/.local/share/rtx/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/rollbar-3.3.3/lib/rollbar/plugins/sidekiq.rb:15> 
```

This change adds a third parameter to the handler to accept that configuration and defaults the value to `nil` since

1. Older versions of Sidekiq will not pass a third parameter
2. Rollbar does not need to do anything with that value (yet?)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1131

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
