### PR TITLE
Fix warning: attribute accessor as module_function

### DIFF
--- a/lib/rollbar/json.rb
+++ b/lib/rollbar/json.rb
@@ -5,8 +5,6 @@ module Rollbar
   module JSON # :nodoc:
     module_function
 
-    attr_writer :options_module
-
     def dump(object)
       Rollbar.plugins.get('basic_socket').load_scoped!(true) do
         ::JSON.generate(object)


### PR DESCRIPTION
## Description of the change

When Running rspec with --warnings enabled a warning is emitted by the rollbar gem.

```
$ rspec --warnings
/my/path/ruby-3.2.2/gems/rollbar-3.4.1/lib/rollbar/json.rb:8: warning: attribute accessor as module_function
```

This is caused by the line
```
attr_writer :options_module
```
Within [lib/rollbar/json.rb](https://github.com/rollbar/rollbar-gem/blob/8c6a9e94629c0a8b964f0a3b13eab742c3800841/lib/rollbar/json.rb#L8)

The line was introduced here, when there was a more complicated way of configuring the json parser.

https://github.com/rollbar/rollbar-gem/commit/e33f10e7fb9d383b5ec76d675cee68d0ae31cd84#diff-9e64389290ff8e4e50cba9436521333bdd3307baa63ed84b74f0f9b28a6cfceaR13

However in 2019 this code was removed, and replaced with Ruby's JSON module

https://github.com/rollbar/rollbar-gem/commit/de45e80cee2d43f1ba58ff05ba6f2bc2ab374f97#diff-9e64389290ff8e4e50cba9436521333bdd3307baa63ed84b74f0f9b28a6cfceaL39-L41

But the attr_writer was not removed.

As the `options_module` attribute writer is not documented or referenced anywhere else in the project I believe it can be removed.

This commit removes the unused `attr_writer` and fixes the warning.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1108

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests - The removed line was not previously tested, it is still not tested, but it is also not there.
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
