### PR TITLE
Ruby 3.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - gemfiles/rails61.gemfile
         include:
           - gemfile: gemfiles/rails71.gemfile
+            ruby-version: 3.4.1
+          - gemfile: gemfiles/rails71.gemfile
             ruby-version: 3.2.2
           - gemfile: gemfiles/rails71.gemfile
             ruby-version: 3.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # This Gemfile is compatible with Ruby 2.5.0 or greater. To test with
 # earlier Rubies, use the appropriate Gemfile from the ./gemfiles/ dir.
-ruby '3.2.2'
+ruby '3.4.1'
 
 source 'https://rubygems.org'
 

--- a/lib/rollbar/item/frame.rb
+++ b/lib/rollbar/item/frame.rb
@@ -18,7 +18,11 @@ module Rollbar
 
       def to_h
         # parse the line
-        match = frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
+        match = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+                  frame.match(/(.*):(\d+)(?::in '([^']+)')?/)
+                else
+                  frame.match(/(.*):(\d+)(?::in `([^']+)')?/)
+                end
 
         return unknown_frame unless match
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -441,7 +441,11 @@ describe HomeController do
 
         expect(frames[-1][:locals]).to be_eql(locals[0])
 
-        expect(frames[-2][:method]).to be_eql('tap')
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+          expect(frames[-2][:method]).to be_eql('Kernel#tap')
+        else
+          expect(frames[-2][:method]).to be_eql('tap')
+        end
         if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
           expect(frames[-2][:locals]).to be_nil
         else

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -48,7 +48,11 @@ describe HomeController do
       trace = body[:trace] || body[:trace_chain][0]
 
       trace[:exception][:class].should eq('NoMethodError')
-      trace[:exception][:message].should =~ /^undefined method `-'/
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+        trace[:exception][:message].should =~ /^undefined method '-'/
+      else
+        trace[:exception][:message].should =~ /^undefined method `-'/
+      end
     end
   end
 end

--- a/spec/rollbar/item/frame_spec.rb
+++ b/spec/rollbar/item/frame_spec.rb
@@ -48,7 +48,11 @@ foo13
         '/lib/action_controller/metal/implicit_render.rb'
       end
       let(:frame) do
-        "#{filepath}:7:in `send_action'"
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+          "#{filepath}:7:in 'send_action'"
+        else
+          "#{filepath}:7:in `send_action'"
+        end
       end
       let(:options) do
         { :configuration => configuration }
@@ -235,7 +239,11 @@ foo13
 
           context 'having less pre lines than maximum' do
             let(:frame) do
-              "#{filepath}:3:in `send_action'"
+              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+                "#{filepath}:3:in 'send_action'"
+              else
+                "#{filepath}:3:in `send_action'"
+              end
             end
 
             it 'returns up to 2 pre lines' do
@@ -257,7 +265,11 @@ foo13
 
           context 'having less post lines than maximum' do
             let(:frame) do
-              "#{filepath}:11:in `send_action'"
+              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+                "#{filepath}:11:in 'send_action'"
+              else
+                "#{filepath}:11:in `send_action'"
+              end
             end
 
             it 'returns up to 2 post lines' do

--- a/spec/rollbar/item_spec.rb
+++ b/spec/rollbar/item_spec.rb
@@ -358,8 +358,13 @@ describe Rollbar::Item do
       end
 
       let(:pattern) do
-        /^(undefined\ local\ variable\ or\ method\ `bar'|
-          undefined\ method\ `bar'\ on\ an\ instance\ of)/x
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+          /^(undefined\ local\ variable\ or\ method\ 'bar'|
+            undefined\ method\ 'bar'\ on\ an\ instance\ of)/x
+        else
+          /^(undefined\ local\ variable\ or\ method\ `bar'|
+            undefined\ method\ `bar'\ on\ an\ instance\ of)/x
+        end
       end
 
       it 'should build valid exception data' do

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -288,7 +288,11 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
 
           expect(frames[-1][:locals]).to be_eql(locals[0])
 
-          expect(frames[-2][:method]).to be_eql('tap')
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+            expect(frames[-2][:method]).to be_eql('Kernel#tap')
+          else
+            expect(frames[-2][:method]).to be_eql('tap')
+          end
           if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
             expect(frames[-2][:locals]).to be_nil
           else

--- a/spec/rollbar/plugins/rails_js_spec.rb
+++ b/spec/rollbar/plugins/rails_js_spec.rb
@@ -21,7 +21,7 @@ describe ApplicationController, :type => 'request' do
       get '/test_rollbar_js'
 
       snippet_from_submodule = File.read(
-        File.expand_path('../../../../rollbar.js/dist/rollbar.snippet.js', __FILE__)
+        File.expand_path('../../../../data/rollbar.snippet.js', __FILE__)
       )
 
       expect(response.body).to include(


### PR DESCRIPTION
## Description of the change

Ruby 3.4.0 changes the format of trace frames:
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

This PR updates rollbar-gem to expect the new format when running Ruby 3.4.0 or higher.

This PR also adds 3.4.1 to the test matrix and bumps the version in the main Gemfile.

## Type of change

- [x] Maintenance


## Related issues

Fixes: https://github.com/rollbar/rollbar-gem/issues/1178

