### PR TITLE
ci: pin resque to version compatible with older rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: [2.5.9, 2.6.0, 2.6.10, 2.7.8]
         gemfile:

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -32,7 +32,7 @@ gem 'database_cleaner'
 gem 'delayed_job', '4.1.9', :require => false
 gem 'generator_spec'
 gem 'redis', '<= 4.8.0'
-gem 'resque'
+gem 'resque', '2.7.0'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'
 

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -32,7 +32,7 @@ gem 'database_cleaner'
 gem 'delayed_job', '4.1.10', :require => false
 gem 'generator_spec'
 gem 'redis', '<= 4.8.0'
-gem 'resque'
+gem 'resque', '2.7.0'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'
 

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -31,7 +31,7 @@ gem 'database_cleaner'
 gem 'delayed_job', '4.1.10', :require => false
 gem 'generator_spec'
 gem 'redis', '<= 4.8.0'
-gem 'resque'
+gem 'resque', '2.7.0'
 gem 'secure_headers', '~> 6.3.2', :require => false
 gem 'simplecov'
 


### PR DESCRIPTION
## Description of the change

This PR pins resque to a version compatible with older rails in gemfiles where CI stopped passing after the resque 3.0.0 release.

This PR also sets `fail-fast: false` on the CI matrix to more quickly and easily see all matrix combinations that are failing.
