### PR TITLE
Fix rack deprecation warning

### DIFF
--- a/lib/rollbar/middleware/rails/show_exceptions.rb
+++ b/lib/rollbar/middleware/rails/show_exceptions.rb
@@ -7,7 +7,7 @@ module Rollbar
         def render_exception_with_rollbar(env, exception, wrapper = nil)
           key = 'action_dispatch.show_detailed_exceptions'
 
-          if exception.is_a?(ActionController::RoutingError) && env[key]
+          if exception.is_a?(ActionController::RoutingError) && env.params[key.to_s]
             scope = extract_scope_from(env)
 
             Rollbar.scoped(scope) do


### PR DESCRIPTION
## Description of the change

The warning message:
```
warning: Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead
```

[This helper](https://github.com/rack/rack/blob/v3.0.8/lib/rack/request.rb#L608-L613) has been around since Rack 1.x and was deprecated in Rack 2.x.

The fix includes `to_s` on the key, as the helper did.

## Type of change

- [x] Maintenance

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1134

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached

