### PR TITLE
Fix JSON::GeneratorError for objects with invalid UTF-8 in to_s

### DIFF
--- a/lib/rollbar/encoding.rb
+++ b/lib/rollbar/encoding.rb
@@ -10,11 +10,12 @@ module Rollbar
     end
 
     def self.encode(object)
-      can_be_encoded = object.is_a?(String) || object.is_a?(Symbol)
-
-      return object unless can_be_encoded
-
-      encoding_class.new(object).encode
+      case object
+      when Numeric, TrueClass, FalseClass, NilClass
+        object
+      else
+        encoding_class.new(object).encode
+      end
     end
   end
 end

--- a/spec/rollbar/util_spec.rb
+++ b/spec/rollbar/util_spec.rb
@@ -134,10 +134,14 @@ describe Rollbar::Util do
     it 'should replace invalid utf8 values' do
       bad_key = force_to_ascii("inner \x92bad key")
 
+      class ObjClass; def to_s; "bad obj\255".force_encoding('ASCII-8BIT'); end; end
+      bad_obj = ObjClass.new
+
       payload = {
         :bad_value => force_to_ascii("bad value 1\255"),
         :bad_value2 => force_to_ascii("bad\255 value 2"),
         force_to_ascii("bad\255 key") => 'good value',
+        :bad_obj => bad_obj,
         :hash => {
           :inner_bad_value => force_to_ascii("\255\255bad value 3"),
           bad_key.to_sym => 'inner good value',
@@ -157,6 +161,7 @@ describe Rollbar::Util do
       payload_copy[:bad_value].should eq('bad value 1')
       payload_copy[:bad_value2].should eq('bad value 2')
       payload_copy['bad key'].should eq('good value')
+      payload_copy[:bad_obj].should eq('bad obj')
       payload_copy.keys.should_not include("bad\456 key")
       payload_copy[:hash][:inner_bad_value].should eq('bad value 3')
       payload_copy[:hash][:"inner bad key"].should eq('inner good value')


### PR DESCRIPTION
## Description of the change

Rollbar::Encoding.encode only processed String and Symbol types. When objects with to_s methods returning invalid UTF-8 were included in the payload, they bypassed encoding and caused JSON serialization to fail with "source sequence is illegal/malformed utf-8".

Now all non-JSON-native types are passed through the Encoder, which already calls to_s and handles encoding normalization.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fixes #1196

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
