### PR TITLE
Move Rollbar::ActiveJob out of the plugin

### DIFF
--- a/lib/rollbar/plugins/active_job.rb
+++ b/lib/rollbar/plugins/active_job.rb
@@ -1,45 +1,45 @@
+module Rollbar
+  # Report any uncaught errors in a job to Rollbar and reraise
+  module ActiveJob
+    def self.included(base)
+      base.send :rescue_from, Exception do |exception|
+        job_data = {
+          :job => self.class.name,
+          :use_exception_level_filters => true
+        }
+
+        # When included in ActionMailer, the handler is called twice.
+        # This detects the execution that has the expected state.
+        if defined?(ActionMailer::Base) && self.class.ancestors.include?(ActionMailer::Base)
+          job_data[:action] = action_name
+          job_data[:params] = @params
+
+          Rollbar.error(exception, job_data)
+
+        # This detects other supported integrations.
+        elsif defined?(arguments)
+          job_data[:arguments] = \
+            if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
+              arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
+            else
+              arguments
+            end
+          job_data[:job_id] = job_id if defined?(job_id)
+
+          Rollbar.error(exception, job_data)
+        end
+
+        raise exception
+      end
+    end
+  end
+end
+
 Rollbar.plugins.define('active_job') do
   dependency { !configuration.disable_monkey_patch }
   dependency { !configuration.disable_action_mailer_monkey_patch }
 
   execute do
-    module Rollbar
-      # Report any uncaught errors in a job to Rollbar and reraise
-      module ActiveJob
-        def self.included(base)
-          base.send :rescue_from, Exception do |exception|
-            job_data = {
-              :job => self.class.name,
-              :use_exception_level_filters => true
-            }
-
-            # When included in ActionMailer, the handler is called twice.
-            # This detects the execution that has the expected state.
-            if defined?(ActionMailer::Base) && self.class.ancestors.include?(ActionMailer::Base)
-              job_data[:action] = action_name
-              job_data[:params] = @params
-
-              Rollbar.error(exception, job_data)
-
-            # This detects other supported integrations.
-            elsif defined?(arguments)
-              job_data[:arguments] = \
-                if self.class.respond_to?(:log_arguments?) && !self.class.log_arguments?
-                  arguments.map(&Rollbar::Scrubbers.method(:scrub_value))
-                else
-                  arguments
-                end
-              job_data[:job_id] = job_id if defined?(job_id)
-
-              Rollbar.error(exception, job_data)
-            end
-
-            raise exception
-          end
-        end
-      end
-    end
-
     if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
       ActiveSupport.on_load(:action_mailer) do
         if defined?(ActionMailer::MailDeliveryJob) # Rails >= 6.0


### PR DESCRIPTION
## Description of the change

This PR moves Rollbar::ActiveJob out of the plugin. This allows it to be available before plugin load, and when the action mailer integration is disabled.

The github diff shows a lot of +/- but it is just moving the module definition to be outside the plugin definition. (In the diff view, :gear: -> "hide whitespace" results in a much cleaner diff.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1148
