### PR TITLE
Enable Rails 7 error reporter via Rollbar config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,9 +65,9 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/HashSyntax:
-  EnforcedStyle: hash_rockets
+  EnforcedStyle: no_mixed_keys
   SupportedStyles:
-    - hash_rockets
+    - no_mixed_keys
 
 Style/Lambda:
   Enabled: false

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -27,7 +27,8 @@ module Rollbar
     end
 
     def capture_uncaught?
-      Rollbar.configuration.capture_uncaught != false
+      Rollbar.configuration.capture_uncaught != false &&
+        !Rollbar.configuration.enable_rails_error_subscriber
     end
 
     def log_exception_message(exception)

--- a/lib/rollbar/logger.rb
+++ b/lib/rollbar/logger.rb
@@ -17,12 +17,10 @@ module Rollbar
   class Logger < ::Logger
     class Error < RuntimeError; end
 
-    class DatetimeFormatNotSupported < Error; end
-
-    class FormatterNotSupported < Error; end
-
     def initialize
-      @level = ERROR
+      super(nil)
+
+      self.level = ERROR
     end
 
     def add(severity, message = nil, progname = nil)
@@ -37,22 +35,6 @@ module Rollbar
 
     def <<(message)
       error(message)
-    end
-
-    def formatter=(_)
-      raise(FormatterNotSupported)
-    end
-
-    def formatter
-      raise(FormatterNotSupported)
-    end
-
-    def datetime_format=(_)
-      raise(DatetimeFormatNotSupported)
-    end
-
-    def datetime_format
-      raise(DatetimeFormatNotSupported)
     end
 
     # Returns a Rollbar::Notifier instance with the current global scope and

--- a/lib/rollbar/plugins/rails.rb
+++ b/lib/rollbar/plugins/rails.rb
@@ -79,3 +79,11 @@ Rollbar.plugins.define('rails-rollbar.js') do
     Rollbar::Js::Frameworks::Rails.new.load(self)
   end
 end
+
+Rollbar.plugins.define('rails-error-subscriber') do
+  dependency { defined?(Rails::VERSION) && Rails::VERSION::MAJOR >= 7 }
+
+  execute! do
+    require 'rollbar/plugins/rails/error_subscriber'
+  end
+end

--- a/lib/rollbar/plugins/rails/error_subscriber.rb
+++ b/lib/rollbar/plugins/rails/error_subscriber.rb
@@ -1,0 +1,9 @@
+module Rollbar
+  class ErrorSubscriber
+    def report(error, handled:, severity:, context:, source: nil)
+      extra = context.is_a?(Hash) ? context.deep_dup : {}
+      extra[:custom_data_method_context] = source
+      Rollbar.log(severity, error, extra)
+    end
+  end
+end

--- a/lib/rollbar/plugins/rails/error_subscriber.rb
+++ b/lib/rollbar/plugins/rails/error_subscriber.rb
@@ -1,6 +1,9 @@
 module Rollbar
   class ErrorSubscriber
     def report(error, handled:, severity:, context:, source: nil)
+      # The default `nil` for capture_uncaught means `true`. so check for false.
+      return unless handled || Rollbar.configuration.capture_uncaught != false
+
       extra = context.is_a?(Hash) ? context.deep_dup : {}
       extra[:custom_data_method_context] = source
       Rollbar.log(severity, error, extra)

--- a/spec/dummyapp/app/controllers/home_controller.rb
+++ b/spec/dummyapp/app/controllers/home_controller.rb
@@ -22,8 +22,22 @@ class HomeController < ApplicationController
     render :json => {}
   end
 
+  def handle_rails_error
+    Rails.error.handle do
+      raise 'Handle Rails error'
+    end
+
+    render :json => {}
+  end
+
+  def record_rails_error
+    Rails.error.record do
+      raise 'Record Rails error'
+    end
+  end
+
   def cause_exception
-    _foo = bar
+    raise NameError, 'Uncaught Rails error'
   end
 
   def cause_exception_with_locals

--- a/spec/dummyapp/config/routes.rb
+++ b/spec/dummyapp/config/routes.rb
@@ -4,6 +4,8 @@ Dummy::Application.routes.draw do
     member { post :start_session }
   end
 
+  match '/handle_rails_error' => 'home#handle_rails_error', :via => [:get, :post]
+  match '/record_rails_error' => 'home#record_rails_error', :via => [:get, :post]
   match '/cause_exception' => 'home#cause_exception', :via => [:get, :post]
   match '/cause_exception_with_locals' => 'home#cause_exception_with_locals',
         :via => [:get, :post]

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -91,7 +91,7 @@ describe Rollbar::Logger do
       logger = notifier.configuration.logger
       logdev = logger.instance_eval { @logdev }
 
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+      if Gem::Version.new(Logger::VERSION) >= Gem::Version.new('1.4.3')
         # The Logger class no longer creates a LogDevice when the device is `File::NULL`
         # See: ruby/ruby@f3e12caa088cc893a54bc2810ff511e4c89b322b
         expect(logdev).to be_nil

--- a/spec/rollbar/logger_spec.rb
+++ b/spec/rollbar/logger_spec.rb
@@ -85,38 +85,6 @@ describe Rollbar::Logger do
     end
   end
 
-  describe '#formatter=' do
-    it 'fails with FormatterNotSupported' do
-      expect do
-        subject.formatter = double
-      end.to raise_error(Rollbar::Logger::FormatterNotSupported)
-    end
-  end
-
-  describe '#formatter' do
-    it 'fails with FormatterNotSupported' do
-      expect do
-        subject.formatter
-      end.to raise_error(Rollbar::Logger::FormatterNotSupported)
-    end
-  end
-
-  describe '#datetime_format=' do
-    it 'fails with DatetimeFormatNotSupported' do
-      expect do
-        subject.datetime_format = double
-      end.to raise_error(Rollbar::Logger::DatetimeFormatNotSupported)
-    end
-  end
-
-  describe '#datetime_format' do
-    it 'fails with DatetimeFormatNotSupported' do
-      expect do
-        subject.datetime_format
-      end.to raise_error(Rollbar::Logger::DatetimeFormatNotSupported)
-    end
-  end
-
   describe '#rollbar' do
     it 'returns a Rollbar notifier with a logger pointing to /dev/null' do
       notifier = subject.rollbar


### PR DESCRIPTION
## Description of the change

Optionally enables the Rails 7 error reporter. https://edgeguides.rubyonrails.org/error_reporting.html

The new Boolean config key is `enable_rails_error_subscriber`.
```ruby
      Rollbar.configure do |config|
        config.enable_rails_error_subscriber = true
      end
```

This is off by default for back compatibility, and can be enabled in the Rollbar initializer, or enabled/disabled at any time via the `Rollbar.configure` method.

This is available with Rails 7.1+ because that's when `unsubscribe` was introduced.

This PR also fixes an issue with the `Rollbar::Logger` class.
* `initialize` should call `super`. This issue breaks in recent Logger versions.
* The Logger version should be used to branch in tests.

Normally I'd put this in a separate PR, but since it breaks CI I've added it here.

Note: This PR also enables both hash syntaxes in rubocop. 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Fixes:
https://github.com/rollbar/rollbar-gem/issues/1105
https://github.com/rollbar/rollbar-gem/issues/1153
https://github.com/rollbar/rollbar-gem/issues/1156

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
