### PR TITLE
Allow not loading the rails middleware

### DIFF
--- a/lib/no_rails_middleware.rb
+++ b/lib/no_rails_middleware.rb
@@ -1,0 +1,9 @@
+# When required in the application's Gemfile, this prevents the Rollbar
+# middleware from being inserted into the Rails middleware stack.
+#
+# ex:
+# `gem 'rollbar', require: ['no_rails_middleware', 'rollbar']`
+#
+module Rollbar
+  NO_RAILS_MIDDLEWARE = true
+end

--- a/lib/rollbar/plugins/rails/railtie32.rb
+++ b/lib/rollbar/plugins/rails/railtie32.rb
@@ -9,8 +9,10 @@ module Rollbar
       require 'rollbar/middleware/rails/rollbar'
       require 'rollbar/middleware/rails/show_exceptions'
 
-      app.config.middleware.insert_after ActionDispatch::DebugExceptions,
-                                         Rollbar::Middleware::Rails::RollbarMiddleware
+      unless defined?(Rollbar::NO_RAILS_MIDDLEWARE) && Rollbar::NO_RAILS_MIDDLEWARE
+        app.config.middleware.insert_after ActionDispatch::DebugExceptions,
+                                           Rollbar::Middleware::Rails::RollbarMiddleware
+      end
       ActionDispatch::DebugExceptions.send(:include,
                                            Rollbar::Middleware::Rails::ShowExceptions)
     end


### PR DESCRIPTION
## Description of the change

This PR adds an optional Gemfile `require` option allowing Rollbar's Rails middleware not to load.

**Background**

This is likely to be used in configs where the Rails error reporter is enabled, and the Rails middleware is disabled. See https://github.com/rollbar/rollbar-gem/issues/1163

The behavior should be the same in both cases since even when loaded, the Rails middleware is disabled. However, this option allows the middleware to not be added to the middleware chain at all.

**Notes**
This is implemented as a Gemfile require because the Rollbar initializer in the host Rails application runs after the Rails middleware is loaded, preventing a config option from controlling the load behavior.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Related issues

Fixes https://github.com/rollbar/rollbar-gem/issues/1163

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


