### PR TITLE
Fix JSON::GeneratorError masking errors for malformed UTF-8 request bodies

### DIFF
--- a/lib/rollbar/request_data_extractor.rb
+++ b/lib/rollbar/request_data_extractor.rb
@@ -4,6 +4,7 @@ require 'tempfile'
 require 'rollbar/scrubbers'
 require 'rollbar/scrubbers/url'
 require 'rollbar/scrubbers/params'
+require 'rollbar/util'
 require 'rollbar/util/ip_obfuscator'
 require 'rollbar/util/ip_anonymizer'
 require 'rollbar/json'
@@ -91,14 +92,23 @@ module Rollbar
     def mergeable_raw_body_params(rack_req)
       raw_body_params = rollbar_raw_body_params(rack_req)
 
-      case raw_body_params
-      when Hash
-        raw_body_params
-      when Array
-        { 'body.multi' => raw_body_params }
-      else
-        { 'body.value' => raw_body_params }
-      end
+      params = case raw_body_params
+               when Hash
+                 raw_body_params
+               when Array
+                 { 'body.multi' => raw_body_params }
+               else
+                 { 'body.value' => raw_body_params }
+               end
+
+      # The request body is serialized to JSON right here in the extractor,
+      # before the payload-wide UTF-8 pass in Rollbar::Item runs. A parsed
+      # body carrying invalid UTF-8 (e.g. a malformed request) would make that
+      # serialization raise JSON::GeneratorError and mask the original error
+      # being reported, so normalize the encoding up front.
+      Rollbar::Util.enforce_valid_utf8(params)
+
+      params
     end
 
     def rollbar_request_method(env)

--- a/spec/rollbar/request_data_extractor_spec.rb
+++ b/spec/rollbar/request_data_extractor_spec.rb
@@ -322,6 +322,27 @@ describe Rollbar::RequestDataExtractor do
       end
     end
 
+    context 'with JSON POST body containing invalid UTF-8' do
+      let(:body) { "{\"key\":\"\xAE\"}".b }
+      let(:env) do
+        Rack::MockRequest.env_for('/?foo=bar',
+                                  'CONTENT_TYPE' => 'application/json',
+                                  :input => body,
+                                  :method => 'POST')
+      end
+
+      it 'does not raise and serializes a valid body' do
+        result = nil
+
+        expect { result = subject.extract_request_data_from_rack(env) }
+          .not_to raise_error
+
+        expect(result[:body]).to be_kind_of(String)
+        expect(result[:body].encoding).to be_eql(Encoding::UTF_8)
+        expect(result[:body]).to be_valid_encoding
+      end
+    end
+
     context 'with JSON DELETE body' do
       let(:params) { { 'key' => 'value' } }
       let(:body) { params.to_json }


### PR DESCRIPTION
## Problem

`Rollbar::RequestDataExtractor#extract_request_data_from_rack` serializes the parsed raw body params to JSON while building the `:body` field:

```ruby
:body => Rollbar::JSON.dump(raw_body_params),
```

This serialization happens *before* the payload-wide UTF-8 normalization pass that `Rollbar::Item` runs (`Rollbar::Util.enforce_valid_utf8`). When a request body contains invalid UTF-8 — for example a malformed request that Rails rejects with `ActionController::BadRequest` — `Rollbar::JSON.dump` raises `JSON::GeneratorError: source sequence is illegal/malformed utf-8`.

The result is that the original exception being reported gets replaced with a failsafe report, masking the real error (`ActionController::BadRequest`) from users.

## Fix

Normalize the parsed body params with `Rollbar::Util.enforce_valid_utf8` inside `mergeable_raw_body_params`, before they are scrubbed and serialized. This mirrors the existing payload-wide UTF-8 handling and ensures the `:body` field can always be serialized, so the original error is reported correctly.

The change is limited to error-report payload content; request parsing/validation is unaffected.

## Test

Added a spec that feeds a JSON `POST` body with an invalid UTF-8 byte through `extract_request_data_from_rack`. Without the fix it raises `JSON::GeneratorError`; with the fix it returns a valid, UTF-8 `:body` string.