### PR TITLE
Don't require the unused `ostruct` gem

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -9,7 +9,6 @@ require 'rollbar/delay/thread'
 require 'rollbar/logger_proxy'
 require 'rollbar/item'
 require 'rollbar/notifier/trace_with_bindings'
-require 'ostruct'
 
 module Rollbar
   # The notifier class. It has the core functionality


### PR DESCRIPTION
## Description of the change
`ostruct` is still being `required` while not used.  
https://github.com/rollbar/rollbar-gem/blob/11f60a36888b17a83a60624357cfafe3aec0c678/lib/rollbar/notifier.rb#L12

```
.direnv/ruby/bundler/gems/rollbar-gem-11f60a36888b/lib/rollbar/notifier.rb:12: warning: /nix/store/kjbc5w8aygsszla6ww1a43x8lazv70mj-ruby-3.4.0-rc1/lib/ruby/3.4.0+1/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- #1165 
- possibly missed by #1169 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
