### PR TITLE
ci: pin concurrent-ruby version for older rails versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,10 @@ else
   gem 'rspec-rails', '~> 6.0.3'
 end
 
+if GEMFILE_RAILS_VERSION < '7.1'
+  gem 'concurrent-ruby', '1.3.4'
+end
+
 if GEMFILE_RAILS_VERSION < '6.0'
   gem 'sqlite3', '< 1.4.0', :platform => [:ruby, :mswin, :mingw]
 else

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -34,13 +34,15 @@ gem 'sucker_punch', '~> 2.0'
 
 gem 'rack', '2.1.2' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 
-# We need last sinatra that uses rack 2.1.x
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner', '~> 1.8.4'
 gem 'delayed_job', :require => false
 gem 'generator_spec'
 gem 'redis', '<= 3.3.5'
 gem 'resque'
 gem 'secure_headers', '~> 6.3.2', :require => false
+
+# We need last sinatra that uses rack 2.1.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 
 unless is_jruby

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -37,6 +37,7 @@ gem 'rack', '2.1.2' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3')
 # We need last sinatra that uses rack 2.1.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag => 'v2.0.8'
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner', '~> 1.8.4'
 gem 'delayed_job', :require => false
 gem 'generator_spec'

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -31,6 +31,7 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x and ruby 2.5.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner'
 gem 'delayed_job', :require => false
 gem 'generator_spec'

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -27,6 +27,7 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x and ruby 2.5.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -27,6 +27,7 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x and ruby 2.5.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -27,6 +27,7 @@ gem 'sucker_punch', '~> 2.0'
 # We need last sinatra that uses rack 2.x and ruby 2.5.x
 gem 'sinatra', :git => 'https://github.com/sinatra/sinatra', :tag =>'v2.1.0'
 
+gem 'concurrent-ruby', '1.3.4'
 gem 'database_cleaner'
 gem 'delayed_job', '4.1.10', :require => false
 gem 'generator_spec'


### PR DESCRIPTION
## Description of the change

Latest versions of concurrent-ruby introduced a breaking change for older Rails versions. This PR pins the version used for the test matrix.

## Type of change


- [x] Maintenance



