### PR TITLE
Move most verbose logs to debug level

### DIFF
--- a/lib/rollbar/notifier.rb
+++ b/lib/rollbar/notifier.rb
@@ -607,11 +607,10 @@ module Rollbar
     def eventmachine_callback(req)
       req.callback do
         if req.response_header.status == 200
-          log_info '[Rollbar] Success'
+          log_debug '[Rollbar] Success'
         else
           log_warning '[Rollbar] Got unexpected status code from Rollbar.io api: ' \
-            "#{req.response_header.status}"
-          log_info "[Rollbar] Response: #{req.response}"
+            "#{req.response_header.status}, response: #{req.response}"
         end
       end
     end
@@ -619,14 +618,14 @@ module Rollbar
     def eventmachine_errback(req)
       req.errback do
         log_warning(
-          "[Rollbar] Call to API failed, status code: #{req.response_header.status}"
+          "[Rollbar] Call to API failed, status code: #{req.response_header.status}, "\
+            "response: #{req.response}"
         )
-        log_info "[Rollbar] Error's response: #{req.response}"
       end
     end
 
     def send_item(item)
-      log_info '[Rollbar] Sending item'
+      log_debug '[Rollbar] Sending item'
 
       body = item.dump
       return unless body
@@ -640,7 +639,7 @@ module Rollbar
     end
 
     def send_body(body)
-      log_info '[Rollbar] Sending json'
+      log_debug '[Rollbar] Sending json'
 
       uri = URI.parse(configuration.endpoint)
 
@@ -750,12 +749,12 @@ module Rollbar
 
     def handle_response(response)
       if response.code == '200'
-        log_info '[Rollbar] Success'
+        log_debug '[Rollbar] Success'
       else
         log_warning(
-          "[Rollbar] Got unexpected status code from Rollbar api: #{response.code}"
+          "[Rollbar] Got unexpected status code from Rollbar api: #{response.code}, " \
+            "response: #{response.body}"
         )
-        log_info "[Rollbar] Response: #{response.body}"
         configuration.execute_hook(:on_error_response, response)
       end
     end
@@ -769,7 +768,7 @@ module Rollbar
     end
 
     def do_write_item(item)
-      log_info '[Rollbar] Writing item to file'
+      log_debug '[Rollbar] Writing item to file'
 
       body = item.dump
       return unless body
@@ -783,7 +782,7 @@ module Rollbar
         @file.flush
         update_file(@file, file_name)
 
-        log_info '[Rollbar] Success'
+        log_debug '[Rollbar] Success'
       rescue IOError => e
         log_error "[Rollbar] Error opening/writing to file: #{e}"
       end
@@ -846,7 +845,7 @@ module Rollbar
     def schedule_item(item)
       return unless item
 
-      log_info '[Rollbar] Scheduling item'
+      log_debug '[Rollbar] Scheduling item'
 
       if configuration.use_async
         process_async_item(item)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -249,7 +249,7 @@ describe HomeController do
 
   describe "GET 'index'" do
     it 'should be successful and report two messages' do
-      logger_mock.should_receive(:info).with('[Rollbar] Success').twice
+      logger_mock.should_receive(:debug).with('[Rollbar] Success').twice
       get 'index'
       expect(response.status).to eq(200)
     end
@@ -257,14 +257,14 @@ describe HomeController do
 
   describe "'report_exception'", :type => 'request' do
     it 'should raise a NameError and report an exception after a GET' do
-      logger_mock.should_receive(:info).with('[Rollbar] Success').once
+      logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
       get '/report_exception'
       expect(response.status).to eq(200)
     end
 
     it 'should raise a NameError and have PUT params in the reported exception' do
-      logger_mock.should_receive(:info).with('[Rollbar] Success')
+      logger_mock.should_receive(:debug).with('[Rollbar] Success')
 
       send_req(:put, '/report_exception', wrap_process_args(:putparam => 'putval'))
 
@@ -274,7 +274,7 @@ describe HomeController do
 
     context 'using deprecated report_exception' do
       it 'reports the errors successfully' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success')
+        logger_mock.should_receive(:debug).with('[Rollbar] Success')
 
         send_req(:put, '/deprecated_report_exception',
                  wrap_process_args(:putparam => 'putval'))
@@ -285,7 +285,7 @@ describe HomeController do
     end
 
     it 'should raise a NameError and have JSON POST params' do
-      logger_mock.should_receive(:info).with('[Rollbar] Success')
+      logger_mock.should_receive(:debug).with('[Rollbar] Success')
       @request.env['HTTP_ACCEPT'] = 'application/json'
 
       params = { :jsonparam => 'jsonval' }.to_json
@@ -316,7 +316,7 @@ describe HomeController do
 
     context 'when Rails Error Subscriber is enabled', if: ::Rails.gem_version >= ::Gem::Version.new('7.1.0') do
       it '`handle` should not raise an error and report a warning via rails error subscriber' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').never
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').never
 
         expect(Rollbar).to receive(:log) do |level, _, extra|
           expect(extra[:custom_data_method_context]).to be_eql('application')
@@ -327,7 +327,7 @@ describe HomeController do
       end
 
       it '`handle` should report a warning via rails error subscriber when capture_uncaught is false' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').never
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').never
 
         Rollbar.configure do |config|
           config.capture_uncaught = false
@@ -342,7 +342,7 @@ describe HomeController do
       end
 
       it '`report` should raise an error and report an error via rails error subscriber' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').never
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').never
 
         expect(Rollbar).to receive(:log) do |level, _, extra|
           expect(extra[:custom_data_method_context]).to be_eql('application')
@@ -355,7 +355,7 @@ describe HomeController do
       end
 
       it 'uncaught exception should raise an error and report an error via rails error subscriber' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').never
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').never
 
         expect(Rollbar).to receive(:log) do |level, _, extra|
           expect(extra[:custom_data_method_context]).to be_eql('application.action_dispatch')
@@ -368,7 +368,7 @@ describe HomeController do
       end
 
       it 'uncaught exception should not report an error when capture_uncaught is not set' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').never
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').never
 
         Rollbar.configure do |config|
           config.capture_uncaught = false
@@ -384,7 +384,7 @@ describe HomeController do
 
     context 'when Rails Error Subscriber is enabled in unsupported Rails', if: ::Rails.gem_version < ::Gem::Version.new('7.1.0') do
       it 'uncaught exception should raise an error and report via middleware' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').once
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
         expect do
           get '/cause_exception'
@@ -431,7 +431,7 @@ describe HomeController do
       end
 
       it 'should include locals in extra data' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').once
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
         expect {
           get '/cause_exception_with_locals?test_fibers=true'
@@ -468,7 +468,7 @@ describe HomeController do
       end
 
       it 'should not include locals in extra data' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').once
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
         expect { get '/cause_exception_with_locals' }.to raise_exception(NoMethodError)
         expect(Rollbar.last_report[:body][:trace][:frames][-1][:locals]).to be_eql(nil)
@@ -478,7 +478,7 @@ describe HomeController do
 
   describe "'cause_exception'", :type => 'request' do
     it 'should raise an uncaught exception and report a message' do
-      logger_mock.should_receive(:info).with('[Rollbar] Success').once
+      logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
       expect { get '/cause_exception' }.to raise_exception(NameError)
     end
@@ -517,7 +517,7 @@ describe HomeController do
       end
 
       it 'middleware should catch the exception and only report to rollbar once' do
-        logger_mock.should_receive(:info).with('[Rollbar] Success').once
+        logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
         get '/cause_exception'
       end

--- a/spec/rollbar/middleware/sinatra_spec.rb
+++ b/spec/rollbar/middleware/sinatra_spec.rb
@@ -280,7 +280,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
         end
 
         it 'should include locals in extra data' do
-          logger_mock.should_receive(:info).with('[Rollbar] Success').once
+          logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
           expect { get '/cause_exception_with_locals' }.to raise_exception(NoMethodError)
 
@@ -315,7 +315,7 @@ describe Rollbar::Middleware::Sinatra, :reconfigure_notifier => true do
         end
 
         it 'should not include locals in extra data' do
-          logger_mock.should_receive(:info).with('[Rollbar] Success').once
+          logger_mock.should_receive(:debug).with('[Rollbar] Success').once
 
           expect { get '/cause_exception_with_locals' }.to raise_exception(NoMethodError)
           expect(Rollbar.last_report[:body][:trace][:frames][-1][:locals]).to be_eql(nil)

--- a/spec/support/notifier_helpers.rb
+++ b/spec/support/notifier_helpers.rb
@@ -6,6 +6,7 @@ module NotifierHelpers
       # special test access token
       config.access_token = test_access_token
       config.logger = ::Rails.logger
+      config.logger_level = :debug
       config.root = ::Rails.root
       config.framework = "Rails: #{::Rails::VERSION::STRING}"
       config.open_timeout = 60
@@ -22,6 +23,7 @@ module NotifierHelpers
 
     Rollbar.preconfigure do |config|
       config.logger = rails_logger
+      config.logger_level = :debug
       config.environment = defined?(::Rails.env) && ::Rails.env ||
                            defined?(RAILS_ENV) && RAILS_ENV
       config.root = defined?(::Rails.root) && ::Rails.root ||


### PR DESCRIPTION
## Description of the change

Moving most of the unnecessarily verbose logs to log level, so by default instead of:
```
[Rollbar] Scheduling item
[Rollbar] Sending item
[Rollbar] Sending json
[Rollbar] Success
[Rollbar] Details: https://rollbar.com/instance/uuid?uuid=00000000-0000-0000-0000-000000000000 (only available if report was successful)
```

We'll only have:
```
[Rollbar] Details: https://rollbar.com/instance/uuid?uuid=00000000-0000-0000-0000-000000000000 (only available if report was successful)
```

The motivation is that in our project we find Rollbar logs unnecessarily verbose - the only line that we really care about (given the report was successful) is the line including the details url.
Since that line we care about is on the same level as the other messages, hiding the other messages while preserving the the url message intact was not trivial.

Screenshot from our Datadog logs:
<img width="574" height="561" alt="457972899-c0fa8a4a-5f22-4df0-86fa-8ac074ba82d5" src="https://github.com/user-attachments/assets/7015af92-14f6-45bb-ad3f-9a0a49db9c7b" />


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
