### PR TITLE
Remove `OpenStruct` from the project (solve warnings)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,8 +156,6 @@ Performance/InefficientHashSearch:
 
 Performance/OpenStruct:
   Enabled: true
-  Exclude:
-    - spec/**/*
 
 Performance/RangeInclude:
   Enabled: true

--- a/spec/delayed/backend/test.rb
+++ b/spec/delayed/backend/test.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'delayed_job'
 require 'delayed/backend/base'
 

--- a/spec/rollbar_spec.rb
+++ b/spec/rollbar_spec.rb
@@ -7,7 +7,6 @@ require 'active_support/core_ext/object'
 require 'active_support/json/encoding'
 
 require 'rollbar/item'
-require 'ostruct'
 
 require 'spec_helper'
 
@@ -242,7 +241,7 @@ describe Rollbar do
           notifier.configuration = configuration
           allow_any_instance_of(Net::HTTP)
             .to receive(:request)
-            .and_return(OpenStruct.new(:code => 500, :body => 'Error'))
+            .and_return(double(code: 500, body: 'Error'))
           @uri = URI.parse(Rollbar::Configuration::DEFAULT_ENDPOINT)
         end
 
@@ -1518,7 +1517,7 @@ describe Rollbar do
     before do
       allow_any_instance_of(Net::HTTP)
         .to receive(:request)
-        .and_return(OpenStruct.new(:code => 200, :body => 'Success'))
+        .and_return(double(code: 200, body: 'Success'))
       @env_vars = clear_proxy_env_vars
     end
 


### PR DESCRIPTION
## Description of the change

This pull request aims to solve one of the warnings we've been getting when loading the gem (#1165)

```
/usr/local/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

`OpenStruct` was introduced in the project [back in 2017](https://github.com/rollbar/rollbar-gem/pull/626) to be used a test double.

I'm proposing replacing those `OpenStruct` instances with [RSpec doubles](https://rspec.info/documentation/3.13/rspec-mocks/RSpec/Mocks/ExampleMethods.html#double-instance_method).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #1165

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
