### PR TITLE
fix: compatibility fixes for ActionMailer plugin

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -8,22 +8,32 @@ Rollbar.plugins.define('active_job') do
       module ActiveJob
         def self.included(base)
           base.send :rescue_from, Exception do |exception|
-            args = if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
-                     arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
-                   else
-                     arguments
-                   end
-
             job_data = {
               :job => self.class.name,
-              :use_exception_level_filters => true,
-              :arguments => args
+              :use_exception_level_filters => true
             }
 
-            # job_id isn't present when this is a mailer class.
-            job_data[:job_id] = job_id if defined?(job_id)
+            # When included in ActionMailer, the handler is called twice.
+            # This detects the execution that has the expected state.
+            if defined?(ActionMailer::Base) && self.class.ancestors.include?(ActionMailer::Base)
+              job_data[:action] = action_name
+              job_data[:params] = @params
 
-            Rollbar.error(exception, job_data)
+              Rollbar.error(exception, job_data)
+
+            # This detects other supported integrations.
+            elsif defined?(arguments)
+              job_data[:arguments] = \
+                if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
+                  arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
+                else
+                  arguments
+                end
+              job_data[:job_id] = job_id if defined?(job_id)
+
+              Rollbar.error(exception, job_data)
+            end
+
             raise exception
           end
         end


### PR DESCRIPTION
## Description of the change

This PR fixes several compatibility issues with plugin support for ActionMailer.
* Correctly detect whether included in a mailer class.
* Report metadata available in subclasses of ActionMailer::Base, and don't reference attributes that aren't. (e.g. `arguments`)
* Prevent double Rollbar reports, caused by the `rescue_from` handler getting called twice.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1145