### PR TITLE
initial edit for forked gem

### DIFF
--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -17,7 +17,8 @@ require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
 require 'rollbar/exceptions'
 require 'rollbar/lazy_store'
-require 'rollbar/notifier'
+#require 'rollbar/notifier'
+require "rollbar/justworks_notifier"
 
 # The Rollbar module. It stores a Rollbar::Notifier per thread and
 # provides some module methods in order to use the current thread notifier.
@@ -37,7 +38,7 @@ module Rollbar
     def notifier
       # Use the global instance @root_notifier so we don't fall
       # in a infinite loop
-      Thread.current[:_rollbar_notifier] ||= Notifier.new(@root_notifier)
+      Thread.current[:_rollbar_notifier] ||= LoggerNotifier.new(@root_notifier)
     end
 
     def notifier=(notifier)

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -37,7 +37,7 @@ module Rollbar
     def notifier
       # Use the global instance @root_notifier so we don't fall
       # in a infinite loop
-      Thread.current[:_rollbar_notifier] ||= LoggerNotifier.new(@root_notifier)
+      Thread.current[:_rollbar_notifier] ||= LoggerNotifier.new(@root_notifier) # Forked Update: use overridden notifier class
     end
 
     def notifier=(notifier)

--- a/lib/rollbar.rb
+++ b/lib/rollbar.rb
@@ -17,8 +17,7 @@ require 'rollbar/configuration'
 require 'rollbar/logger_proxy'
 require 'rollbar/exceptions'
 require 'rollbar/lazy_store'
-#require 'rollbar/notifier'
-require "rollbar/justworks_notifier"
+require "rollbar/logger_notifier"
 
 # The Rollbar module. It stores a Rollbar::Notifier per thread and
 # provides some module methods in order to use the current thread notifier.

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -39,7 +39,7 @@ module Rollbar
 
     def exception_data(exception)
       Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception,
-                  :use_exception_level_filters => true)
+                  :use_exception_level_filters => true, :uncaught_error => true)
     end
   end
 end

--- a/lib/rollbar/exception_reporter.rb
+++ b/lib/rollbar/exception_reporter.rb
@@ -39,7 +39,7 @@ module Rollbar
 
     def exception_data(exception)
       Rollbar.log(Rollbar.configuration.uncaught_exception_level, exception,
-                  :use_exception_level_filters => true, :uncaught_error => true)
+                  :use_exception_level_filters => true, :uncaught_error => true) # Forked Update: add "uncaught error" indicator
     end
   end
 end

--- a/lib/rollbar/logger_notifier.rb
+++ b/lib/rollbar/logger_notifier.rb
@@ -1,18 +1,32 @@
 require "rollbar/notifier"
 require "json"
 
+# This overrides the Notifier in the original rollbar-gem.
+#
+# It overrides two methods:
+#  1. #send_using_eventmachine(body)
+#  2. #send_body(body)
+# These two methods are the last methods called before messages are sent to the Rollbar server.
+#
+# The override allows for the injection of code that sends messages to the application log
+#  before sending the messages to the Rollbar server.
+#
 module Rollbar
 	class LoggerNotifier < Notifier
+    # This is an override of a method in the original rollbar-gem.
     def send_using_eventmachine(body)
       format_and_log(body)
       super(body)
     end
 
+    # This is an override of a method in the original rollbar-gem.
     def send_body(body)
       format_and_log(body)
       super(body)
     end
 
+    # This method takes the messages meant to be sent to Rollbar's server and logs them to the application log,
+    #  where the Datadog agent will pick up the messages and send them to Datadog.
     def format_and_log(body)
       body_hash = ::JSON.parse(body)
 

--- a/lib/rollbar/logger_notifier.rb
+++ b/lib/rollbar/logger_notifier.rb
@@ -1,0 +1,42 @@
+require "rollbar/notifier"
+require "json"
+
+module Rollbar
+	class LoggerNotifier < Notifier
+    def send_using_eventmachine(body)
+      format_and_log(body)
+      super(body)
+    end
+
+    def send_body(body)
+      format_and_log(body)
+      super(body)
+    end
+
+    def format_and_log(body)
+      body_hash = ::JSON.parse(body)
+
+      # Skip logging to application logger for Datadog to pick up. Datadog is already configured to log uncaught errors directly.
+      return if body_hash.dig("data", "body", "message", "extra", "uncaught_error")
+
+      level = body_hash.dig("data", "level")
+      method_name = :error
+
+      # Rollbar levels: https://github.com/rollbar/rollbar-gem/blob/f9d0be72a8048a5e8ae54200c84a5dff2fe513fb/lib/rollbar/logger.rb#L67-L69
+      case level
+      when "debug"
+        method_name = :debug
+      when "info"
+        method_name = :info
+      when "warning"
+        method_name = :warn
+      when "error"
+        method_name = :error
+      when "critical"
+        method_name = :fatal
+      end
+
+      ::Rails.logger.send(method_name, body)
+    end
+	end
+end


### PR DESCRIPTION
Initial edit for the forked rollbar gem. It includes the initial implementation of a class to override functionality so that messages are logged to the application log before being sent to the Rollbar serve. This excludes the use case of when an uncaught exception is caught by Rollbar.