### PR TITLE
Fix ActionMailer plugin to add `rescue_from` to the correct class

### DIFF
--- a/lib/rollbar/configuration.rb
+++ b/lib/rollbar/configuration.rb
@@ -18,6 +18,7 @@ module Rollbar
                   :custom_data_method,
                   :default_logger,
                   :delayed_job_enabled,
+                  :disable_action_mailer_monkey_patch,
                   :disable_core_monkey_patch,
                   :disable_monkey_patch,
                   :disable_rack_monkey_patch,
@@ -99,6 +100,7 @@ module Rollbar
       @logger_level = :info
       @delayed_job_enabled = true
       @disable_monkey_patch = false
+      @disable_action_mailer_monkey_patch = false
       @disable_core_monkey_patch = false
       @disable_rack_monkey_patch = false
       @enable_error_context = true

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -27,14 +27,11 @@ Rollbar.plugins.define('active_job') do
 
     if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
       ActiveSupport.on_load(:action_mailer) do
-        # Automatically add to ActionMailer::DeliveryJob
-        if defined?(ActionMailer::DeliveryJob)
+        if defined?(ActionMailer::MailDeliveryJob) # Rails >= 6.0
+          ActionMailer::Base.send(:include, Rollbar::ActiveJob)
+        elsif defined?(ActionMailer::DeliveryJob) # Rails < 6.0
           ActionMailer::DeliveryJob.send(:include,
                                          Rollbar::ActiveJob)
-        end
-        # Rails >= 6.0
-        if defined?(ActionMailer::Base)
-          ActionMailer::Base.send(:include, Rollbar::ActiveJob)
         end
       end
     end

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -33,8 +33,8 @@ Rollbar.plugins.define('active_job') do
                                          Rollbar::ActiveJob)
         end
         # Rails >= 6.0
-        if defined?(ActionMailer::MailDeliveryJob)
-          ActionMailer::MailDeliveryJob.send(:include, Rollbar::ActiveJob)
+        if defined?(ActionMailer::Base)
+          ActionMailer::Base.send(:include, Rollbar::ActiveJob)
         end
       end
     end

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -14,11 +14,16 @@ Rollbar.plugins.define('active_job') do
                      arguments
                    end
 
-            Rollbar.error(exception,
-                          :job => self.class.name,
-                          :job_id => job_id,
-                          :use_exception_level_filters => true,
-                          :arguments => args)
+            job_data = {
+              :job => self.class.name,
+              :use_exception_level_filters => true,
+              :arguments => args
+            }
+
+            # job_id isn't present when this is a mailer class.
+            job_data[:job_id] = job_id if defined?(job_id)
+
+            Rollbar.error(exception, job_data)
             raise exception
           end
         end

--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -1,35 +1,42 @@
-module Rollbar
-  # Report any uncaught errors in a job to Rollbar and reraise
-  module ActiveJob
-    def self.included(base)
-      base.send :rescue_from, Exception do |exception|
-        args = if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
-                 arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
-               else
-                 arguments
-               end
+Rollbar.plugins.define('active_job') do
+  dependency { !configuration.disable_monkey_patch }
+  dependency { !configuration.disable_action_mailer_monkey_patch }
 
-        Rollbar.error(exception,
-                      :job => self.class.name,
-                      :job_id => job_id,
-                      :use_exception_level_filters => true,
-                      :arguments => args)
-        raise exception
+  execute do
+    module Rollbar
+      # Report any uncaught errors in a job to Rollbar and reraise
+      module ActiveJob
+        def self.included(base)
+          base.send :rescue_from, Exception do |exception|
+            args = if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
+                     arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
+                   else
+                     arguments
+                   end
+
+            Rollbar.error(exception,
+                          :job => self.class.name,
+                          :job_id => job_id,
+                          :use_exception_level_filters => true,
+                          :arguments => args)
+            raise exception
+          end
+        end
       end
     end
-  end
-end
 
-if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
-  ActiveSupport.on_load(:action_mailer) do
-    # Automatically add to ActionMailer::DeliveryJob
-    if defined?(ActionMailer::DeliveryJob)
-      ActionMailer::DeliveryJob.send(:include,
-                                     Rollbar::ActiveJob)
-    end
-    # Rails >= 6.0
-    if defined?(ActionMailer::MailDeliveryJob)
-      ActionMailer::MailDeliveryJob.send(:include, Rollbar::ActiveJob)
+    if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
+      ActiveSupport.on_load(:action_mailer) do
+        # Automatically add to ActionMailer::DeliveryJob
+        if defined?(ActionMailer::DeliveryJob)
+          ActionMailer::DeliveryJob.send(:include,
+                                         Rollbar::ActiveJob)
+        end
+        # Rails >= 6.0
+        if defined?(ActionMailer::MailDeliveryJob)
+          ActionMailer::MailDeliveryJob.send(:include, Rollbar::ActiveJob)
+        end
+      end
     end
   end
 end

--- a/spec/dummyapp/config/application.rb
+++ b/spec/dummyapp/config/application.rb
@@ -58,5 +58,9 @@ module Dummy
     if Gem::Version.new(Rails.version) >= Gem::Version.new('4.2.0')
       config.active_job.queue_adapter = :inline
     end
+
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('6.0.0')
+      config.load_defaults 6.0
+    end
   end
 end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -51,7 +51,7 @@ describe Rollbar::ActiveJob do
 
   it 'scrubs all arguments if job has `log_arguments` disabled' do
     allow(TestJob).to receive(:log_arguments?).and_return(false)
-     
+
     expected_params = {
       :job => 'TestJob',
       :job_id => job_id,
@@ -63,6 +63,20 @@ describe Rollbar::ActiveJob do
       TestJob.new(1, 2, 3).perform(exception, job_id)
     rescue StandardError
       nil
+    end
+  end
+
+  context 'disabled in config' do
+    subject { Rollbar.plugins.get('active_job') }
+    before do
+      subject.unload!
+
+      # Configur will load all plugins after applying the config.
+      Rollbar.configure { |c| c.disable_action_mailer_monkey_patch = true }
+    end
+
+    it "isn't loaded" do
+      expect(subject.loaded).to eq(false)
     end
   end
 

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -22,73 +22,46 @@ describe Rollbar::ActiveJob do
     end
   end
 
+  class TestMailer < ActionMailer::Base
+    attr_accessor :arguments
+
+    def test_email(*_arguments)
+      error = StandardError.new('oh no')
+      raise(error)
+    end
+  end
+
   before { reconfigure_notifier }
 
   let(:exception) { StandardError.new('oh no') }
   let(:job_id) { '123' }
   let(:argument) { 12 }
-
-  it 'reports the error to Rollbar' do
-    expected_params = {
+  let(:expected_params) do
+    {
       :job => 'TestJob',
       :job_id => job_id,
       :use_exception_level_filters => true,
       :arguments => [argument]
     }
-    expect(Rollbar).to receive(:error).with(exception, expected_params)
-    begin
-      TestJob.new(argument).perform(exception, job_id)
-    rescue StandardError
-      nil
-    end
   end
 
-  it 'reraises the error so the job backend can handle the failure and retry' do
-    expect do
-      TestJob.new(argument).perform(exception, job_id)
-    end.to raise_error exception
-  end
-
-  it 'scrubs all arguments if job has `log_arguments` disabled' do
-    allow(TestJob).to receive(:log_arguments?).and_return(false)
-
-    expected_params = {
-      :job => 'TestJob',
-      :job_id => job_id,
-      :use_exception_level_filters => true,
-      :arguments => ['******', '******', '******']
-    }
-    expect(Rollbar).to receive(:error).with(exception, expected_params)
-    begin
-      TestJob.new(1, 2, 3).perform(exception, job_id)
-    rescue StandardError
-      nil
-    end
-  end
-
-  context 'disabled in config' do
-    subject { Rollbar.plugins.get('active_job') }
-    before do
-      subject.unload!
-
-      # Configur will load all plugins after applying the config.
-      Rollbar.configure { |c| c.disable_action_mailer_monkey_patch = true }
+  shared_examples 'an ActiveMailer plugin' do
+    it 'reraises the error so the job backend can handle the failure and retry' do
+      expect do
+        TestJob.new(argument).perform(exception, job_id)
+      end.to raise_error exception
     end
 
-    it "isn't loaded" do
-      expect(subject.loaded).to eq(false)
-    end
-  end
+    it 'scrubs all arguments if job has `log_arguments` disabled' do
+      allow(TestJob).to receive(:log_arguments?).and_return(false)
 
-  context 'using ActionMailer::DeliveryJob', :if => Gem::Version.new(Rails.version) < Gem::Version.new('6.0') do
-    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
-
-    class TestMailer < ActionMailer::Base
-      attr_accessor :arguments
-
-      def test_email(*_arguments)
-        error = StandardError.new('oh no')
-        raise(error)
+      expected_params[:job_id] = job_id
+      expected_params[:arguments] = ['******', '******', '******']
+      expect(Rollbar).to receive(:error).with(exception, expected_params)
+      begin
+        TestJob.new(1, 2, 3).perform(exception, job_id)
+      rescue StandardError
+        nil
       end
     end
 
@@ -99,7 +72,36 @@ describe Rollbar::ActiveJob do
       end.to have_enqueued_job.on_queue('mailers')
     end
 
-    it 'reports the error to Rollbar' do
+    context 'disabled in config' do
+      subject { Rollbar.plugins.get('active_job') }
+      before do
+        subject.unload!
+
+        # Configur will load all plugins after applying the config.
+        Rollbar.configure { |c| c.disable_action_mailer_monkey_patch = true }
+      end
+
+      it "isn't loaded" do
+        expect(subject.loaded).to eq(false)
+      end
+    end
+  end
+
+  context 'using ActionMailer::DeliveryJob', :if => Gem::Version.new(Rails.version) < Gem::Version.new('6.0') do
+    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
+
+    it_behaves_like 'an ActiveMailer plugin'
+
+    it 'reports the job error to Rollbar' do
+      expect(Rollbar).to receive(:error).with(exception, expected_params)
+      begin
+        TestJob.new(argument).perform(exception, job_id)
+      rescue StandardError
+        nil
+      end
+    end
+
+    it 'reports the mailer error to Rollbar' do
       expected_params = {
         :job => 'ActionMailer::DeliveryJob',
         :use_exception_level_filters => true,
@@ -149,6 +151,35 @@ describe Rollbar::ActiveJob do
       end
       Rollbar.last_report[:body][:trace][:extra][:arguments][3]['user_id']
              .should match(/^*+$/)
+    end
+  end
+
+  context 'using ActionMailer::MailDeliveryJob', :if => Gem::Version.new(Rails.version) >= Gem::Version.new('6.0') do
+    include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
+
+    let(:expected_params) do
+      {
+        :job => 'TestJob',
+        :use_exception_level_filters => true
+      }
+    end
+
+    it_behaves_like 'an ActiveMailer plugin'
+
+    it 'reports the error to Rollbar' do
+      expected_params.delete(:job)
+
+      # In 6+, the re-raise in the plugin will cause the rescue_from to be called twice.
+      expect(Rollbar).to receive(:error).twice.with(kind_of(StandardError),
+                                              hash_including(expected_params))
+
+      perform_enqueued_jobs do
+        begin
+          TestMailer.test_email(argument).deliver_later
+        rescue StandardError => e
+          nil
+        end
+      end
     end
   end
 end

--- a/spec/rollbar/plugins/active_job_spec.rb
+++ b/spec/rollbar/plugins/active_job_spec.rb
@@ -80,7 +80,7 @@ describe Rollbar::ActiveJob do
     end
   end
 
-  context 'using ActionMailer::DeliveryJob', :if => defined?(ActionMailer::DeliveryJob) do
+  context 'using ActionMailer::DeliveryJob', :if => Gem::Version.new(Rails.version) < Gem::Version.new('6.0') do
     include ActiveJob::TestHelper if defined?(ActiveJob::TestHelper)
 
     class TestMailer < ActionMailer::Base


### PR DESCRIPTION
## Description of the change

This PR has two fixes.
* The `ActiveJob` plugin is now a true plugin, with all of the methods and capabilities that should be present. It now loads at the correct load time, and can be disabled from the Rollbar config. d3e0029f3fbc928adbe44647239dd9e290b1c8e4
* The `rescue_from` handler is added to the correct base class. 4d4f391ee6bd11b96c4fe4acd93337aeaf292634

This PR also refactors the tests to test Rails 6+, which previously didn't get coverage that included the mailer class. Where possible, the tests are now in shared examples called by both the old and new contexts.

Background facts about `rescue_from` handlers.
* These have precedence in the order they are added, with the last added having the highest precedence.
* Only one handler is called for an exception. Handlers are not chained or cascaded.
* The first handler in order of precedence that matches the exception class is the one called.
 
When `MailDeliveryJob` was added in Rails 6.x, it included a `rescue_from` handler [that calls the `rescue_from` of the Mailer class](https://github.com/rails/rails/blob/b1d57fb8c87d771d9a74ac31cd9969e6806b03b2/actionmailer/lib/action_mailer/mail_delivery_job.rb#L40-L46).

When the Rollbar `ActiveJob` plugin installs its handler on `MailDeliveryJob`, it is added after the one in the `MailDeliveryJob` class, and has precedence. This causes the intended handler to never get called, and therefore never pass the error to the Mailer class.

`ActionMailer::Base` is the base class for all Mailers, and this is the correct place to add the Rollbar handler. With this fix, the application's handler will be used if it matches the exception class, and if not, the Rollbar handler is called.



## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1126


